### PR TITLE
Configure gorouter keep alive probe interval

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -178,6 +178,9 @@ properties:
   router.max_idle_connections:
     default: 100
     description: "Maximum idle keepalive connections per backend. This value can only between 0 and 100. When 0, support for keepalive connections is disabled."
+  router.keep_alive_probe_interval:
+    default: 1s
+    description: Interval between TCP keep alive probes. Value is a string (e.g. "10s")
   router.force_forwarded_proto_https:
     description: "Enables setting X-Forwarded-Proto header if SSL termination happened upstream and incorrectly set the header value. When this property is set to true gorouter sets the header X-Forwarded-Proto to https. When this value set to false, gorouter set the header X-Forwarded-Proto to the protocol of the incoming request"
     default: false

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -75,6 +75,7 @@ route_latency_metric_muzzle_duration: 30s
 disable_keep_alives: false
 max_idle_conns: <%= p("router.max_idle_connections") %>
 max_idle_conns_per_host: 100
+endpoint_keep_alive_probe_interval: <%= p("router.keep_alive_probe_interval") %>
 <% else %>
 disable_keep_alives: true
 <% end%>


### PR DESCRIPTION
### A short explanation of the proposed change:

In https://github.com/cloudfoundry/gorouter/pull/258 we customised and made configurable the endpoint_keep_alive_probe_interval property in gorouter.

This commit allows the user to configure the `endpoint_keep_alive_probe_interval` using the `router.keep_alive_probe_interval` property, and adds a default so documentation is clear.

In order to confirm that my template logic was correct I added some tests.

I am on my work Macbook Air, so I have not run all the tests, I have only run `bundle exec rspec` as my changes is limited to the gorouter job spec.

### Mentions

@KauzClay @angelachin are the two people mentioned in https://github.com/cloudfoundry/gorouter/pull/258

### Links to any other associated PRs

- https://github.com/cloudfoundry/gorouter/pull/258

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests`

* [ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] I have run CF Acceptance Tests on bosh lite
