### PR TITLE
allow cf-deployment to expose available uaa_clients in BOSH link [fixes #93]

### DIFF
--- a/jobs/routing-api/spec
+++ b/jobs/routing-api/spec
@@ -20,6 +20,13 @@ packages:
 - routing_utils
 
 provides:
+- name: routing_api
+  type: routing_api
+  properties:
+  - routing_api.clients
+  - routing_api.system_domain
+  - uaa.ca_cert
+  - skip_ssl_validation
 - name: routing_api_db
   type: routing_api_db
   properties:
@@ -94,6 +101,12 @@ properties:
 
   uaa.tls_port:
     description: "Port on which UAA is listening for TLS connections. This is required for obtaining a key to verify client OAuth tokens."
+
+  routing_api.clients:
+    description: "OAuth client ids and secrets provided via link to jobs in other BOSH deployments that need to read and/or write to Routing API. These clients must be configured in UAA via API or using the property uaa.clients with the desired scopes. For a list of scopes supported see https://github.com/cloudfoundry-incubator/routing-api/blob/master/docs/api_docs.md. Jobs consuming the link should use these credentials to fetch a token from UAA with which to authenticate with Routing API."
+    example:
+      cfcr_routing_api_client:
+        secret: "((uaa_clients_cfcr_routing_api_client_secret))"
 
   routing_api.router_groups:
     description: "Array of router groups that will be seeded into routing_api database. Once some value is included with a deploy, subsequent changes to this property will be ignored. TCP Routing requires a router group of type: tcp."

--- a/jobs/tcp_router/spec
+++ b/jobs/tcp_router/spec
@@ -74,4 +74,3 @@ properties:
   uaa.ca_cert:
     description : "Certificate authority for communication between clients and uaa."
     default: ""
-


### PR DESCRIPTION
![242732-200](https://user-images.githubusercontent.com/108/33729414-6033ddb0-db32-11e7-89ec-ce0425f02c45.png)

## Issue

As a BOSH operator, I want to deploy CFCR (Kubernetes on BOSH, formerly called Kubo). It has a routing option that allows Kubernetes Services to be exposed to the CF TCP router, enabled via a BOSH operator file [1]. Currently a BOSH operator must use `credhub` CLI, a Post-It note, and a local `vars.yml` file on their computer to transfer the UAA client/secret from their `cf` deployment across to their `kubo` deployment. This is counter to the goals and dreams of BOSH links, credhub, and Post-It notes.

[1] https://github.com/cloudfoundry-incubator/kubo-deployment/blob/master/manifests/ops-files/cf-routing.yml#L46-L47

## Solution

Instead, `kubo-deployment` needs to be able to use BOSH links to discover the UAA client/secret to be used to connect to the TCP routing API + UAA.

In order to allow BOSH links to expose additional information/properties/credentials, we will need to add a `uaa_clients` property to `tcp_router` job `spec` file. It does not need to be used within `tcp_router` itself, rather the job property exists only to be passed thru from the `cf` deployment manifest to other deployments via shared BOSH links.

After this issue is resolved in `tcp_router`, BOSH operators will be able to expose their routing UAA clients from `cf` deployment to their other BOSH deployments without manually touching credhub nor using Post-It notes.

## Consumer example

A BOSH consumer job can now consume `tcp_router` link and `cloud_controller_ng`'s `cloud_controller` link to have all the information for connecting to the TCP router. For example, a consumer template might include this ERb:

```ruby
<%
routing_api_client = p("cloud_foundry.routing_api_client_id")
api_url = uaa_url = app_domain = routing_api_client_secret = nil
skip_tls_verification = false # default from spec file
if_link("tcp_router") do |tcp|
  routing_api_client_secret = tcp.p("uaa_clients")[routing_api_client]["secret"]
end
if_link("cloud_controller") do |cc|
  system_domain = cc.p("system_domain")
  api_url = "https://api.#{system_domain}"
  uaa_url = "https://uaa.#{system_domain}"
  skip_tls_verification = true # currently default to true as 'skip_tls_verification' not provided in link
  app_domain = cc.p("app_domains").first
end
%>
```

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

(other todo items removed as this PR only adds an unused property to `tcp_router` job for the benefit of bosh links consumers)