### PR TITLE
Fixes tcp_router haproxy_reloader

### DIFF
--- a/jobs/tcp_router/templates/haproxy_reloader
+++ b/jobs/tcp_router/templates/haproxy_reloader
@@ -2,8 +2,10 @@
 
 set -e
 
-PATH=/var/vcap/packages/tcp_router/bin:$PATH
-DAEMON=$(which haproxy)
+LOGFILE="/var/vcap/sys/log/tcp_router/haproxy_reloader.log"
+
+PATH="/var/vcap/packages/tcp_router/bin:/var/vcap/packages/haproxy/bin:$PATH"
+DAEMON="$(which haproxy)"
 CONFIG=/var/vcap/data/tcp_router/config/haproxy.conf
 HAPROXY_PID_FILE=/var/vcap/data/tcp_router/config/haproxy.pid
 HAPROXY_SOCKET_FILE=/var/vcap/data/tcp_router/config/haproxy.sock
@@ -11,4 +13,8 @@ HAPROXY_SOCKET_FILE=/var/vcap/data/tcp_router/config/haproxy.sock
 test -x "${DAEMON}"
 test -f "${CONFIG}"
 
-"${DAEMON}" -f "${CONFIG}" -p "${HAPROXY_PID_FILE}" -x "${HAPROXY_SOCKET_FILE}" -D -sf $(cat $HAPROXY_PID_FILE) 0<&-
+echo "$(date --rfc-3339=ns) starting haproxy_reloader" >> "${LOGFILE}"
+
+"${DAEMON}" -f "${CONFIG}" -p "${HAPROXY_PID_FILE}" -x "${HAPROXY_SOCKET_FILE}" -D -sf "$(cat ${HAPROXY_PID_FILE})" 0<&- &>> "${LOGFILE}"
+
+echo "$(date --rfc-3339=ns) done" >> "${LOGFILE}"


### PR DESCRIPTION
## A short explanation of the proposed change

When `cf-tcp-router` attempted to use `haproxy_reloader` to reload `haproxy`, the script itself would fail because the `haproxy` binary is not in the path.

This fixes the path and adds some logging.

## Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

```bash
cf push tcp-potato --no-route --manifest "${HOME}/workspace/cf-acceptance-tests/assets/tcp-listener" --path "${HOME}/workspace/cf-acceptance-tests/assets/tcp-listener"
env_name=something
cf create-shared-domain tcp.$env_name.cf-app.com --router-group default-tcp
cf map-route tcp-potato tcp.$env_name.cf-app.com
```

watch it
```bash
env_name=lawngreen
nc_port=1031
watch -n1 "echo 'kittens' | nc -N tcp.$env_name.cf-app.com $nc_port"
```
```bash
cf logs tcp-potato
```

### Current result before the change
If I kill `haproxy`, the tcp router never comes back up and I can not access my tcp apps.

### Expected result after the change
- `haproxy` is monitored and restarts after being killed.
- I am able to create new tcp routes without issue


## Links
[#177371112](https://www.pivotaltracker.com/story/show/177371112)
