### PR TITLE
Configure components to log human-readable RFC3339 timestamps

### DIFF
--- a/jobs/route_registrar/templates/bpm.yml.erb
+++ b/jobs/route_registrar/templates/bpm.yml.erb
@@ -4,6 +4,8 @@ processes:
     args:
     - --configPath
     - /var/vcap/jobs/route_registrar/config/registrar_settings.json
+    - -timeFormat
+    - rfc3339
 <%
   paths = []
   routes = p('route_registrar.routes')

--- a/jobs/routing-api/templates/bpm.yml.erb
+++ b/jobs/routing-api/templates/bpm.yml.erb
@@ -8,6 +8,8 @@ processes:
     - <%= p("routing_api.port") %>
     - -logLevel
     - <%= p("routing_api.log_level") %>
+    - -timeFormat
+    - rfc3339
     - -ip
     - <%= spec.ip %>
     <% if p("routing_api.auth_disabled") == true %>- -devMode <% end %>

--- a/jobs/tcp_router/templates/tcp_router_ctl.erb
+++ b/jobs/tcp_router/templates/tcp_router_ctl.erb
@@ -77,6 +77,7 @@ set -e
 exec /var/vcap/packages/tcp_router/bin/cf-tcp-router\
   -debugAddr=<%= p("tcp_router.debug_address") %> \
   -logLevel=<%= p("tcp_router.log_level") %> \
+  -timeFormat=rfc3339 \
   -tcpLoadBalancerConfig="${CONFIG}" \
   -tcpLoadBalancerBaseConfig="/var/vcap/jobs/tcp_router/config/haproxy.conf.template" \
   -config="/var/vcap/jobs/tcp_router/config/tcp_router.yml" \

--- a/packages/acceptance_tests/spec
+++ b/packages/acceptance_tests/spec
@@ -15,6 +15,7 @@ files:
   - code.cloudfoundry.org/cf-routing-test-helpers/schema/*.go # gosub
   - code.cloudfoundry.org/clock/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/lager/lagerctx/*.go # gosub
   - code.cloudfoundry.org/lager/lagertest/*.go # gosub
   - code.cloudfoundry.org/routing-acceptance-tests/assets/golang/*.go # gosub

--- a/packages/gorouter/spec
+++ b/packages/gorouter/spec
@@ -60,6 +60,7 @@ files:
   - code.cloudfoundry.org/gorouter/test_util/rss/common/*.go # gosub
   - code.cloudfoundry.org/gorouter/varz/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/localip/*.go # gosub
   - code.cloudfoundry.org/routing-api/*.go # gosub
   - code.cloudfoundry.org/routing-api/models/*.go # gosub

--- a/packages/route_registrar/spec
+++ b/packages/route_registrar/spec
@@ -7,6 +7,7 @@ dependencies:
 files:
   - code.cloudfoundry.org/clock/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/lager/lagerflags/*.go # gosub
   - code.cloudfoundry.org/multierror/*.go # gosub
   - code.cloudfoundry.org/route-registrar/*.go # gosub

--- a/packages/routing-api/spec
+++ b/packages/routing-api/spec
@@ -17,6 +17,7 @@ files:
   - code.cloudfoundry.org/go-loggregator/*.go # gosub
   - code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/lager/lagerflags/*.go # gosub
   - code.cloudfoundry.org/locket/*.go # gosub
   - code.cloudfoundry.org/locket/lock/*.go # gosub

--- a/packages/tcp_router/spec
+++ b/packages/tcp_router/spec
@@ -28,6 +28,7 @@ files:
   - code.cloudfoundry.org/clock/*.go # gosub
   - code.cloudfoundry.org/debugserver/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/lager/lagerflags/*.go # gosub
   - code.cloudfoundry.org/routing-api/*.go # gosub
   - code.cloudfoundry.org/routing-api/models/*.go # gosub


### PR DESCRIPTION
This change configures the cf-tcp-router, route-registrar, and routing-api components to format the timestamps in their logs in RFC3339 format, which is more human-readable than the current Unix epoch timestamp while still being straightforward for machines to process. Log levels are also displayed as human-readable strings (`debug`,`info`,`error`, and `fatal`) instead of integers from 0 to 3.

A BOSH operator can observe the effects of this change by inspecting the stdout logs of the route_registrar, routing-api, and tcp_router jobs in a BOSH-deployed CF environment.

<details>
<summary>Log output examples</summary>

### Route Registrar
```
{"timestamp":"2019-01-24T11:32:37.238408184Z","level":"info","source":"Route Registrar","message":"Route Registrar.Registering route","data":{"route":{"Type":"","Name":"api","Port":9022,"TLSPort":9024,"Tags":{"component":"CloudController"},"URIs":["api.bosh-lite.com"],"RouterGroup":"","Host":"","ExternalPort":null,"RouteServiceUrl":"","RegistrationInterval":10000000000,"HealthCheck":{"Name":"api-health-check","ScriptPath":"/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng_health_check","Timeout":6000000000},"ServerCertDomainSAN":"api.bosh-lite.com"}}}
{"timestamp":"2019-01-24T11:32:37.238501256Z","level":"info","source":"Route Registrar","message":"Route Registrar.Registered routes successfully","data":{}}
```

### Routing API
```
{"timestamp":"2019-01-24T11:32:21.642962913Z","level":"info","source":"routing-api","message":"routing-api.prune-routes.successfully-finished-pruning-tcp-routes","data":{"rowsAffected":0,"session":"7"}}
{"timestamp":"2019-01-24T11:32:21.643422582Z","level":"info","source":"routing-api","message":"routing-api.prune-routes.successfully-finished-pruning-http-routes","data":{"rowsAffected":0,"session":"7"}}
```

### TCP Router
```
{"timestamp":"2019-01-24T11:32:16.273178217Z","level":"info","source":"tcp-router","message":"tcp-router.watcher.Subscribing-to-routing-api-event-stream","data":{"session":"6"}}
{"timestamp":"2019-01-24T11:32:16.492452007Z","level":"info","source":"tcp-router","message":"tcp-router.watcher.Successfully-subscribed-to-routing-api-event-stream","data":{"session":"6"}}
```
</details>

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests`
  - N/A: this PR introduces no changes to component code (although it does bump the `lager` library).

* [ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite
  - N/A: this PR introduces no changes that are expected to affect behavior that the acceptance tests assess.

* [ ] I have run CF Acceptance Tests on bosh lite
  - N/A: this PR introduces no changes that are expected to affect behavior that the acceptance tests assess.