### PR TITLE
Seeded router group should not cause breaking change by default

### DIFF
--- a/jobs/routing-api/spec
+++ b/jobs/routing-api/spec
@@ -51,6 +51,11 @@ provides:
   - routing_api.sqldb
   - release_level_backup
 
+consumes:
+  - name: tcp_router
+    type: tcp-router
+    optional: true
+
 properties:
   routing_api.max_ttl:
     description: "String representing the maximum TTL a client can request for route registration."
@@ -181,6 +186,9 @@ properties:
       Users will not be able to create router_groups with ports that overlap
       with this value. Please see docs for more information about these ports.
     default: [2822,2825,3457,3458,3459,3460,3461,8853,9100,14726,14727,14821,14822,14823,14824,14829,14830,14920,14922,15821,17002,53035,53080]
+
+  routing_api.fail_on_router_port_conflicts:
+    description: "This should come via a bosh link from the tcp_routing job. This property is here in case it needs to be overwritten."
 
   routing_api.lock_ttl:
     description: "TTL for service lock"

--- a/jobs/routing-api/templates/routing-api.yml.erb
+++ b/jobs/routing-api/templates/routing-api.yml.erb
@@ -26,12 +26,27 @@ def parse_ip (ip, var_name)
   end
 end
 
+def fail_on_router_port_conflicts
+  if_p('routing_api.fail_on_router_port_conflicts') do |prop|
+    return prop
+  end.else do
+    if_link('tcp_router') do |link|
+      link.if_p('tcp_router.fail_on_router_port_conflicts') do |prop|
+        return prop
+      end
+    end
+  end
+
+  return 'false' # There is a default on the tcp_router property. This should only happen when tcp_router is not deployed.
+end
+
 parse_ip(p('routing_api.debug_address'), 'routing_api.debug_address')
 -%>
 debug_address: <%= p("routing_api.debug_address") %>
 statsd_client_flush_interval: <%= p("routing_api.statsd_client_flush_interval") %>
 router_groups: <%= p("routing_api.router_groups").to_yaml.gsub("---","") %>
 reserved_system_component_ports: <%= p("routing_api.reserved_system_component_ports").map(&:to_i) %>
+fail_on_router_port_conflicts: <%= fail_on_router_port_conflicts %>
 uuid: <%= spec.id %>
 admin_port: <%= p("routing_api.admin_port") %>
 

--- a/jobs/tcp_router/spec
+++ b/jobs/tcp_router/spec
@@ -22,6 +22,8 @@ packages:
 provides:
   - name: tcp_router
     type: tcp-router
+    properties:
+    - tcp_router.fail_on_router_port_conflicts
 
 consumes:
   - name: routing_api

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -187,7 +187,7 @@ describe 'gorouter' do
           'per_request_metrics_reporting' => true,
           'send_http_start_stop_server_event' => true,
           'send_http_start_stop_client_event' => true,
-          'per_app_prometheus_http_metrics_reporting' => false,
+          'per_app_prometheus_http_metrics_reporting' => false
         },
         'golang' => {},
         'request_timeout_in_seconds' => 100,
@@ -470,14 +470,14 @@ describe 'gorouter' do
         context 'when prometheus is configured' do
           before do
             deployment_manifest_fragment['router']['per_app_prometheus_http_metrics_reporting'] = true
-            deployment_manifest_fragment['router']['prometheus'] = {'port' => 9090 }
+            deployment_manifest_fragment['router']['prometheus'] = { 'port' => 9090 }
           end
           it 'should set prometheus configuration' do
             expect(parsed_yaml['per_app_prometheus_http_metrics_reporting']).to be true
             expect(parsed_yaml['prometheus']['port']).to eq(9090)
-            expect(parsed_yaml['prometheus']['cert_path']).to eq("/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.crt")
-            expect(parsed_yaml['prometheus']['key_path']).to eq("/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.key")
-            expect(parsed_yaml['prometheus']['ca_path']).to eq("/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus_ca.crt")
+            expect(parsed_yaml['prometheus']['cert_path']).to eq('/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.crt')
+            expect(parsed_yaml['prometheus']['key_path']).to eq('/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.key')
+            expect(parsed_yaml['prometheus']['ca_path']).to eq('/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus_ca.crt')
           end
         end
         context 'when per app metrics is configured but prometheus port is not' do
