### PR TITLE
gorouter: expose drain_timeout

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -67,6 +67,10 @@ properties:
       During this time the server will reject requests to the /health endpoint.
       This accommodates requests forwarded by a load balancer until it considers the router unhealthy.
     default: 20
+  router.drain_timeout:
+    description: |
+      Maximum delay in seconds after shut down is initiated before server stops completely.
+    default: 900
   router.healthcheck_user_agent:
     description: DEPRECATED. Use /health endpoint on port specified by status.port. User-Agent for the health check agent (usually the Load Balancer).
     example: "ELB-HealthChecker/1.0"

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -93,6 +93,7 @@ routing_api:
 <% end %>
 
 drain_wait: <%= p("router.drain_wait") %>s
+drain_timeout: <%= p("router.drain_timeout") %>s
 healthcheck_user_agent: <%= p("router.healthcheck_user_agent") %>
 endpoint_timeout: <%= p("request_timeout_in_seconds") %>s
 


### PR DESCRIPTION
Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Expose drain_timeout of gorouter configuration as router.drain_timeout

* An explanation of the use cases your change solves
Will allow to change endpoint_timeout without affecting drain_timeout
See https://github.com/cloudfoundry/gorouter/issues/181#issuecomment-318257511

* Expected result after the change
Default behavior is not changed

* Current result before the change
Not being able to change endpoint_timeout without affecting drain_timeout

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch