### PR TITLE
Enable HTTP/2 by default

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -106,7 +106,7 @@ properties:
     description: Disables the http listener on port specified by router.port. This cannot be set to true if enable_ssl is false.
     default: false
   router.enable_http2:
-    description: Enables the HTTP/2 protocol for communicating with apps.
+    description: Enables support for HTTP/2 ingress traffic to the Gorouter. Also enables the option to use the HTTP/2 protocol for traffic to specified backends.
     default: true
   router.min_tls_version:
     description: Minimum accepted version of TLS protocol. All versions above this, up to the max_tls_version, will also be accepted. Valid values are TLSv1.0, TLSv1.1, TLSv1.2, and TLSv1.3.

--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -106,8 +106,8 @@ properties:
     description: Disables the http listener on port specified by router.port. This cannot be set to true if enable_ssl is false.
     default: false
   router.enable_http2:
-    description: Enables the HTTP/2 protocol for communicating with apps. Currently in beta, use at your own risk. Will default to true when the feature exits beta.
-    default: false
+    description: Enables the HTTP/2 protocol for communicating with apps.
+    default: true
   router.min_tls_version:
     description: Minimum accepted version of TLS protocol. All versions above this, up to the max_tls_version, will also be accepted. Valid values are TLSv1.0, TLSv1.1, TLSv1.2, and TLSv1.3.
     default: TLSv1.2


### PR DESCRIPTION
`router.enable_http2` will be true by default and is no longer described as a beta feature.

* Links to any other associated PRs
cloudfoundry/gorouter#292

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
