### PR TITLE
WIP: Allow inject custom headers into gorouter response

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -167,6 +167,14 @@ properties:
       When force_forwarded_proto_https: true, this property will be ignored.
       Otherwise,  we recommend setting the property to true if Gorouter is the first component to terminate TLS, and set to false when your load balancer is terminating TLS and setting the X-Forwarded-Proto header.
     default: false
+  router.http_rewrite.inject_response_headers:
+    description: |
+      (optional, array pairs name-value) If set, gorouter will inject the given headers if into the response unless the backend already set a header with the same name.
+    example:
+    - name: "Strict-Transport-Security"
+      value: "max-age=31536000; includeSubDomains; preload"
+    - name: "Cache-Control"
+      value: "no-cache"
   router.frontend_idle_timeout:
     description: |
       (optional, integer) Duration in seconds to maintain an open connection when client supports keep-alive.

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -179,6 +179,10 @@ token_fetcher_expiration_buffer_time: 30
 enable_proxy: <%= p("router.enable_proxy") %>
 force_forwarded_proto_https: <%= p("router.force_forwarded_proto_https") %>
 sanitize_forwarded_proto: <%= p("router.sanitize_forwarded_proto") %>
+<% if_p("router.http_rewrite") do |r| %>
+http_rewrite: <%= r.to_json %>
+<% end %>
+
 pid_file: /var/vcap/sys/run/gorouter/gorouter.pid
 
 ip_local_port_range: <%= p("router.ip_local_port_range") %>


### PR DESCRIPTION
What?
-----

Follow up of comment https://github.com/cloudfoundry/routing-release/pull/126#issuecomment-433709859

Add the changes necessary to use the feature added in
https://github.com/cloudfoundry/gorouter/pull/232
We want to be able to inject the heades in any response from the
go router. The header would be injected only if the backend
does not return those headers.

One example use case can be add a HSTS header,
Strict-Transport-Security into any response from the gorouter[1]

We allow some new configuration as in the router as:

    http_rewrite:
      inject_response_headers:
      - name: X-A-Header
      value: the-value
      - name: X-A-Header
      value: other-value
      - name: X-Other-Header
      value: some value

See https://github.com/cloudfoundry/gorouter/pull/232


Use case
--------

In our organisation there is a requirement of any application to use HTTPS and set HSTS headers. We want every application to respond with these headers. The tenant can always override them if they need to.

How to review/test
----------------------

 - Set the right config as above. Check that gorouter returns the header as desired.

Related PR
----------------
https://github.com/cloudfoundry/gorouter/pull/232 should be merged and the commit referencing the submodule updated or deleted.

Checklist
---------

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests`

* [ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] I have run CF Acceptance Tests on bosh lite