### PR TITLE
Fail on cert without san

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -429,4 +429,4 @@ properties:
 
   golang.x509ignoreCN:
     description: "Environment Flag to temporarily ignore golang's strict checking for at least one SAN in a TLS certificate. See: https://github.com/cloudfoundry/routing-release/blob/develop/docs/golang1.15-remove-x509ignoreCN%3D0-flag-certificates-now-require-SANs.md for more info."
-    default: true
+    default: false

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -268,7 +268,18 @@ if p('router.enable_ssl')
     if !cert_pair.is_a?(Hash) || !cert_pair.key?('cert_chain') || !cert_pair.key?('private_key')
       raise 'must provide cert_chain and private_key with tls_pem'
     end
+
+    cert = OpenSSL::X509::Certificate.new cert_pair['cert_chain']
+    has_san = cert.extensions.map { |ext|
+      x509ext = OpenSSL::X509::Extension.new ext
+      x509ext.oid == "2.5.29.17" # https://oidref.com/2.5.29.17
+    }.reduce(:|)
+
+    if ! p('golang.x509ignoreCN') and ! has_san
+      raise 'tls_pem must include a SAN entry'
+    end
   }
+
   params['tls_pem'] = p('router.tls_pem')
 
   allowed_client_cert_validations = ["none", "request", "require"]


### PR DESCRIPTION
Updates the gorouter template to fail when rendering, if a cert provided in the`router.tls_pem` list does not contain a SAN. As of golang 1.17, this will be a requirement, so adding these warnings to allow people to be aware of the issue. After encountering it, you can set `golang.x509ignoreCN` to avoid the error, until such a time as you get your cert upgraded, but this stopgap will cease to work after gorouter is built against golang 1.17.