### PR TITLE
Add microseconds to logs

### DIFF
--- a/src/routing_utils/syslog_utils.sh
+++ b/src/routing_utils/syslog_utils.sh
@@ -12,5 +12,5 @@ function tee_output_to_sys_log() {
 }
 
 function prepend_datetime() {
-  perl -ne 'BEGIN { use POSIX strftime; STDOUT->autoflush(1) }; my $time = strftime("[%Y-%m-%d %H:%M:%S%z]", localtime); print("$time $_")'
+  perl -ne 'BEGIN { use Time::HiRes "time"; use POSIX "strftime"; STDOUT->autoflush(1) }; my $t = time; my $fsec = sprintf ".%06d", ($t-int($t))*1000000; my $time = strftime("%Y-%m-%dT%H:%M:%S".$fsec."%z", localtime $t); print("$time $_")'
 }


### PR DESCRIPTION
Seconds are often not enough especially when sorting is required.

Timestamp is in ISO 8601.

Before:
```
$ echo test | prepend_datetime
[2018-04-27 20:37:20+0900] test
```

After:
```
$ echo test | prepend_datetime
2018-04-27T20:37:32.618717+0900 test
```

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests`

* [ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] I have run CF Acceptance Tests on bosh lite
