### PR TITLE
enable http2 cats

### DIFF
--- a/ci/tasks/create-integration-configs/task
+++ b/ci/tasks/create-integration-configs/task
@@ -40,34 +40,35 @@ RATS_INTEGRATION_CONFIG='created-integration-configs/rats_integration_config.jso
 echo "Creating ${CATS_INTEGRATION_CONFIG}"
 cat > "${CATS_INTEGRATION_CONFIG}" <<EOF
 {
-  "api": "api.${SYSTEM_DOMAIN}",
-  "admin_user": "admin",
   "admin_password": "PROGRAMMATICALLY REPLACED",
+  "admin_user": "admin",
+  "api": "api.${SYSTEM_DOMAIN}",
   "apps_domain": "${SYSTEM_DOMAIN}",
   "artifacts_directory": "logs",
-  "skip_ssl_validation": true,
-  "use_http": true,
-  "timeout_scale": 2,
   "backend": "diego",
   "include_apps": true,
   "include_backend_compatibility": false,
   "include_detect": true,
   "include_docker": false,
-  "include_ssh": false,
+  "include_http2_routing": true,
   "include_internet_dependent": true,
-  "include_privileged_container_support": false,
   "include_isolation_segments": ${ENABLE_ISOLATION_SEGMENT_TESTS},
-  "include_tcp_isolation_segments": ${ENABLE_ISOLATION_SEGMENT_TESTS},
-  "isolation_segment_name": "${ISO_SEG_NAME}",
+  "include_privileged_container_support": false,
   "include_route_services": true,
   "include_routing": true,
   "include_security_groups": true,
   "include_services": true,
+  "include_ssh": false,
   "include_sso": false,
   "include_tasks": false,
+  "include_tcp_isolation_segments": ${ENABLE_ISOLATION_SEGMENT_TESTS},
   "include_v3": false,
   "include_zipkin": true,
-  "stacks": ["cflinuxfs3"]
+  "isolation_segment_name": "${ISO_SEG_NAME}",
+  "skip_ssl_validation": true,
+  "stacks": ["cflinuxfs3"],
+  "timeout_scale": 2,
+  "use_http": true
 }
 EOF
 


### PR DESCRIPTION
- added the flag to turn on http2 cats in the routing pipeline
- sorted the keys to leave the file better than we found it

Signed-off-by: Michael Oleske <moleske@vmware.com>

<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

Turn on the property that enables h2 cats

* An explanation of the use cases your change solves

We want to run the h2 cats in CI now that h2 is going to be generally available and is on by default.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

Look at the cats output and see that the h2 tests are running.

* Expected result after the change

They will be running

* Current result before the change

They won't be running

* Links to any other associated PRs

https://github.com/cloudfoundry/routing-release/issues/200

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
