### PR TITLE
Stdout and stderr to the same file

### DIFF
--- a/src/routing_utils/syslog_utils.sh
+++ b/src/routing_utils/syslog_utils.sh
@@ -12,5 +12,5 @@ function tee_output_to_sys_log() {
 }
 
 function prepend_datetime() {
-  perl -ne 'BEGIN { use POSIX strftime; STDOUT->autoflush(1) }; my $time = strftime("[%Y-%m-%d %H:%M:%S%z]", localtime); print("$time $_")'
+  perl -ne 'BEGIN { use Time::HiRes "time"; use POSIX "strftime"; STDOUT->autoflush(1) }; my $t = time; my $fsec = sprintf ".%06d", ($t-int($t))*1000000; my $time = strftime("%Y-%m-%dT%H:%M:%S".$fsec."%z", localtime $t); print("$time $_")'
 }

--- a/src/routing_utils/syslog_utils.sh
+++ b/src/routing_utils/syslog_utils.sh
@@ -7,10 +7,10 @@ function tee_output_to_sys_log() {
   declare log_dir="$1"
   declare log_name="$2"
 
-  exec > >(tee -a >(logger -p user.info -t "vcap.${log_name}.stdout") | prepend_datetime >>"${log_dir}/${log_name}.log")
-  exec 2> >(tee -a >(logger -p user.error -t "vcap.${log_name}.stderr") | prepend_datetime >>"${log_dir}/${log_name}.err.log")
+  exec 1> >(tee -a >(log_prefix "O" >> "${log_dir}/${log_name}.log") | logger -p user.info -t "vcap.${log_name}.stdout")
+  exec 2> >(tee -a >(log_prefix "E" >> "${log_dir}/${log_name}.log") | logger -p user.error -t "vcap.${log_name}.stderr")
 }
 
-function prepend_datetime() {
-  perl -ne 'BEGIN { use Time::HiRes "time"; use POSIX "strftime"; STDOUT->autoflush(1) }; my $t = time; my $fsec = sprintf ".%06d", ($t-int($t))*1000000; my $time = strftime("%Y-%m-%dT%H:%M:%S".$fsec."%z", localtime $t); print("$time $_")'
+function log_prefix() {
+  perl -sne 'BEGIN { use Time::HiRes "time"; use POSIX "strftime"; STDOUT->autoflush(1) }; my $t = time; my $fsec = sprintf ".%06d", ($t-int($t))*1000000; my $time = strftime("%Y-%m-%dT%H:%M:%S".$fsec."%z", localtime $t); print("$time $prefix $_")' -- -prefix="${1:--}"
 }


### PR DESCRIPTION
Running Cloud Foundry for long time we find that having a single log file per job is more convenient than having two, one for STDOUT and one for STDERR. Of course this might not be true for everybody.

Before (different log files for stdout and stderr):
```
$ echo test | prepend_datetime
2018-04-27T21:13:17.593262+0900 test
```

After (one log file):
```
$ echo test_ok | log_prefix "O" && echo test_err | log_prefix "E"
2018-04-27T21:14:42.151025+0900 O test_ok
2018-04-27T21:14:42.179927+0900 E test_err
```

This change is made on top of https://github.com/cloudfoundry/routing-release/pull/106.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests`

* [ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] I have run CF Acceptance Tests on bosh lite
