### PR TITLE
Gorouter can be configured with HTML error pages

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -16,6 +16,7 @@ templates:
   bpm-pre-start.erb: bin/bpm-pre-start
   retrieve-local-routes.erb: bin/retrieve-local-routes
   indicators.yml.erb: config/indicators.yml
+  error.html.erb: config/error.html
 
 packages:
   - routing_utils
@@ -267,6 +268,19 @@ properties:
       This is to comply with EU regulations that do not allow persisting personal data. When Gorouter is behind an L3 load balancer that
       persists the IP of the originating client, set this to true to comply with GDPR.
     default: false
+  router.html_error_template:
+    description: |
+      (optional) When given a valid Go template, gorouter will generate HTML error pages instead of plain text error pages.
+      The following is an example of a valid HTML template:
+
+      <html>
+        <body>
+          Code: {{ .Status }} {{ .StatusText }}
+          Message: {{ .Message }}
+          Cause: {{ .Header.Get "X-Cf-RouterError" }}
+        </body>
+      </html>
+    default: ""
 
   nats.user:
     description: User name for NATS authentication

--- a/jobs/gorouter/templates/error.html.erb
+++ b/jobs/gorouter/templates/error.html.erb
@@ -1,0 +1,1 @@
+<%= p("router.html_error_template") %>

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -292,5 +292,9 @@ pid_file: /var/vcap/sys/run/gorouter/gorouter.pid
 
 ip_local_port_range: <%= p("router.ip_local_port_range") %>
 
+<% if_p('router.html_error_template') do |t| %>
+html_error_template_file: <%= t == "" ? "" : "/var/vcap/jobs/gorouter/config/error.html" %>
+<% end %>
+
 #backwards compatibility only section
 empty_pool_response_code_503: <%= p("for_backwards_compatibility_only.empty_pool_response_code_503") %>

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -273,6 +273,22 @@ describe 'gorouter' do
         end
       end
 
+      context 'html_error_template' do
+        it 'is not set by default' do
+          expect(parsed_yaml['html_error_template_file']).to be_nil
+        end
+
+        context 'when enabled' do
+          before do
+            deployment_manifest_fragment['router']['html_error_template'] = '<html>...goes here...</html>'
+          end
+
+          it 'sets the template path to the templated file' do
+            expect(parsed_yaml['html_error_template_file']).to eq('/var/vcap/jobs/gorouter/config/error.html')
+          end
+        end
+      end
+
       context 'tls_pem' do
         context 'when correct tls_pem is provided' do
           it 'should configure the property' do
@@ -831,6 +847,29 @@ describe 'gorouter' do
 
     it 'contains indicators' do
       expect(parsed_yaml['spec']['indicators']).to_not be_empty
+    end
+  end
+
+  describe 'error.html' do
+    let(:template) { job.template('config/error.html') }
+    let(:rendered_template) do
+      template.render({ 'router' => { 'html_error_template' => html } })
+    end
+
+    context 'by default' do
+      let(:html) { '' }
+
+      it 'is empty' do
+        expect(rendered_template).to eq("\n")
+      end
+    end
+
+    context 'when an error template is defined' do
+      let(:html) { '<html>error</html>' }
+
+      it 'consists of the rendered template' do
+        expect(rendered_template).to eq("<html>error</html>\n")
+      end
     end
   end
 end


### PR DESCRIPTION
## What

Read [gorouter#271](https://github.com/cloudfoundry/gorouter/pull/271) for detailed information

Allows an operator to use a Go template to customise the error pages, for example:

```
<html>
  <body>
    Code: {{ .Status }} {{ .StatusText }}<br>
    Message: {{ .Message }}<br>
    Cause: {{ .Header.Get "X-Cf-RouterError" }}
  </body>
</html>
```

## Why

As an operator, I would like to customise the error pages, so that my end-users get a more helpful error page.

As an operator, I would like to return HTML in the error pages, because plaintext error pages scare my users.

## How to test

Deploy the following ops file to a CF deployment

```
- type: replace
  path: /releases/name=routing
  value:
    name: "routing"
    version: 0.0.1597688047
    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/routing-0.0.1597688047.tgz
    sha1: 55c752a94605245e34bf2eacc0d89969c16e5724

- type: replace
  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/html_error_template?
  value: |
    <html>
      <body>
        Code: {{ .Status }} {{ .StatusText }}
        <br>
        Message: {{ .Message }}
        <br>
        Cause: {{ .Header.Get "X-Cf-RouterError" }}
      </body>
    </html>
```

### Expected result

A HTML error page with contents:

```
<html>
  <body>
    Code: 404 Not Found
    <br>
    Message: Requested route (&#39;404.route&#39;) does not exist.
    <br>
    Cause: unknown_route
  </body>
</html>
```
 
### Current result

A plaintext error page with contents:
```
404 Not Found: Requested route ('404.route') does not exist.
```

## Other PRs

https://github.com/cloudfoundry/gorouter/pull/271

## Checklist

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch
* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`
* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on ~bosh lite~ cf-deployment
* [x] (Optional) I have run CF Acceptance Tests on ~bosh lite~ cf-deployment
