### PR TITLE
Update Slack channel reference in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ delivers HTTP and TCP routing for Cloud Foundry.
 
 ## Getting Help
 
-For help or questions with this release or any of its submodules, you can reach the maintainers on Slack at [cloudfoundry.slack.com](https://cloudfoundry.slack.com) in the `#routing` channel.
+For help or questions with this release or any of its submodules, you can reach the maintainers on Slack at [cloudfoundry.slack.com](https://cloudfoundry.slack.com) in the `#networking` channel.
 
 ## Developer Workflow
 


### PR DESCRIPTION
CF Slack #routing and some others got merged into #networking in Feb 2019.