### PR TITLE
Allow set HSTS header value for gorouter

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -167,6 +167,9 @@ properties:
       When force_forwarded_proto_https: true, this property will be ignored.
       Otherwise,  we recommend setting the property to true if Gorouter is the first component to terminate TLS, and set to false when your load balancer is terminating TLS and setting the X-Forwarded-Proto header.
     default: false
+  router.strict_transport_security_header:
+    description: (optional, string) If set, gorouter will inject the HSTS (HTTP Strict Transport Security) Header if not set by the backend into the response using the provided value. The value must follow the HSTS spec.
+    example: "max-age=31536000; includeSubDomains; preload"
   router.frontend_idle_timeout:
     description: |
       (optional, integer) Duration in seconds to maintain an open connection when client supports keep-alive.

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -179,6 +179,10 @@ token_fetcher_expiration_buffer_time: 30
 enable_proxy: <%= p("router.enable_proxy") %>
 force_forwarded_proto_https: <%= p("router.force_forwarded_proto_https") %>
 sanitize_forwarded_proto: <%= p("router.sanitize_forwarded_proto") %>
+<% if_p("router.strict_transport_security_header") do |h| %>
+strict_transport_security_header: <%= h %>
+<% end %>
+
 pid_file: /var/vcap/sys/run/gorouter/gorouter.pid
 
 ip_local_port_range: <%= p("router.ip_local_port_range") %>


### PR DESCRIPTION
What?
-----

Add the changes necessary to use the feature added in
https://github.com/cloudfoundry/gorouter/pull/231

We want to be able to inject the HSTS header, Strict-Transport-Security
into the response of the gorouter[1]

A new option strict_transport_security_header is added and can be
set to any free string to be inserted in this header, the
operator must set the right format.

The header would be injected only if configured and if the backend
does not return that header.

Use case
--------

In our organisation there is a requirement of any application to use HTTPS and set HSTS headers. We want every application to respond with these headers. The tenant can always override them if they need to.

How to review/test
----------------------

 - Set the right config `strict_transport_security_header` with the right value. Check that gorouter returns the header as desired.

Related PR
----------------
https://github.com/cloudfoundry/gorouter/pull/231 should be merged and the commit referencing the submodule updated or deleted.

Checklist
---------

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests`

* [x] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [x] I have run CF Acceptance Tests on bosh lite