### PR TITLE
Consume per request metrics reporting config

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -382,7 +382,7 @@ properties:
     default: true
 
   router.per_request_metrics_reporting:
-    description: "Report metrics for each request"
+    description: "Report the metrics latency, latency.<component> and route_lookup_time for each request"
     default: true
 
   router.send_http_start_stop_server_event:

--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -380,3 +380,15 @@ properties:
       This property is provided for backwards compatibility reasons. We recommend leaving it set to true.
       When it set to true, the gorouter will return a 503 when a route is known but there is nothing in the pool available to handle the request. When false, the gorouter will return a 404.
     default: true
+
+  router.per_request_metrics_reporting:
+    description: "Report metrics for each request"
+    default: true
+
+  router.send_http_start_stop_server_event:
+    description: "Send a httpstartstopevent of type server for each request"
+    default: true
+
+  router.send_http_start_stop_client_event:
+    description: "Send a httpstartstopevent of type client for each request"
+    default: true

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -298,3 +298,7 @@ html_error_template_file: <%= t == "" ? "" : "/var/vcap/jobs/gorouter/config/err
 
 #backwards compatibility only section
 empty_pool_response_code_503: <%= p("for_backwards_compatibility_only.empty_pool_response_code_503") %>
+
+per_request_metrics_reporting: <%= p("router.per_request_metrics_reporting") %> 
+send_http_start_stop_server_event: <%= p("router.send_http_start_stop_server_event") %> 
+send_http_start_stop_client_event: <%= p("router.send_http_start_stop_client_event") %> 

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -105,7 +105,10 @@ describe 'gorouter' do
             'private_key' => ROUTE_SERVICES_CLIENT_TEST_KEY
           },
           'frontend_idle_timeout' => 5,
-          'ip_local_port_range' => '1024 65535'
+          'ip_local_port_range' => '1024 65535',
+          'per_request_metrics_reporting' => true,
+          'send_http_start_stop_server_event' => true,
+          'send_http_start_stop_client_event' => true
         },
         'request_timeout_in_seconds' => 100,
         'routing_api' => {


### PR DESCRIPTION
* A short explanation of the proposed change:
This change addresses https://github.com/cloudfoundry/gorouter/issues/159 and makes new properties from the gorouter consumable.

See instructions and explanation in related PR for gorouter: https://github.com/cloudfoundry/gorouter/pull/275

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop ` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

