### PR TITLE
Adds bpm as this is required from routing release 0.180.0

### DIFF
--- a/templates/routing.yml
+++ b/templates/routing.yml
@@ -5,12 +5,20 @@ releases:
   version: (( release_version_overrides.routing.version || "latest" ))
 - name: cf
   version: (( release_version_overrides.cf.version || "latest" ))
+- name: bpm
+  version: latest
 
 compilation:
   network: router1
   reuse_compilation_vms: true
   workers: (( iaas_settings.compilation_workers || 6))
   cloud_properties: (( iaas_settings.compilation_cloud_properties ))
+
+addons:
+- name: bpm
+  jobs:
+  - name: bpm
+    release: bpm
 
 update:
   canaries: 1


### PR DESCRIPTION
Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Adds BPM as this is required from routing release `0.180.0` for jobs on the component VMs for gorouter, routing-api and route-registrar

* An explanation of the use cases your change solves
Rather than an operator having to add BPM onto any component VMs for gorouter, routing-api and route-registrar which are using the `cf-routing-release` > `0.180.0`, this should already be made available via the upstream release.


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests`

* [ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] I have run CF Acceptance Tests on bosh lite
