### PR TITLE
Configure components to log human-readable RFC3339 timestamps

### DIFF
--- a/jobs/route_registrar/templates/bpm.yml.erb
+++ b/jobs/route_registrar/templates/bpm.yml.erb
@@ -4,6 +4,8 @@ processes:
     args:
     - --configPath
     - /var/vcap/jobs/route_registrar/config/registrar_settings.json
+    - -timeFormat
+    - rfc3339
 <%
   paths = []
   routes = p('route_registrar.routes')

--- a/jobs/routing-api/templates/bpm.yml.erb
+++ b/jobs/routing-api/templates/bpm.yml.erb
@@ -8,6 +8,8 @@ processes:
     - <%= p("routing_api.port") %>
     - -logLevel
     - <%= p("routing_api.log_level") %>
+    - -timeFormat
+    - rfc3339
     - -ip
     - <%= spec.ip %>
     <% if p("routing_api.auth_disabled") == true %>- -devMode <% end %>

--- a/jobs/tcp_router/templates/tcp_router_ctl.erb
+++ b/jobs/tcp_router/templates/tcp_router_ctl.erb
@@ -77,6 +77,7 @@ set -e
 exec /var/vcap/packages/tcp_router/bin/cf-tcp-router\
   -debugAddr=<%= p("tcp_router.debug_address") %> \
   -logLevel=<%= p("tcp_router.log_level") %> \
+  -timeFormat=rfc3339 \
   -tcpLoadBalancerConfig="${CONFIG}" \
   -tcpLoadBalancerBaseConfig="/var/vcap/jobs/tcp_router/config/haproxy.conf.template" \
   -config="/var/vcap/jobs/tcp_router/config/tcp_router.yml" \

--- a/packages/acceptance_tests/spec
+++ b/packages/acceptance_tests/spec
@@ -15,6 +15,7 @@ files:
   - code.cloudfoundry.org/cf-routing-test-helpers/schema/*.go # gosub
   - code.cloudfoundry.org/clock/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/lager/lagerctx/*.go # gosub
   - code.cloudfoundry.org/lager/lagertest/*.go # gosub
   - code.cloudfoundry.org/routing-acceptance-tests/assets/golang/*.go # gosub

--- a/packages/gorouter/spec
+++ b/packages/gorouter/spec
@@ -60,6 +60,7 @@ files:
   - code.cloudfoundry.org/gorouter/test_util/rss/common/*.go # gosub
   - code.cloudfoundry.org/gorouter/varz/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/localip/*.go # gosub
   - code.cloudfoundry.org/routing-api/*.go # gosub
   - code.cloudfoundry.org/routing-api/models/*.go # gosub

--- a/packages/route_registrar/spec
+++ b/packages/route_registrar/spec
@@ -7,6 +7,7 @@ dependencies:
 files:
   - code.cloudfoundry.org/clock/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/lager/lagerflags/*.go # gosub
   - code.cloudfoundry.org/multierror/*.go # gosub
   - code.cloudfoundry.org/route-registrar/*.go # gosub

--- a/packages/routing-api/spec
+++ b/packages/routing-api/spec
@@ -17,6 +17,7 @@ files:
   - code.cloudfoundry.org/go-loggregator/*.go # gosub
   - code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/lager/lagerflags/*.go # gosub
   - code.cloudfoundry.org/locket/*.go # gosub
   - code.cloudfoundry.org/locket/lock/*.go # gosub

--- a/packages/tcp_router/spec
+++ b/packages/tcp_router/spec
@@ -28,6 +28,7 @@ files:
   - code.cloudfoundry.org/clock/*.go # gosub
   - code.cloudfoundry.org/debugserver/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/lager/lagerflags/*.go # gosub
   - code.cloudfoundry.org/routing-api/*.go # gosub
   - code.cloudfoundry.org/routing-api/models/*.go # gosub


### PR DESCRIPTION
This change configures the cf-tcp-router, route-registrar, and routing-api components to format the timestamps in their logs in RFC3339 format, which is more human-readable than the current Unix epoch timestamp while still being straightforward for machines to process.

Redo of https://github.com/cloudfoundry/routing-release/pull/133.

/cc @KauzClay 