### PR TITLE
Feat: toggle HTTP/2 functionality

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -103,7 +103,7 @@ properties:
     description: Disables the http listener on port specified by router.port. This cannot be set to true if enable_ssl is false.
     default: false
   router.enable_http2:
-    description: Enables the HTTP/2 protocol for communicating with apps.
+    description: Enables the HTTP/2 protocol for communicating with apps. Currently in beta, use at your own risk. Will default to true when the feature exits beta.
     default: false
   router.min_tls_version:
     description: Minimum accepted version of TLS protocol. All versions above this, up to the max_tls_version, will also be accepted. Valid values are TLSv1.0, TLSv1.1, and TLSv1.2.

--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -102,6 +102,9 @@ properties:
   router.disable_http:
     description: Disables the http listener on port specified by router.port. This cannot be set to true if enable_ssl is false.
     default: false
+  router.enable_http2:
+    description: Enables the HTTP/2 protocol for communicating with apps.
+    default: false
   router.min_tls_version:
     description: Minimum accepted version of TLS protocol. All versions above this, up to the max_tls_version, will also be accepted. Valid values are TLSv1.0, TLSv1.1, and TLSv1.2.
     default: TLSv1.2

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -255,6 +255,7 @@ ssl_port: <%= p("router.tls_port") %>
 <% end %>
 
 disable_http: <%= p("router.disable_http") %>
+enable_http2: <%= p("router.enable_http2") %>
 
 <% if p("router.ca_certs")
      ca_certs = p("router.ca_certs")


### PR DESCRIPTION
We've added a bosh property to the routing-release called `router.enable_http2` that configures HTTP/2 support for Gorouter as part of cloudfoundry/routing-release#200. `router.enable_http2` defaults to false.

Should be merged after cloudfoundry/gorouter#278.

**Instructions to try it out**
* Deploy routing release with `router.enable_http2` not set, curl Gorouter with HTTP/2, see your request fail with a protocol error.
* Deploy routing release with `router.enable_http2` set to true, curl Gorouter with HTTP/2, see your request succeed.
* Deploy routing release with `router.enable_http2` set to false, curl Gorouter with HTTP/2, see your request fail with a protocol error.


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite

**TODO:**
* [x] Make sure Gorouter submodule is pointing to the right commit