### PR TITLE
Do recursive search for dns_health_check_host

### DIFF
--- a/jobs/routing-api/templates/bpm-pre-start.erb
+++ b/jobs/routing-api/templates/bpm-pre-start.erb
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 set +e
-host -r <%= p("dns_health_check_host") %>
+host <%= p("dns_health_check_host") %>
 if [[ "0" != "$?" ]]; then
   echo "DNS is not up"
   exit 1


### PR DESCRIPTION
This fixes deploying containerised Cloud Foundry on GKE.

The flag `-r` has been added for Bosh DNS initially when the check was part of start script.
Now, when the check moved pre-start, it can be removed.
Gorouter lost this flag when it was BPMized. https://github.com/cloudfoundry/routing-release/commit/54bc6f635b0fb12e795f1a5d222265de206cc394#diff-f604b5c718a155ccd0bf5e9070c83f5c

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests`

* [ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] I have run CF Acceptance Tests on bosh lite
