### PR TITLE
Add tls_handshake_timeout paramter to override the default 10 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ rubocop ./spec/
 
 If you do not have `rspec` or `rubocop` installed locally, run
 `./scripts/start-docker-for-testing.sh` and execute the commands in the docker
-container.
+container. Prepend "sudo" to he script if you are an unpreviledged user.
+
 
 
 #### <a name="running-unit-and-integration-tests"></a> Running Unit and Integration Tests
@@ -121,7 +122,7 @@ container.
   runs unit *and* integration tests, that's why they need to run in a container.
 
   ```bash
-  ./scripts/run-unit-tests-in-docker
+  ./scripts/run-unit-tests-in-docker #sudo for unpreviledged users
   ```
 
 * If you'd like to run a specific component's tests in a Docker container,

--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -344,6 +344,12 @@ properties:
       and `router.keep_alive_probe_interval`.
     default: 900
 
+  tls_handshake_timeout_in_seconds:
+    description: |
+      Maximum time in seconds for gorouter to establish a TLS connection with a backend container. This timeout is for establishing
+      the TLS connection only. Actual HTTP request timeout is defined by `router.request_timeout_in_seconds`.
+    default: 10
+
   metron.port:
     description: "The port used to emit dropsonde messages to the Metron agent."
     default: 3457

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -45,6 +45,7 @@ params = {
   'drain_timeout' => "#{p('router.drain_timeout')}s",
   'healthcheck_user_agent' => p('router.healthcheck_user_agent'),
   'endpoint_timeout' => "#{p('request_timeout_in_seconds')}s",
+  'tls_handshake_timeout' => "#{p('tls_handshake_timeout_in_seconds')}s",
   'start_response_delay_interval' => "#{p('router.requested_route_registration_interval_in_seconds')}s",
   'load_balancer_healthy_threshold' => "#{p('router.load_balancer_healthy_threshold')}s",
   'balancing_algorithm' => p('router.balancing_algorithm'),


### PR DESCRIPTION
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:
 Add tls_handshake_timeout so it can be configured

* An explanation of the use cases your change solves: 
When the diego_cells go through vSphere vMotion, there is a stun time (like the VM is frozen). When that happens, new gorouter connections to the diego_cell will timeout after 10 seconds. The parameter will allow us to shorten the timeout, so gorouter would attempt another diego_cell, mitigating the long wait (or 499 errors) on the clients.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
Inspect /var/vcap/jobs/gorouter/config/gorouter.yml. When the parameter is not provided, it should say "tls_handshake_timeout: 10s"; or whatever value is provided by the operator.

* Expected result after the change
Gorouter clients see faster response time during vMotion, or fewer 499 erros

* Current result before the change
Gorouter clients experience timeouts.

* Links to any other associated PRs
N/A

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
