### PR TITLE
Fix up removing reliance on bosh link named NATS

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -53,8 +53,6 @@ properties:
     description: "PEM-encoded certificate for the route-emitter to present to NATS for verification when connecting via TLS."
   nats.tls.client_key:
     description: "PEM-encoded private key for the route-emitter to present to NATS for verification when connecting via TLS."
-  nats.tls.hostname:
-    description: "Hostname of the NATS cluster."
 
   host:
     description: (string, optional) By default, route_registrar will detect the IP of the VM and use it, in combination with port as the backend destination for each uri being registered. This property enables overriding the destination hostname or IP.

--- a/spec/route_registar_templates_spec.rb
+++ b/spec/route_registar_templates_spec.rb
@@ -203,7 +203,7 @@ describe 'route_registrar' do
           name: 'nats',
           properties: {
             'nats' => {
-              'host' => 'nats-host', 'user' => 'nats-user', 'password' => 'nats-password', 'port' => 8080
+              'hostname' => 'nats-host', 'user' => 'nats-user', 'password' => 'nats-password', 'port' => 8080
             }
           },
           instances: [Bosh::Template::Test::LinkInstance.new(address: 'my-nats-address')]
@@ -214,7 +214,7 @@ describe 'route_registrar' do
     describe 'nats properties' do
       it 'renders with the default' do
         rendered_hash = JSON.parse(template.render(merged_manifest_properties, consumes: links))
-        expect(rendered_hash['message_bus_servers'][0]['host']).to eq('my-nats-address:8080')
+        expect(rendered_hash['message_bus_servers'][0]['host']).to eq('nats-host:8080')
         expect(rendered_hash['message_bus_servers'][0]['user']).to eq('nats-user')
         expect(rendered_hash['message_bus_servers'][0]['password']).to eq('nats-password')
       end
@@ -285,7 +285,7 @@ describe 'route_registrar' do
               name: 'nats',
               properties: {
                 'nats' => {
-                  'host' => '', 'user' => '', 'password' => '', 'port' => 8080
+                  'hostname' => '', 'user' => '', 'password' => '', 'port' => 8080
                 }
               }
             )
@@ -318,7 +318,7 @@ describe 'route_registrar' do
         rendered_hash = JSON.parse(template.render(merged_manifest_properties, consumes: links))
         expect(rendered_hash).to eq(
           'host' => '192.168.0.0',
-          'message_bus_servers' => [{ 'host' => 'my-nats-address:8080', 'password' => 'nats-password', 'user' => 'nats-user' }],
+          'message_bus_servers' => [{ 'host' => 'nats-host:8080', 'password' => 'nats-password', 'user' => 'nats-user' }],
           'routes' => [
             {
               'health_check' => { 'name' => 'uaa-healthcheck', 'script_path' => '/var/vcap/jobs/uaa/bin/health_check' },


### PR DESCRIPTION
* Context: this provides some changes minor requested in a [comment](https://github.com/cloudfoundry/routing-release/pull/214#issuecomment-896388136) by @acrmp

* A short explanation of the proposed change: this removes the deprecated `nats.tls.hostname` property, and fixes a misnamed field in a test

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
