### PR TITLE
Enabling TLS 1.3 support

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -109,7 +109,7 @@ properties:
     description: |
       Maximum accepted version of TLS protocol. Versions below this will, down to the min_tls_version, will also be accepted. Valid values are TLSv1.2 and TLSv1.3.
       Warning: Setting this to TLSv1.3 will cause things to fail with any Java clients using versions of Java without a fix for the following issue: https://bugs.openjdk.java.net/browse/JDK-8236039
-    default: TLSv1.2
+    default: TLSv1.3
   router.dns_health_check_host:
       description: "Host to ping for confirmation of DNS resolution, only used when Routing API is enabled"
       default: "uaa.service.cf.internal"

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -234,11 +234,11 @@ enable_ssl: <%= p("router.enable_ssl") %>
 %>
 client_cert_validation: <%= client_cert_validation %>
 <%
-  allowed_min_tls_versions = ["TLSv1.0", "TLSv1.1", "TLSv1.2"]
+  allowed_min_tls_versions = ["TLSv1.0", "TLSv1.1", "TLSv1.2", "TLSv1.3"]
   min_tls_version = p("router.min_tls_version")
 
   if !allowed_min_tls_versions.include?(min_tls_version)
-    raise 'router.min_tls_version must be "TLSv1.0", "TLSv1.1", or "TLSv1.2"'
+    raise 'router.min_tls_version must be "TLSv1.0", "TLSv1.1", "TLSv1.2" or "TLSv1.3"'
   end
 %>
 min_tls_version: <%= p("router.min_tls_version") %>

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -79,7 +79,7 @@ describe 'gorouter' do
             }
           ],
           'min_tls_version' => 'TLSv1.2',
-          'max_tls_version' => 'TLSv1.2',
+          'max_tls_version' => 'TLSv1.3',
           'disable_http' => false,
           'ca_certs' => 'test-certs',
           'cipher_suites' => 'test-suites',
@@ -197,7 +197,7 @@ describe 'gorouter' do
             end
 
             it 'fails' do
-              expect { raise parsed_yaml }.to raise_error(RuntimeError, 'router.min_tls_version must be "TLSv1.0", "TLSv1.1", or "TLSv1.2"')
+              expect { raise parsed_yaml }.to raise_error(RuntimeError, 'router.min_tls_version must be "TLSv1.0", "TLSv1.1", "TLSv1.2" or "TLSv1.3"')
             end
           end
         end


### PR DESCRIPTION
- Setting default max tls version to 1.3
- Added 1.3 as a configurable min tls entry

Authored-by: Ramkumar Vengadakrishnan <ramkumarv@vmware.com>

<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change: Enabling TLS 1.3 support

* An explanation of the use cases your change solves: This PR expands support for TLS 1.3

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics) - Is OPS manager under "Networking" - > Minimum version of TLS supported by the Gorouter and **HAProxy** a new 1.3 option will show up. 

* Expected result after the change - Minimum TLS version will show 1.3 as an option and default max tls version will be set to 1.3

* Current result before the change - Currently the minimum TLS will not show version 1.3 as an option and default max tls version will be set to 1.2

* Links to any other associated PRs - https://github.com/cloudfoundry/gorouter/pull/286

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
