### PR TITLE
Add logging_level for route_registrar job

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -44,6 +44,9 @@ properties:
     description: (string, optional) By default, route_registrar will detect the IP of the VM and use it, in combination with port as the backend destination for each uri being registered. This property enables overriding the destination hostname or IP.
     example: 192.168.60.25
 
+  route_registrar.logging_level:
+    description: "Log level for route_registrar"
+    default: "info"
   route_registrar.routing_api.api_url:
     description: (optional, string) The routing API's URL. This is required to register any TCP routes.
     default: https://routing-api.service.cf.internal:3001

--- a/jobs/route_registrar/templates/bpm.yml.erb
+++ b/jobs/route_registrar/templates/bpm.yml.erb
@@ -6,6 +6,8 @@ processes:
     - /var/vcap/jobs/route_registrar/config/registrar_settings.json
     - -timeFormat
     - rfc3339
+    - -logLevel
+    - <%= p('route_registrar.logging_level') %>
 <%
   paths = []
   routes = p('route_registrar.routes')


### PR DESCRIPTION
Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change: Add logging_level for route_registrar job

* An explanation of the use cases your change solves: We are seeing a good number of the info logs in our syslog endpoint that is contributing to going over our quote limit. We would like to be able to set this logging_level to `error` to help stay within our account limit. 

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics): `route_registrar.logging_level` can now be set to `debug`, `info`, `error`, and `fatal`.

* Expected result after the change: As a user when I set this property, to `error` level, I stop seeing `info` logs in our aggregation endpoint.

* Current result before the change: I see all types of logs without being able to filter.

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests`

* [ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] I have run CF Acceptance Tests on bosh lite
