### PR TITLE
Only use passwd auth if NATS requires it

### DIFF
--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -1,13 +1,18 @@
 ---
 <%=
-def property_or_link(description, property, link_path, link_name=nil)
+def property_or_link(description, property, link_path, link_name=nil, optional=false)
   link_name ||= link_path.split('.').first
   if_p(property) do |prop|
     return prop
   end.else do
     if_link(link_name) do |link_object|
-      return link_object.p(link_path)
+      link_object.if_p(link_path) do |prop|
+        return prop
+      end
     end
+  end
+  if optional
+    return nil
   end
   raise RuntimeError, "#{description} not found in properties nor in \"#{link_name}\" link. This value can be specified using the \"#{property}\" property."
 end
@@ -128,18 +133,26 @@ end.else do
 end
 nats['hosts'] = nats_machines.map { |hostname| {'hostname' => hostname, 'port' => nats_port} }
 
-nats['user'] = property_or_link(
+nats_user = property_or_link(
   'NATS server username',
   'nats.user',
   "nats.user",
   link_name=nats_link_name,
+  optional=true,
 )
-nats['pass'] = property_or_link(
+if nats_user
+  nats['user'] = nats_user
+end
+nats_pass = property_or_link(
   'NATS server username',
   'nats.password',
   "nats.password",
   link_name=nats_link_name,
+  optional=true,
 )
+if nats_pass
+  nats['pass'] = nats_pass
+end
 
 params['nats'] = nats
 

--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -50,9 +50,9 @@ properties:
     description: Enable connecting to NATS server via TLS.
     default: false
   nats.tls.client_cert:
-    description: "PEM-encoded certificate for the route-emitter to present to NATS for verification when connecting via TLS."
+    description: "PEM-encoded certificate for the route-registrar to present to NATS for verification when connecting via TLS."
   nats.tls.client_key:
-    description: "PEM-encoded private key for the route-emitter to present to NATS for verification when connecting via TLS."
+    description: "PEM-encoded private key for the route-registrar to present to NATS for verification when connecting via TLS."
 
   host:
     description: (string, optional) By default, route_registrar will detect the IP of the VM and use it, in combination with port as the backend destination for each uri being registered. This property enables overriding the destination hostname or IP.

--- a/jobs/route_registrar/templates/registrar_settings.json.erb
+++ b/jobs/route_registrar/templates/registrar_settings.json.erb
@@ -28,22 +28,35 @@
   if_p('nats.user') do |prop|
     nats_user = prop
   end.else_if_link(nats_link_name) do |nats_link|
-    nats_user = nats_link.p("nats.user")
+    nats_link.if_p("nats.user") do |prop|
+      nats_user = prop
+    end
   end
 
   nats_password = nil
   if_p('nats.password') do |prop|
     nats_password = prop
   end.else_if_link(nats_link_name) do |nats_link|
-    nats_password = nats_link.p("nats.password")
+    nats_link.if_p("nats.password") do |prop|
+      nats_password = prop
+    end
   end
 
-  message_bus_servers = nats_machines.map do |host|
-    {
-      host: "#{host}:#{nats_port}",
-      user: "#{nats_user}",
-      password: "#{nats_password}"
-    }
+  message_bus_servers = nil
+  if nats_user and nats_password
+    message_bus_servers = nats_machines.map do |host|
+      {
+        host: "#{host}:#{nats_port}",
+        user: "#{nats_user}",
+        password: "#{nats_password}"
+      }
+    end
+  else
+    message_bus_servers = nats_machines.map do |host|
+      {
+        host: "#{host}:#{nats_port}"
+      }
+    end
   end
 
   routes = p('route_registrar.routes')

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -509,7 +509,7 @@ describe 'gorouter' do
         end
       end
 
-      context 'certficate authorities' do
+      context 'certificate authorities' do
         context 'client_ca_certs' do
           context 'are not provided' do
             before do
@@ -610,7 +610,7 @@ describe 'gorouter' do
             before do
               deployment_manifest_fragment['router']['ca_certs'] = test_certs
             end
-            it 'suceessfully configures the property' do
+            it 'successfully configures the property' do
               expect(parsed_yaml['ca_certs']).to eq(test_certs)
             end
           end
@@ -763,6 +763,33 @@ describe 'gorouter' do
             link_namespace: 'nats-tls',
             parsed_yaml_property: 'nats.hosts.0.port'
           )
+        end
+
+        describe 'optional authentication' do
+          let(:nats) { parsed_yaml['nats'] }
+
+          context 'when username and password are provided' do
+            before do
+              deployment_manifest_fragment['nats']['user'] = 'nats'
+              deployment_manifest_fragment['nats']['password'] = 'stan'
+            end
+
+            it 'contains auth information' do
+              expect(nats['user']).to eq('nats')
+              expect(nats['pass']).to eq('stan')
+            end
+          end
+          context 'when username and password are not provided' do
+            before do
+              deployment_manifest_fragment['nats']['user'] = nil
+              deployment_manifest_fragment['nats']['password'] = nil
+            end
+
+            it 'omits auth information' do
+              expect(nats['user']).to be_nil
+              expect(nats['pass']).to be_nil
+            end
+          end
         end
 
         describe 'ca_certs' do


### PR DESCRIPTION
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:
This is a companion PR to https://github.com/cloudfoundry/nats-release/pull/39

With the introduction of nats-tls the use of password authentication is no longer needed. Instead we can rely on mTLS for trust. Therefore, I've made a change to nats-tls that makes `nats.user` and `nats.password` optional which allows to decide on NATS side whether or not a password authentication is required.

This PR changes gorouter and route-registrar so that they read the `nats.user` and `nats.password` properties optionally via BOSH link to decide if the password should be used when talking to NATS. Using this mechanism allows to control the password usage at one central place in the NATS release and no further config change is required for NATS clients.

* An explanation of the use cases your change solves

This change allows to discard password authentication with NATS-tls in favor of mTLS authentication. One less password to worry about.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

1. Merge https://github.com/cloudfoundry/nats-release/pull/39
2. Merge this PR
3. In the cf-deployment manifest, you can now optionally remove `nats.user` and `nats.password` properties at the `nats-tls` job
4. Deploy

* Expected result after the change
Gorouter config.yml change

```
nats:
  tls_enabled: true
  ca_certs: |
    -----BEGIN CERTIFICATE-----
(...)
    -----END CERTIFICATE-----
  cert_chain: |
    -----BEGIN CERTIFICATE-----
(...)
    -----END CERTIFICATE-----
  private_key: |
    -----BEGIN RSA PRIVATE KEY-----
(...)
    -----END RSA PRIVATE KEY-----
  hosts:
  - hostname: nats.service.cf.internal
    port: 4224
```
(so the user and pass props are gone)

Route-Registrar registrar_setting.yml change

```
  "message_bus_servers": [
    {
      "host": "nats.service.cf.internal:4224"
    }
  ],
  "nats_mtls_config": {
    "enabled": true,
    "cert_path": "/var/vcap/jobs/route_registrar/config/nats/certs/client.crt",
    "key_path": "/var/vcap/jobs/route_registrar/config/nats/certs/client_private.key",
    "ca_path": "/var/vcap/jobs/route_registrar/config/nats/certs/server_ca.crt"
  },

```
(so user and password props are gone)

* Current result before the change
Gorouter config.yml 

```
nats:
  tls_enabled: true
  ca_certs: |
    -----BEGIN CERTIFICATE-----
(...)
    -----END CERTIFICATE-----
  cert_chain: |
    -----BEGIN CERTIFICATE-----
(...)
    -----END CERTIFICATE-----
  private_key: |
    -----BEGIN RSA PRIVATE KEY-----
(...)
    -----END RSA PRIVATE KEY-----
  hosts:
  - hostname: nats.service.cf.internal
    port: 4224
  user: nats
  pass: super-secure-pwd
```

Route-Registrar registrar_setting.yml change

```
  "message_bus_servers": [
    {
      "host": "nats.service.cf.internal:4224"
      "user": "nats",
      "password": "super-secure-pwd"
    }
  ],
  "nats_mtls_config": {
    "enabled": true,
    "cert_path": "/var/vcap/jobs/route_registrar/config/nats/certs/client.crt",
    "key_path": "/var/vcap/jobs/route_registrar/config/nats/certs/client_private.key",
    "ca_path": "/var/vcap/jobs/route_registrar/config/nats/certs/server_ca.crt"
  },

```

* Links to any other associated PRs
https://github.com/cloudfoundry/nats-release/pull/39

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
