### PR TITLE
make open files configurable

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -421,3 +421,7 @@ properties:
   router.send_http_start_stop_client_event:
     description: "Send a httpstartstopevent of type client for each request"
     default: true
+
+  router.max_open_files:
+    description: "The number of file descriptors a router can have open at one time"
+    default: 100000

--- a/jobs/gorouter/templates/bpm.yml.erb
+++ b/jobs/gorouter/templates/bpm.yml.erb
@@ -6,7 +6,7 @@ processes:
   - -c
   - /var/vcap/jobs/gorouter/config/gorouter.yml
   limits:
-    open_files: 100000
+    open_files: <%= p("router.max_open_files") %>
   env:
     GODEBUG: netdns=cgo,x509ignoreCN=0
   hooks:

--- a/jobs/gorouter/templates/pre-start.erb
+++ b/jobs/gorouter/templates/pre-start.erb
@@ -33,7 +33,7 @@ tee_output_to_sys_log "${LOG_DIR}" "pre-start" <%= p("router.logging.format.time
 <% end %>
 
 # Allowed number of open file descriptors
-ulimit -n 100000
+ulimit -n <%= p("router.max_open_files") %>
 
 # Add jq to path
 cp /var/vcap/jobs/gorouter/bin/setup-jq /etc/profile.d/jq.sh


### PR DESCRIPTION
* A short explanation of the proposed change:
We have seen cases with our gorouters with many open connections

* An explanation of the use cases your change solves
Because we configure a higher router.max_idle_connections, we need to increase the matching part on OS level, the maximum of open file handles

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
enablement to configure the hardcoded value

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
