### PR TITLE
Clarify GCP TCP setting for `frontend_idle_timeout`

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -167,8 +167,8 @@ properties:
     description: |
       (optional, integer) Duration in seconds to maintain an open connection when client supports keep-alive.
       This property must be configured with regards to how an IaaS-provided load balancer behaves in order to prevent connections from being closed prematurely.
-      Generally, this timeout must be greater than that of the load balancer. As examples, GCP has a default timeout of 600 seconds so a value greater than 600 is recommended and AWS ELB has a default timeout of 60 seconds so a value greater than 60 is recommended.
-      However, depending on the IaaS, this timeout may need to be shorter than the load balancer's timeout, e.g., Azure's load balancer times out at 240 seconds (by default) without sending a TCP RST to clients, so a value lower than this is recommended in order to force it to send the TCP RST.
+      Generally, this timeout must be greater than that of the load balancer. As examples, GCP HTTP(S) load balancer has a default timeout of 600 seconds so a value greater than 600 is recommended and AWS ELB has a default timeout of 60 seconds so a value greater than 60 is recommended.
+      However, depending on the IaaS, this timeout may need to be shorter than the load balancer's timeout, e.g., Azure's load balancer times out at 240 seconds (by default) and GCP TCP load balancer times out at 600 seconds without sending a TCP RST to clients, so a value lower than this is recommended in order to force it to send the TCP RST.
     default: 900
   router.backends.enable_tls:
     description:


### PR DESCRIPTION
We recently noticed strange "connection reset by peer" occasionally when running test suites with a GCP TCP LB.  Turns out GCP will forcibly cut all idle TCP connections after 10 minutes: https://cloud.google.com/compute/docs/troubleshooting/general-tips#communicatewithinternet. With the default value of 900 seconds for `router.frontend_idle_timeout` our app would come up successfully and open a keep-alive connection through the TCP LB to the gorouter, but the first request after the 10 minute mark would result in "connection reset by peer". Looks like GCP cuts the connection without shutting down the keep-alive connection properly. So to use a GCP TCP LB you need to set `frontend_idle_timeout` to something less than 600 seconds. Setting this property to 60 seconds fixed the flakiness for us. However, for GCP **HTTP** LBs you still want to use a value over 600 seconds as described here: https://blog.percy.io/tuning-nginx-behind-google-cloud-platform-http-s-load-balancer-305982ddb340. Fun times.
