### PR TITLE
Fix router.tls_pem.example indentation

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -91,13 +91,12 @@ properties:
   router.tls_pem:
     description: "Array of private keys and certificates used for TLS handshakes with downstream clients. Each element in the array is an object containing fields 'private_key' and 'cert_chain', each of which supports a PEM block. Required if router.enable_ssl is true."
     example: |
-        tls_pem:
-        - cert_chain: |
+      - cert_chain: |
           -----BEGIN CERTIFICATE-----
           -----END CERTIFICATE-----
           -----BEGIN CERTIFICATE-----
           -----END CERTIFICATE-----
-          private_key: |
+        private_key: |
           -----BEGIN RSA PRIVATE KEY-----
           -----END RSA PRIVATE KEY-----
   router.ca_certs:


### PR DESCRIPTION
Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Small fixup to the property example value:

    - repeating the `tls_pem` name may be a style issue, but is (a) redundant, and (b) inconsistent with the`nats.machines.example` value that doesn't have a `machines` name at the top.

    - the actual PEM value must be indented below their field names; the current example is invalid YAML syntax

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

I don't know if the example values are used programatically anywhere; I suspect they are just documentation. They still should be correct. :)

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests`

* [ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] I have run CF Acceptance Tests on bosh lite