@@ -1060,7 +1060,7 @@ describe 'gorouter' do
   end
 
   describe 'prom_scraper_config.yml' do
-    let(:deployment_manifest_fragment) { Hash.new }
+    let(:deployment_manifest_fragment) { {} }
     let(:template) { job.template('config/prom_scraper_config.yml') }
     let(:rendered_template) { template.render(deployment_manifest_fragment) }
     subject(:parsed_yaml) { YAML.safe_load(rendered_template) }


### PR DESCRIPTION
### Context

In [routing release 0.214.0 ](https://github.com/cloudfoundry/routing-release/releases/tag/0.214.0) we added a bug fix to prevent tcp route ports from overlapping with system component route ports. We enabled this in two stages, (1) warning stage: every time the tcp_router is started it will log warnings for all invalid router groups and (2) error stage: every time the tcp_router is started it will error if there are invalid router groups.

In both stages we made it so that all new router groups and router group updates MUST use valid ports that don't overlap with system component ports. 

See more docs on this [here](https://github.com/cloudfoundry/routing-release/blob/develop/docs/tcp-router-port-conflict-known-issue.md).

### Bug

We did not take into account [the seeded router group](https://github.com/cloudfoundry/routing-release/blob/03ccfeccae197cd673d3cd2a3e79940b41fdf980/jobs/routing-api/spec#L170-L176) that is a routing-api bosh property. This router group is only seeded on the VERY first deploy of CF. Regardless, the current routing-api will error if this bosh property contains ports that overlap with system component ports. This results in the following errors:

bosh deploy error
```
 L Error: 'api/34e428ea-e81c-4ec9-897d-33a14eb5da07 (0)' is not running after update. Review logs for failed jobs: routing-api
```

routing-api log line
```
`{"timestamp":"1645813359.014326334","source":"routing-api","message":"routing-api.failed-load-config","log_level":2,"data":{"error":"Invalid ports. Reservable ports must not include the following reserved system component ports: [2822 2825 3457 3458 3459 3460 3461 8853 9100 14726 14727 14821 14822 14823 14824 14829 14830 14920 14922 15821 17002 53035 53080]."}}`
```

### Reproduction Steps

1. Use routing release 0.214.0 to 0.229.0
2. Set the `routing-api.router_groups` property as shown below to include ports that overlap with system component ports.
```
  - name: routing-api
    properties:
      routing_api:
        router_groups:
        - name: default-tcp
          reservable_ports: 1024-10000
          type: tcp
```
3. Deploy

#### What happens
The deploy fails because of the `routing-api` job.

#### What should happen
The deploy should succeed.


### The change

This PR adds a new bosh property called `routing-api.fail_on_router_port_conflicts`. This property is pulled in via a bosh link from the property `tcp_router.fail_on_router_port_conflicts`. This way the tcp-router and the routing-api will either fail or not in unison.

Currently we are in the "warning" phase, so `fail_on_router_port_conflicts` defaults to false.


| Router groups defined in `routing-api.router_groups` are valid?  |  Is it the first deploy? |  `fail_on_router_port_conflicts` |  Deploy Result |  Explanation | 
|---|---|---|---|---|
| yes  | yes  | true or false  | success | The router group is created. Nothing fails.  |
| yes  | no  | true or false |  success | Nothing will fail. It is not the first deploy, so the router group is not created. It might already exist from the first deploy, or it might not. |
| no  |  yes  |  true |  failure | The routing-api will try to create the router group because it is the first deploy. The deploy will fail because the ports are invalid and the `fail_on_router_port_conflicts` is set to true.  |
|  no  |  no  | true  |  failure | The routing-api will not try to create the router group because it is not the first deploy. However, the routing-api will still validate the seeded router group because `fail_on_router_port_conflicts` is set to true. Thus, the routing-api will fail to deploy.  |
|  no  |  yes  | false  |   success | The deploy will succeed because ` fail_on_router_port_conflicts` is set to false  |
|  no  |  no  | false  |  success |  The deploy will succeed because  `fail_on_router_port_conflicts` is set to false |

### Related links
* Routing-api PR: https://github.com/cloudfoundry/routing-api/pull/22





Thanks @jrussett who started this work before I took it from him because I am obsessed with tcp router 🐱 