### PR TITLE
Update description for request_timeout_in_seconds

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -291,7 +291,12 @@ properties:
       trace headers are added to the response.
     default: 22
   request_timeout_in_seconds:
-    description: "Time that Router -> Endpoint connections are allowed to remain idle before being closed."
+    description: |
+      This configures a "request timeout" and a "backend idle timeout".
+      Requests from router to backend endpoints that are longer than this duration will be canceled and logged as
+      `backend-request-timeout` errors. In addition, TCP connections between router and backend endpoints that
+      are idle for longer than this duration will be closed. Related properties: `router.max_idle_connections`
+      and `router.keep_alive_probe_interval`.
     default: 900
 
   metron.port:


### PR DESCRIPTION
- Clarify that it configures both a "request timeout" and a "backend idle timeout"
- Bump gorouter with related changes that adds a `backend-request-timeout` log message for requests that timeout.

cloudfoundry/routing-release#167

* A short explanation of the proposed change:

- `router/router_test.go` has been updated to more clearly demonstrate the behavior when requests timeout vs. the backend idle timeout behavior.
- a `backend-request-timeout` log message has been added. previously, a `backend-endpoint-failed` error with message `context deadline exceeded` would be logged only in the case where the backend had not responded _at all_. now, we also log an error in the case the the response has been partially written before the timeout. 
- a small, tangentially change to `router_drain_test.go` is included that removes a sleep from the test.

* An explanation of the use cases your change solves

- Searching logs for `backend-request-timeout` should now show all cases where requests have timed out.
- Future maintainers can more clearly see that `config.EndpointTimeout` configures both a backend idle timeout and a request timeout via tests in `router/router.go`

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

1. Create a BOSH release of `routing-release` that uses this version of `gorouter`
2. Edit a `cf-deployment` manifest to use that version of `routing-release`
3. Set `request_timeout_in_seconds` to a small value (e.g. 5)
4. Deploy `dora` from `cf-acceptance-tests`
5. Curl dora with a delay > request timeout, e.g. `curl dora.mydomain.tld/delay/6`
6. Search `gorouter.stdout.log` for `backend-request-timeout`

Do the same thing with an app that partially writes out a response, e.g.:

```
package main

import (
    "fmt"
    "net/http"
    "time"
)

func main() {
    http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
        for i := 1; i <= 200; i++ {
            fmt.Fprintf(w, "Chunk #%d\n", i)
            w.(http.Flusher).Flush() // Trigger "chunked" encoding and send a chunk...
            time.Sleep(1000 * time.Millisecond)
        }
    })
}
```

h/t this stackoverflow question/answer: https://stackoverflow.com/a/30603654 

* Expected result after the change

Logs for requests to both apps will show an error with `backend-request-timeout` and `context deadline exceeded`

* Current result before the change

Dora will show a `backend-endpoint-failed` message with `context deadline exceeded`; The go failed request to the go app will have no error message.

* Links to any other associated PRs

https://github.com/cloudfoundry/gorouter/pull/211

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` (in `routing-release`)

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite

