### PR TITLE
Add w3c tracing to gorouter BOSH job spec

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -218,6 +218,19 @@ properties:
   router.tracing.enable_zipkin:
     description: "Enables the addition of the X-B3-Trace-Id header to incoming requests. If the header already exists on the incoming request, it will not be overwritten."
     default: false
+  router.tracing.enable_w3c:
+    description: |
+      Enables the addition of the W3C tracing headers to incoming requests.
+      If the traceparent and tracestate headers exist on the incoming request, they will be updated, if they do not exist they will be created.
+      The W3C tracing specification has more information: https://www.w3.org/TR/trace-context/
+    default: false
+  router.tracing.w3c_tenant_id:
+    description: |
+      Specifies the tenant ID to use in the W3C tracestate header, only used when W3C tracing headers are enabled.
+      If specified, the tracestate identifier will be "tenant-id@gorouter" where "tenant-id" is the value specified.
+      If not specified, the tracestate identifier will be "gorouter"
+      The W3C tracing specification has more information: https://www.w3.org/TR/trace-context/
+    default: ""
   router.isolation_segments:
     description: "Routes with these isolation segments will be registered. Used in combination with routing_table_sharding_mode."
     default: []

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -51,6 +51,10 @@ logging:
 
 tracing:
   enable_zipkin: <%= p("router.tracing.enable_zipkin") %>
+  enable_w3c: <%= p("router.tracing.enable_w3c") %>
+  <% if p("router.tracing.enable_w3c") %>
+  w3c_tenant_id: <%= p("router.tracing.w3c_tenant_id") %>
+  <% end %>
 
 port: <%= p("router.port") %>
 index: <%= p("router.offset") + spec.index %>

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -43,7 +43,9 @@ describe 'gorouter' do
           'client_cert_validation' => 'none',
           'logging_level' => 'info',
           'tracing' => {
-            'enable_zipkin' => false
+            'enable_zipkin' => false,
+            'enable_w3c' => false,
+            'w3c_tenant_id' => nil
           },
           'ssl_skip_validation' => false,
           'port' => 80,
@@ -169,6 +171,12 @@ describe 'gorouter' do
             it 'should set max_idle_conns' do
               expect(parsed_yaml['max_idle_conns']).to eq(2500)
               expect(parsed_yaml['max_idle_conns_per_host']).to eq(100)
+            end
+            it 'should not enable zipkin' do
+              expect(parsed_yaml.dig('tracing', 'enable_zipkin')).to eq(false)
+            end
+            it 'should not enable w3c' do
+              expect(parsed_yaml.dig('tracing', 'enable_w3c')).to eq(false)
             end
           end
         end
@@ -663,6 +671,54 @@ describe 'gorouter' do
               link: 'routing_api.mtls_client_cert',
               parsed_yaml_property: 'routing_api.cert_chain'
             )
+          end
+        end
+      end
+
+      context 'tracing' do
+        context 'when zipkin is enabled' do
+          before do
+            deployment_manifest_fragment['router']['tracing']['enable_zipkin'] = true
+          end
+
+          it 'is happy' do
+            expect { parsed_yaml }.not_to raise_error
+          end
+
+          it 'should enable zipkin' do
+            expect(parsed_yaml['tracing']['enable_zipkin']).to eq(true)
+          end
+        end
+
+        context 'when w3c is enabled' do
+          before do
+            deployment_manifest_fragment['router']['tracing']['enable_w3c'] = true
+          end
+
+          it 'is happy' do
+            expect { parsed_yaml }.not_to raise_error
+          end
+
+          it 'should enable w3c tracing' do
+            expect(parsed_yaml['tracing']['enable_w3c']).to eq(true)
+          end
+
+          it 'should not set the w3c tenant ID' do
+            expect(parsed_yaml['tracing']['w3c_tenant_id']).to eq(nil)
+          end
+
+          context 'when w3c is enabled' do
+            before do
+              deployment_manifest_fragment['router']['tracing']['w3c_tenant_id'] = 'tid'
+            end
+
+            it 'is happy' do
+              expect { parsed_yaml }.not_to raise_error
+            end
+
+            it 'should set wc3_tenant_id' do
+              expect(parsed_yaml['tracing']['w3c_tenant_id']).to eq('tid')
+            end
           end
         end
       end


### PR DESCRIPTION
### A short explanation of the proposed change:

In https://github.com/cloudfoundry/gorouter/pull/261 we added support for W3C trace headers (tracestate and traceparent).

This introduced two new parameters to gorouter's configuration file:

- `tracing.enable_w3c`
- `tracing.w3c_tenant_id`

These are now configurable under the router namespace in the gorouter BOSH job spec:

- `router.tracing.enable_w3c`
- `router.tracing.w3c_tenant_id`

### Instructions to functionally test the behavior change

Code review

Run the spec tests

_Change is contingent on associated gorouter PR_

### Links to any other associated PRs

- https://github.com/cloudfoundry/gorouter/pull/261

### Checklist

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests`

* [ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] I have run CF Acceptance Tests on bosh lite
