### PR TITLE
Accommodate GCC 10 Changes

### DIFF
--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -2,7 +2,8 @@ set -ex
 
 tar xzf haproxy/haproxy-*.tar.gz
 cd haproxy-*
-make TARGET=linux2628 USE_OPENSSL=1
+# gcc 10+ changed the default to "-fno-common"; we change it back to build properly
+make TARGET=linux2628 USE_OPENSSL=1 TARGET_CFLAGS=-fcommon
 mkdir ${BOSH_INSTALL_TARGET}/bin
 cp haproxy ${BOSH_INSTALL_TARGET}/bin/
 chmod 755 ${BOSH_INSTALL_TARGET}/bin/haproxy


### PR DESCRIPTION
The newer GCC compiler (10+) has tightened its requirements, throwing errors that were previously ignored. Newer stemcells, e.g. the upcoming Ubuntu 22.04 Jammy Jellyfish, include the newer GCC.

This change will allow the routing release to build on newer stemcells.

From _[Porting to GCC 10](https://gcc.gnu.org/gcc-10/porting_to.html)_

> Default to -fno-common ... In previous GCC versions this error is ignored. GCC 10 defaults to -fno-common, which means a linker error will now be reported

fixes:
```
/bin/ld: src/protocol.o:/var/vcap/data/compile/haproxy/haproxy-1.8.13/include/common/chunk.h:39: multiple definition of `pool_head_trash'; src/ev_poll.o:/var/vcap/data/compile/haproxy/haproxy-1.8.13/include/common/chunk.h:39: first defined here
collect2: error: ld returned 1 exit status
```

Signed-off-by: Brian Cunnie <bcunnie@vmware.com>
Signed-off-by: Daniel Felipe Ochoa <danielfelipo@vmware.com>
Signed-off-by: Ramon Makkelie <ramonmakkelie@gmail.com>

<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

This change allows the routing release to be compiled with versions of GCC >= 10.

We have tested this change on beta Jammy Jellyfish stemcells, as well as regression tests on Bionic and Xenial stemcells.

* An explanation of the use cases your change solves

This allows the routing release to be compiled on newer stemcells such as the upcoming Jammy Jellyfish stemcell.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

There's no behavior change other than successfully compiling on newer stemcells (Impish, Jammy).

* Expected result after the change

There's no change for existing Xenial & Bionic stemcells.

* Current result before the change

* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` (in progress)

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
