### PR TITLE
Config driven host for route-registrar

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -33,6 +33,10 @@ properties:
     description: Password for NATS authentication
     example: natSpa55w0rd
 
+  host:
+    description: Destination hostname or IP for the routes being registered
+    example: 192.168.60.25
+
   route_registrar.routes:
     description: |
       * Array of hashes determining which routes will be registered.

--- a/jobs/route_registrar/templates/registrar_settings.json.erb
+++ b/jobs/route_registrar/templates/registrar_settings.json.erb
@@ -45,9 +45,16 @@
     end
   end
 
+  host = nil
+  if_p('host') do |prop|
+    host = prop
+  end.else do
+    host = spec.ip
+  end
+
   config = {
     message_bus_servers: message_bus_servers,
-    host: spec.ip,
+    host: host,
     routes: routes,
   }
   JSON.pretty_generate(config)


### PR DESCRIPTION
It fixes #108: Idea is to read host from job spec property
if not found default to spec.ip
This intriduces flexibilty as other parameters, keeping existing functionality intact.
This would help other bosh releases consuming route-registrar job from routing-release,
to have flexibility to register routes with configurable host.

Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests`

* [ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] I have run CF Acceptance Tests on bosh lite
