### PR TITLE
Add endpoint_dial_timeout_in_seconds to spec

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -346,7 +346,7 @@ properties:
   endpoint_dial_timeout_in_seconds:
     description: |
       Maximum time in seconds for gorouter to establish a TCP connection with a backend. This timeout comes before `tls_handshake_timeout_in_seconds`
-      and `request_timeout_in_seconds`.
+      and `request_timeout_in_seconds`. This timeout also applies as a read timeout for websocket requests.
     default: 5
   tls_handshake_timeout_in_seconds:
     description: |

--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -343,7 +343,11 @@ properties:
       are idle for longer than this duration will be closed. Related properties: `router.max_idle_connections`
       and `router.keep_alive_probe_interval`.
     default: 900
-
+  endpoint_dial_timeout_in_seconds:
+    description: |
+      Maximum time in seconds for gorouter to establish a TCP connection with a backend. This timeout comes before `tls_handshake_timeout_in_seconds`
+      and `request_timeout_in_seconds`.
+    default: 5
   tls_handshake_timeout_in_seconds:
     description: |
       Maximum time in seconds for gorouter to establish a TLS connection with a backend container. This timeout is for establishing

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -50,6 +50,7 @@ params = {
   'drain_timeout' => "#{p('router.drain_timeout')}s",
   'healthcheck_user_agent' => p('router.healthcheck_user_agent'),
   'endpoint_timeout' => "#{p('request_timeout_in_seconds')}s",
+  'endpoint_dial_timeout' => "#{p('endpoint_dial_timeout_in_seconds')}s",
   'tls_handshake_timeout' => "#{p('tls_handshake_timeout_in_seconds')}s",
   'start_response_delay_interval' => "#{p('router.requested_route_registration_interval_in_seconds')}s",
   'load_balancer_healthy_threshold' => "#{p('router.load_balancer_healthy_threshold')}s",

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -189,6 +189,8 @@ describe 'gorouter' do
         },
         'golang' => {},
         'request_timeout_in_seconds' => 100,
+        'endpoint_dial_timeout_in_seconds' => 6,
+        'tls_handshake_timeout_in_seconds' => 9,
         'routing_api' => {
           'enabled' => false,
           'port' => '23423',
@@ -436,6 +438,14 @@ describe 'gorouter' do
         it 'should configure properly' do
           expect(parsed_yaml['drain_wait']).to eq('10s')
           expect(parsed_yaml['drain_timeout']).to eq('300s')
+        end
+      end
+
+      describe 'connection and request timeouts' do
+        it 'should configure properly' do
+          expect(parsed_yaml['endpoint_dial_timeout']).to eq('6s')
+          expect(parsed_yaml['tls_handshake_timeout']).to eq('9s')
+          expect(parsed_yaml['endpoint_timeout']).to eq('100s')
         end
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:
Add spec to make EndpointDialTimeout configurable. It is currently hard-coded at 5s.

* An explanation of the use cases your change solves
Some of our customers have apps that need to restart frequently and have thousands of clients connected. After the restart all those clients try to reconnect at once which temporarily puts the app under pressure such that the underlying OS can't keep up with accepting connections quick enough to not hit the 5s timeout. Being able to increase the timeout gives the app more time to eventually accept all connections without disruption clients with a 502.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
1. Merge companion PR in [gorouter](https://github.com/cloudfoundry/gorouter/pull/302)
2. The BOSH manifest now allows to set an `endpoint_dial_timeout_in_seconds` property which defaults to 5 as before
```
(...)
  jobs:
  - name: gorouter
    properties:
      endpoint_dial_timeout_in_seconds: 10    <--- set to 10s in this example
      (...)
```
3. Deploy routing-release with new dial timeout

* Expected result after the change
dial timeout is now configurable but remains at 5s by default

* Current result before the change
dial timeout is hard-coded at 5s

* Links to any other associated PRs
https://github.com/cloudfoundry/gorouter/pull/302

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
