### PR TITLE
Add CI status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 This repo is a [BOSH release](https://github.com/cloudfoundry/bosh) that
 delivers HTTP and TCP routing for Cloud Foundry.
 
+## Status
+Job | Status
+--- | ---
+unit tests | [![routing.ci.cf-app.com](https://routing.ci.cf-app.com/api/v1/pipelines/routing/jobs/routing-release-unit/badge)](https://routing.ci.cf-app.com/teams/main/pipelines/routing/jobs/routing-release-unit)
+performance tests | [![routing.ci.cf-app.com](https://routing.ci.cf-app.com/api/v1/pipelines/routing/jobs/diana-tcp-perf-tests/badge)](https://routing.ci.cf-app.com/teams/main/pipelines/routing/jobs/diana-tcp-perf-tests)
+smoke tests | [![routing.ci.cf-app.com](https://routing.ci.cf-app.com/api/v1/pipelines/routing/jobs/batman-cf-smoke-tests/badge)](https://routing.ci.cf-app.com/teams/main/pipelines/routing/jobs/batman-cf-smoke-tests)
+
 ## Getting Help
 
 For help or questions with this release or any of its submodules, you can reach the maintainers on Slack at [cloudfoundry.slack.com](https://cloudfoundry.slack.com) in the `#networking` channel.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ delivers HTTP and TCP routing for Cloud Foundry.
 ## Status
 Job | Status
 --- | ---
-unit tests | [![routing.ci.cf-app.com](https://routing.ci.cf-app.com/api/v1/pipelines/routing/jobs/routing-release-unit/badge)](https://routing.ci.cf-app.com/teams/main/pipelines/routing/jobs/routing-release-unit)
-performance tests | [![routing.ci.cf-app.com](https://routing.ci.cf-app.com/api/v1/pipelines/routing/jobs/diana-tcp-perf-tests/badge)](https://routing.ci.cf-app.com/teams/main/pipelines/routing/jobs/diana-tcp-perf-tests)
-smoke tests | [![routing.ci.cf-app.com](https://routing.ci.cf-app.com/api/v1/pipelines/routing/jobs/batman-cf-smoke-tests/badge)](https://routing.ci.cf-app.com/teams/main/pipelines/routing/jobs/batman-cf-smoke-tests)
+unit tests | [![routing.ci.cf-app.com](https://routing.ci.cf-app.com/api/v1/teams/ga/pipelines/routing/jobs/routing-release-unit/badge)](https://routing.ci.cf-app.com/teams/ga/pipelines/routing/jobs/routing-release-unit)
+performance tests | [![routing.ci.cf-app.com](https://routing.ci.cf-app.com/api/v1/teams/ga/pipelines/routing/jobs/diana-tcp-perf-tests/badge)](https://routing.ci.cf-app.com/teams/ga/pipelines/routing/jobs/diana-tcp-perf-tests)
+smoke tests | [![routing.ci.cf-app.com](https://routing.ci.cf-app.com/api/v1/teams/ga/pipelines/routing/jobs/batman-cf-smoke-tests/badge)](https://routing.ci.cf-app.com/teams/ga/pipelines/routing/jobs/batman-cf-smoke-tests)
 
 ## Getting Help
 


### PR DESCRIPTION
While navigating the code base I tried to find a link to the CI
pipelines to check the status without success.

This PR adds status badges that link to the CI for some jobs that I
found relevant.

More details about Concourse status badges: http://engineering.pivotal.io/post/concourse-badges/

Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* ~~[ ] I have run all the unit tests using `scripts/run-unit-tests`~~

* ~~[ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite~~

* ~~[ ] I have run CF Acceptance Tests on bosh lite~~
