### PR TITLE
Remove reliance on bosh link named 'nats'

### DIFF
--- a/jobs/route_registrar/templates/registrar_settings.json.erb
+++ b/jobs/route_registrar/templates/registrar_settings.json.erb
@@ -1,14 +1,19 @@
 <%=
   require 'json'
 
+  nats_link_name = 'nats'
+  if p('nats.tls.enabled')
+    nats_link_name = 'nats-tls'
+  end
+
   nats_machines = nil
   if_p('nats.machines') do |ips|
     nats_machines = ips.compact
   end.else do
-    link('nats').if_p("nats.hostname") do |hostname|
+    link(nats_link_name).if_p("nats.hostname") do |hostname|
       nats_machines = [hostname]
     end.else do
-      nats_machines = link('nats').instances.map { |instance| instance.address }
+      nats_machines = link(nats_link_name).instances.map { |instance| instance.address }
     end
   end
 
@@ -16,36 +21,21 @@
   if_p('nats.port') do |prop|
     nats_port = prop
   end.else do
-    nats_port = link('nats').p("nats.port")
+    nats_port = link(nats_link_name).p("nats.port")
   end
 
   nats_user = nil
   if_p('nats.user') do |prop|
     nats_user = prop
   end.else do
-    nats_user = link('nats').p("nats.user")
+    nats_user = link(nats_link_name).p("nats.user")
   end
 
   nats_password = nil
   if_p('nats.password') do |prop|
     nats_password = prop
   end.else do
-    nats_password = link('nats').p("nats.password")
-  end
-
-  if_link('nats-tls') do |nats_link|
-    if p('nats.tls.enabled')
-      nats_machines = nats_link.instances.map { |instance| instance.address }
-      nats_link.if_p("nats.hostname") do |hostname|
-        nats_machines = [hostname]
-      end
-      if_p("nats.tls.hostname") do | prop |
-        nats_machines = [prop]
-      end
-      nats_port = nats_link.p("nats.port")
-      nats_user = nats_link.p("nats.user")
-      nats_password = nats_link.p("nats.password")
-    end
+    nats_password = link(nats_link_name).p("nats.password")
   end
 
   message_bus_servers = nats_machines.map do |host|

--- a/spec/route_registar_templates_spec.rb
+++ b/spec/route_registar_templates_spec.rb
@@ -227,7 +227,7 @@ describe 'route_registrar' do
             name: 'nats',
             properties: {
               'nats' => {
-                'host' => 'nats-host', 'user' => 'nats-user', 'password' => 'nats-password', 'port' => 8080
+                'hostname' => 'nats-host', 'user' => 'nats-user', 'password' => 'nats-password', 'port' => 8080
               }
             },
             instances: [Bosh::Template::Test::LinkInstance.new(address: 'my-nats-ip')]
@@ -236,7 +236,7 @@ describe 'route_registrar' do
             name: 'nats-tls',
             properties: {
               'nats' => {
-                'host' => 'nats-tls-host', 'user' => 'nats-tls-user', 'password' => 'nats-tls-password', 'port' => 9090
+                'hostname' => 'nats-tls-host', 'user' => 'nats-tls-user', 'password' => 'nats-tls-password', 'port' => 9090
               }
             },
             instances: [Bosh::Template::Test::LinkInstance.new(address: 'my-nats-tls-ip')]
@@ -247,12 +247,11 @@ describe 'route_registrar' do
       context 'when mTLS is enabled for NATS' do
         it 'renders with the nats-tls properties' do
           merged_manifest_properties['nats'] = { 'tls' => { 'enabled' => true } }
-          merged_manifest_properties['nats']['tls']['hostname'] = 'my-nats-tls-hostname'
 
           rendered_hash = JSON.parse(template.render(merged_manifest_properties, consumes: links))
           expect(rendered_hash['nats_mtls_config']['enabled']).to be true
           expect(rendered_hash['message_bus_servers'].length).to eq(1)
-          expect(rendered_hash['message_bus_servers'][0]['host']).to eq('my-nats-tls-hostname:9090')
+          expect(rendered_hash['message_bus_servers'][0]['host']).to eq('nats-tls-host:9090')
           expect(rendered_hash['message_bus_servers'][0]['user']).to eq('nats-tls-user')
           expect(rendered_hash['message_bus_servers'][0]['password']).to eq('nats-tls-password')
         end
@@ -263,7 +262,7 @@ describe 'route_registrar' do
           rendered_hash = JSON.parse(template.render(merged_manifest_properties, consumes: links))
           expect(rendered_hash['nats_mtls_config']['enabled']).to be false
           expect(rendered_hash['message_bus_servers'].length).to eq(1)
-          expect(rendered_hash['message_bus_servers'][0]['host']).to eq('my-nats-ip:8080')
+          expect(rendered_hash['message_bus_servers'][0]['host']).to eq('nats-host:8080')
           expect(rendered_hash['message_bus_servers'][0]['user']).to eq('nats-user')
           expect(rendered_hash['message_bus_servers'][0]['password']).to eq('nats-password')
         end


### PR DESCRIPTION
In https://github.com/cloudfoundry/cf-deployment/issues/929 we plan to remove plaintext NATS, and enforce that everything uses TLS NATS. The easiest way to do this is to remove the `nats` BOSH link, and have only the `nats-tls` BOSH link.

This commit changes a file that required the `nats` BOSH link to exist. The file will now only use the `nats-tls` BOSH link if told to use TLS NATS.

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch
* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`
* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite
* [ ] (Optional) I have run CF Acceptance Tests on bosh lite