### PR TITLE
Add convenience script to dump gorouter routes

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -13,6 +13,7 @@ templates:
   uaa_ca.crt.erb: config/certs/uaa/ca.crt
   bpm.yml.erb: config/bpm.yml
   bpm-pre-start.erb: bin/bpm-pre-start
+  retrieve-local-routes.erb: bin/retrieve-local-routes
 
 packages:
   - routing_utils

--- a/jobs/gorouter/templates/retrieve-local-routes.erb
+++ b/jobs/gorouter/templates/retrieve-local-routes.erb
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+curl -s http://<%= p("router.status.user") %>:<%= p("router.status.password") %>@127.0.0.1:<%= p("router.status.port") %>/routes


### PR DESCRIPTION
Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Add convenience script to dump gorouter routes

* An explanation of the use cases your change solves

When debugging routability status in Cloud Foundry, it is frequently helpful to dump each gorouter's routing table via its status endpoint. This change introduces a `bin/retrieve-local-routes` script to enable operators and support agents to dump that routing table without having to scrape credentials and other configuration from the rendered gorouter.yml config file.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

```
$ bosh -d cf ssh router/0 -c 'sudo /var/vcap/jobs/gorouter/bin/retrieve-local-routes'
```
<details><summary>Output</summary>

```
Using environment '192.168.50.6' as client 'admin'

Using deployment 'cf'

Task 1037. Done
router/1380a779-5c97-4130-8d1f-4e59c7e0691c: stderr | Unauthorized use is strictly prohibited. All access and activity
router/1380a779-5c97-4130-8d1f-4e59c7e0691c: stderr | is subject to logging and monitoring.
router/1380a779-5c97-4130-8d1f-4e59c7e0691c: stdout | {"*.doppler.bosh-lite.com":[{"address":"10.244.0.140:8081","tls":false,"ttl":120,"tags":null,"private_instance_id":"2069a44e-a1f0-4b46-6ad2-dc850e49c37d"}],"*.log-cache.bosh-lite.com":[{"address":"10.244.0.138:8083","tls":false,"ttl":120,"tags":null,"private_instance_id":"5c40f092-dcde-4c84-7afb-aa6c8c516c88"}],"*.login.bosh-lite.com":[{"address":"10.244.0.132:8080","tls":false,"ttl":120,"tags":{"component":"uaa"},"private_instance_id":"d9736d1f-513e-481a-5f24-1e3221eb1516"}],"*.uaa.bosh-lite.com":[{"address":"10.244.0.132:8080","tls":false,"ttl":120,"tags":{"component":"uaa"},"private_instance_id":"d9736d1f-513e-481a-5f24-1e3221eb1516"}],"api.bosh-lite.com":[{"address":"10.244.0.134:9024","tls":true,"ttl":120,"tags":{"component":"CloudController"},"private_instance_id":"fc94f1aa-4a4d-4ae5-72d0-9cfa4129dd5c","server_cert_domain_san":"api.bosh-lite.com"}],"api.bosh-lite.com/networking":[{"address":"10.244.0.134:4002","tls":false,"ttl":120,"tags":null,"private_instance_id":"fc94f1aa-4a4d-4ae5-72d0-9cfa4129dd5c"}],"api.bosh-lite.com/routing":[{"address":"10.244.0.134:3000","tls":false,"ttl":120,"tags":null,"server_cert_domain_san":"routing_api"}],"blobstore.bosh-lite.com":[{"address":"10.244.0.133:8080","tls":false,"ttl":120,"tags":{"component":"blobstore"},"private_instance_id":"c2b1b1c3-6822-40e6-7cfe-87aa9c43308d"}],"doppler.bosh-lite.com":[{"address":"10.244.0.140:8081","tls":false,"ttl":120,"tags":null,"private_instance_id":"2069a44e-a1f0-4b46-6ad2-dc850e49c37d"}],"dora.bosh-lite.com":[{"address":"10.244.0.139:61002","tls":true,"ttl":120,"tags":{"component":"route-emitter"},"private_instance_id":"c4e3dc50-fe83-4e0f-6bb8-21e5","server_cert_domain_san":"c4e3dc50-fe83-4e0f-6bb8-21e5"}],"log-cache.bosh-lite.com":[{"address":"10.244.0.138:8083","tls":false,"ttl":120,"tags":null,"private_instance_id":"5c40f092-dcde-4c84-7afb-aa6c8c516c88"}],"loggregator.bosh-lite.com":[{"address":"10.244.0.140:8080","tls":false,"ttl":120,"tags":null,"private_instance_id":"2069a44e-a1f0-4b46-6ad2-dc850e49c37d"}],"login.bosh-lite.com":[{"address":"10.244.0.132:8080","tls":false,"ttl":120,"tags":{"component":"uaa"},"private_instance_id":"d9736d1f-513e-481a-5f24-1e3221eb1516"}],"uaa.bosh-lite.com":[{"address":"10.244.0.132:8080","tls":false,"ttl":120,"tags":{"component":"uaa"},"private_instance_id":"d9736d1f-513e-481a-5f24-1e3221eb1516"}]}
router/1380a779-5c97-4130-8d1f-4e59c7e0691c: stderr | Connection to 10.244.0.34 closed.

Succeeded
```
</details>

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests` 
  * N/A: this PR introduces no code changes to the release.

* [ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite
  * No: this PR is not expected to affect CF component functionality or performance.

* [ ] I have run CF Acceptance Tests on bosh lite
  * No: this PR is not expected to affect CF component functionality or performance.
