### PR TITLE
Refine spec with route_service_url

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -86,6 +86,7 @@ properties:
         tls_port (required, integer, for http routes): Either `port` or `tls_port` are required; if both are provided, Gorouter will prefer tls_port.
           Requests for associated URIs will be forwarded over TLS by the router to this port.
           The IP is determined automatically from the host on which route-registrar is run.
+        route_service_url (optional, string, for http routes): When valid route service URL is provided, Gorouter will proxy requests received for the uris above to the specified route service URL.
         server_cert_domain_san (conditional, string, for http routes): Required if tls_port is present.
           Gorouter will validate that the TLS certificate presented by the destination host contains this as a Subject Alternative Name (SAN).
         registration_interval (required, string, for all routes): Interval between heartbeated route registrations
@@ -122,6 +123,7 @@ properties:
           name: my-service-health_check
           script_path: /path/to/script
           timeout: 5s
+        route_service_url: https://my-oauth-proxy-route-service.example.com
       - name: my-tls-endpoint
         tls_port: 12346
         server_cert_domain_san: "my-tls-endpoint.internal.com"


### PR DESCRIPTION
###  A short explanation of the proposed change:

Route registrar cli does support route_service_url, (see https://github.com/cloudfoundry/route-registrar#usage)

Adding it to the spec in the route_registrar.routes description and example

###  An explanation of the use cases your change solves

Need to register [route service](https://docs.cloudfoundry.org/services/route-services.html) with the routing-release.route-registrar job

### Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Discover support for `route_service_url` in the route-registrar spec file
* Set a valid `route_service_url` within a route-registrar `route` property. 

###  Expected result after the change

* Support  for `route_service_url` can be discovered in the route-registrar spec file
* When provided, Gorouter will proxy requests received to the route service.

###  Current result before the change

Spec does not document such support.


* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch
* [ ] I have run all the unit tests using `scripts/run-unit-tests`
* [ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite
* [ ] I have run CF Acceptance Tests on bosh lite

/CC @poblin-orange