### PR TITLE
Clarify gorouter job property max_idle_connections

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -181,7 +181,10 @@ properties:
     default: false
   router.max_idle_connections:
     default: 100
-    description: "Maximum idle keepalive connections per backend. This value can only between 0 and 100. When 0, support for keepalive connections is disabled."
+    description: |
+      When 0, keepalive connections are disabled.
+      When a number greater than zero, keepalives are enabled, and Gorouter will keep up to this number of idle keepalive connections open across all backends.
+      When keepalive connections are enabled, the maximum number of idle keepalive connections Gorouter will keep open to an individual backend is 100, which cannot be changed.
   router.keep_alive_probe_interval:
     default: 1s
     description: Interval between TCP keep alive probes. Value is a string (e.g. "10s")


### PR DESCRIPTION
### A short explanation of the proposed change:

Clarify the usage and bounding of the Gorouter job `router.max_idle_connections` property

### An explanation of the use cases your change solves

The job template for gorouter is as follows:

```
<% if p("router.max_idle_connections") && p("router.max_idle_connections") > 0 %>
disable_keep_alives: false
max_idle_conns: <%= p("router.max_idle_connections") %>
max_idle_conns_per_host: 100
endpoint_keep_alive_probe_interval: <%= p("router.keep_alive_probe_interval") %>
<% else %>
disable_keep_alives: true
<% end%>
```

i.e. when max_idle_connections is set and greater than zero then:

- we use that for the total number of max idle connections
- this number is unbounded (within the context of this template)
- the max number of connections per host is hardcoded to 100

The gorouter codebase does not put a bound on the max number of idle connections. The value for `max_idle_connections` is given directly to `http.Transport{MaxIdleConn:}`

### Code review

- Gorouter job [templating the configuration](https://github.com/cloudfoundry/routing-release/blob/develop/jobs/gorouter/templates/gorouter.yml.erb#L84)
- Gorouter [parsing the `max_idle_conns` configuration](https://github.com/cloudfoundry/gorouter/blob/9aaf446b22db0adb46e8356e1e0bae7355728d80/config/config.go#L254)
- Gorouter [giving the unbounded `MaxIdleConns` to `http.Transport`](https://github.com/cloudfoundry/gorouter/blob/9aaf446b22db0adb46e8356e1e0bae7355728d80/proxy/proxy.go#L108)

### Checklist

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests`

* [ ] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] I have run CF Acceptance Tests on bosh lite
