### PR TITLE
add sni routing support

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -93,9 +93,10 @@ properties:
 
       route object
         name (required, string, for all routes): Human-readable reference for the route
-        type (optional, string, for all routes): Defaults to http, can specify http or tcp.
+        type (optional, string, for all routes): Defaults to http, can specify http, sni, or tcp.
         uris (required, array, for http routes): When Gorouter receives a request that matches one of these URIs,
           it will forward them to the IP of the host on which route_registrar runs, and either port or tls_port.
+        sni_port (required, integer, for sni rotues): When sni type provided, this is the downstream port to route to
         port (required, integer, for all routes): Either `port` or `tls_port` are required; if both are provided, Gorouter will prefer tls_port.
           Requests for associated URIs will be forwarded unencypted by the router to this port.
           The IP is determined automatically from the host on which route-registrar is run.
@@ -116,6 +117,7 @@ properties:
           with error, the route is unregistered.
         router_group (required, string, for tcp routes): Name of the router group to which the TCP route should be added.
         external_port (required, string, for tcp routes): Port that the TCP router will listen on.
+        server_cert_domain_name_modifier (optional, string, for sni routes): a regex replace to help with complicated hostnames
 
       health_check object
         name (required, string): Human-readable reference for the healthcheck

--- a/jobs/route_registrar/templates/registrar_settings.json.erb
+++ b/jobs/route_registrar/templates/registrar_settings.json.erb
@@ -66,6 +66,18 @@
     if route['prepend_instance_index']
       route['uris'].map! { |uri| "#{spec.index}-#{uri}" }
     end
+
+    if route['type'] == 'sni'
+      route['sni_routable_san'] = spec.address
+
+      if route.key?('server_cert_domain_name_modifier')
+        if route['server_cert_domain_name_modifier'].key?('key')
+            route['sni_routable_san'] = spec.address.gsub(route['server_cert_domain_name_modifier']['key'], route['server_cert_domain_name_modifier']['value'])
+        else
+            raise "expected route_registrar.routes[#{index}].route.server_cert_domain_name_modifier.key when server_cert_domain_name_modifier is provided"
+        end
+      end
+    end
   end
 
   host = nil

--- a/jobs/routing-api/spec
+++ b/jobs/routing-api/spec
@@ -174,6 +174,10 @@ properties:
         reservable_ports: 1024-10000,12000
         type: tcp
 
+  routing_api.lock_resource_key:
+    description: "Resource key for service lock"
+    default: "routing_api_lock"
+
   routing_api.lock_ttl:
     description: "TTL for service lock"
     default: "10s"

--- a/jobs/routing-api/templates/routing-api.yml.erb
+++ b/jobs/routing-api/templates/routing-api.yml.erb
@@ -61,6 +61,7 @@ api:
   sqldb.to_yaml[4..-2]
 %>
 
+lock_resource_key: <%= p("routing_api.lock_resource_key") %>
 lock_ttl: <%= p("routing_api.lock_ttl") %>
 retry_interval: <%= p("routing_api.lock_retry_interval") %>
 

--- a/spec/routing_api_templates_spec.rb
+++ b/spec/routing_api_templates_spec.rb
@@ -125,6 +125,7 @@ describe 'routing_api' do
 
     it 'renders a file with default properties' do
       expect(rendered_config).to eq('admin_port' => 15_897,
+                                    'lock_resource_key' => 'routing_api_lock',
                                     'lock_ttl' => '10s',
                                     'retry_interval' => '5s',
                                     'debug_address' => '127.0.0.1:17002',

--- a/templates/routing.yml
+++ b/templates/routing.yml
@@ -236,6 +236,7 @@ properties:
     max_ttl: (( property_overrides.routing_api.max_ttl || nil ))
     lock_retry_interval: (( property_overrides.tcp_emitter.lock_retry_interval || nil ))
     lock_ttl: (( property_overrides.tcp_emitter.lock_ttl || nil ))
+    lock_resource_key: (( property_overrides.routing_api.lock_resource_key || nil ))
     etcd:
       servers: (( property_overrides.routing_api.etcd.servers || nil ))
       ca_cert: (( property_overrides.routing_api.etcd.ca_cert || nil ))


### PR DESCRIPTION
Adds resource lock key to routing-api. (#3)

added sni fields in readme

adds the following fields for sni routing:
add sni_port
add sni type

this type will eventually get adapated back into a tcp type,
but explictly adding an sni type allows for a more clear
api for the user.

<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
