### PR TITLE
Expose SSL port configuration as a BOSH property

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -73,6 +73,9 @@ properties:
   router.enable_ssl:
     description: "When enabled, Gorouter will listen on port 443 and terminate TLS for requests received on this port."
     default: false
+  router.tls_port:
+    description: Listening port for SSL connections to the router, when SSL is enabled.
+    default: 443
   router.client_cert_validation:
     description: |
       none - Gorouter will not request client certificates in TLS handshakes, and will ignore them if presented. Incompatible with `forwarded_client_cert: forward` or `sanitize_set`.

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -148,6 +148,7 @@ enable_ssl: <%= p("router.enable_ssl") %>
 %>
 client_cert_validation: <%= client_cert_validation %>
 min_tls_version: <%= p("router.min_tls_version") %>
+ssl_port: <%= p("router.tls_port") %>
 <% end %>
 
 disable_http: <%= p("router.disable_http") %>

--- a/spec/gorouter.yml.erb.erb_spec.rb
+++ b/spec/gorouter.yml.erb.erb_spec.rb
@@ -27,6 +27,7 @@ describe 'gorouter.yml.erb' do
             'password' => 'pass'
           },
           'enable_ssl' => true,
+          'tls_port' => 443,
           'client_cert_validation' => 'none',
           'logging_level' => 'info',
           'tracing' => {


### PR DESCRIPTION
This allows the operator to move the SSL port to be something other than
443.

Fixes #102

Note that there's a mismatch between the BOSH property name (`router.tls_port` as suggested in #102) and the gorouter config name (`ssl_port`)

-----

Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
This allows the router to listen on a port other than port 443

* An explanation of the use cases your change solves
We run on an environment where listening on a privileged port (<1024) is a bit annoying, and there's a (software) load balancer of sorts in front to map it to the normal port 443.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
This adds a BOSH property to the release, which can be changed via ops files.

* Expected result after the change
The BOSH property `router.tls_port` (as suggested in #102) exists, and changing it changes the port gorouter listens on for SSL/TLS connections.

* Current result before the change
The gorouter always listens on port 443 if SSL is enabled

* Links to any other associated PRs
None — gorouter already has a configuration option to listen on other ports, it just wasn't exposed in `routing-release`.

* [x] I have viewed signed and have submitted the Contributor License Agreement
(Company-wide agreement)

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests`

* [x] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [x] I have run CF Acceptance Tests on bosh lite
