### PR TITLE
Fix use of skip_ssl_validation spec for the route registrar job

### DIFF
--- a/jobs/route_registrar/templates/registrar_settings.json.erb
+++ b/jobs/route_registrar/templates/registrar_settings.json.erb
@@ -67,8 +67,8 @@
   if_p('route_registrar.routing_api.client_secret') do |prop|
     routing_api['client_secret'] = prop
   end
-  if_p('route_registrar.routing_api.skip_cert_validation') do |prop|
-    routing_api['skip_cert_validation'] = prop
+  if_p('route_registrar.routing_api.skip_ssl_validation') do |prop|
+    routing_api['skip_ssl_validation'] = prop
   end
 
   config = {


### PR DESCRIPTION
The route-registrar spec declares the property `route_registrar.routing_api.skip_ssl_validation`, which 
is consistent with the name of the property in the route registrar application (https://github.com/cloudfoundry/route-registrar/blob/a6b40e9899426c6b5bf913469c05019fe2effa43/config/config.go#L26). Despite this, the `registrar_settings.json.erb` template tries to make use of the non-existent `route_registrar.routing_api.skip_cert_validation` property and also to set it as a property to the application.

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests`

* [ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] I have run CF Acceptance Tests on bosh lite
