### PR TITLE
Enable TLS 1.3 support

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -106,7 +106,7 @@ properties:
     description: Disables the http listener on port specified by router.port. This cannot be set to true if enable_ssl is false.
     default: false
   router.min_tls_version:
-    description: Minimum accepted version of TLS protocol. All versions above this, up to the max_tls_version, will also be accepted. Valid values are TLSv1.0, TLSv1.1, and TLSv1.2.
+    description: Minimum accepted version of TLS protocol. All versions above this, up to the max_tls_version, will also be accepted. Valid values are TLSv1.0, TLSv1.1, TLSv1.2, and TLSv1.3.
     default: TLSv1.2
   router.max_tls_version:
     description: |

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -269,11 +269,11 @@ enable_ssl: <%= p("router.enable_ssl") %>
 %>
 client_cert_validation: <%= client_cert_validation %>
 <%
-  allowed_min_tls_versions = ["TLSv1.0", "TLSv1.1", "TLSv1.2"]
+  allowed_min_tls_versions = ["TLSv1.0", "TLSv1.1", "TLSv1.2", "TLSv1.3"]
   min_tls_version = p("router.min_tls_version")
 
   if !allowed_min_tls_versions.include?(min_tls_version)
-    raise 'router.min_tls_version must be "TLSv1.0", "TLSv1.1", or "TLSv1.2"'
+    raise 'router.min_tls_version must be "TLSv1.0", "TLSv1.1", "TLSv1.2" or "TLSv1.3"'
   end
 %>
 min_tls_version: <%= p("router.min_tls_version") %>

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -202,7 +202,7 @@ describe 'gorouter' do
             end
 
             it 'fails' do
-              expect { raise parsed_yaml }.to raise_error(RuntimeError, 'router.min_tls_version must be "TLSv1.0", "TLSv1.1", or "TLSv1.2"')
+              expect { raise parsed_yaml }.to raise_error(RuntimeError, 'router.min_tls_version must be "TLSv1.0", "TLSv1.1", "TLSv1.2" or "TLSv1.3"')
             end
           end
         end


### PR DESCRIPTION
 * Added 1.3 as one of the supported min tls version

 * A short explanation of the proposed change: Enabling TLS 1.3 support
 * An explanation of the use cases your change solves:  This PR expands support for TLS 1.3
 * Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics) - Is OPS manager under "Networking" - > Minimum version of TLS supported by the Gorouter and **HAProxy** a new 1.3 option will show up.
 * Expected result after the change - Minimum TLS version will show 1.3 as an option
 * Current result before the change - Currently the minimum TLS will not show version 1.3 as an option and default max tls version will be set to 1.2
 * Links to any other associated PRs - https://github.com/cloudfoundry/gorouter/pull/288 https://github.com/cloudfoundry-incubator/haproxy-boshrelease/pull/230
 * [x]  I have viewed signed and have submitted the Contributor License Agreement
 * [x]  I have made this pull request to the `main` branch
 * [x]  I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).
 * [ ]  (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite
 * [ ]  (Optional) I have run CF Acceptance Tests on bosh lite