### PR TITLE
Bump HA Proxy 1.8.13 → 2.5.4

### DIFF
--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -3,7 +3,7 @@ set -ex
 tar xzf haproxy/haproxy-*.tar.gz
 cd haproxy-*
 # gcc 10+ changed the default to "-fno-common"; we change it back to build properly
-make TARGET=linux2628 USE_OPENSSL=1 TARGET_CFLAGS=-fcommon
+make TARGET=linux-glibc USE_OPENSSL=1 TARGET_CFLAGS=-fcommon
 mkdir ${BOSH_INSTALL_TARGET}/bin
 cp haproxy ${BOSH_INSTALL_TARGET}/bin/
 chmod 755 ${BOSH_INSTALL_TARGET}/bin/haproxy

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -2,4 +2,4 @@
 name: haproxy
 
 files:
-  - haproxy/haproxy-1.8.13.tar.gz
+  - haproxy/haproxy-2.5.4.tar.gz


### PR DESCRIPTION
We bump the BOSH package HA Proxy to accommodate the new Jammy Jellyfish stemcells, which use OpenSSL 3, which requires HA Proxy > 2.4.14+ [0].

### You Must Do the Following

The blobs must be updated to accommodate this PR, and that's something that needs to be done by a team member—it's not part of this PR:

```
curl -L https://www.haproxy.org/download/2.5/src/haproxy-2.5.4.tar.gz -o ~/Downloads/haproxy-2.5.4.tar.gz
 # confirm shasum
curl -L https://www.haproxy.org/download/2.5/src/haproxy-2.5.4.tar.gz.sha256
shasum -a 256 ~/Downloads/haproxy-2.5.4.tar.gz
 # update blobs
bosh remove-blob \
  haproxy/haproxy-1.8.13.tar.gz
bosh add-blob \
  ~/Downloads/haproxy-2.5.4.tar.gz \
  haproxy/haproxy-2.5.4.tar.gz
```

### Other Notes

We also update the target in the HA Proxy packaging script from "linux2628" to "linux-glibc" as suggested during the compilation phase.

Fixes, during compilation phase on Jammy:
```
L Error: Action Failed get_task: Task 34dd3fc5-0f2c-4d79-5bdc-11d8f2c0c841 result: Compiling package haproxy: Running packaging script: Running packaging script: Command exited with 2; Truncated stdout: checking for equivalent simple type of off_t... 5 /* long */
```
```
L Error: Action Failed get_task: Task 8c34c252-7577-49e8-592d-b12467d7a70a result: Compiling package haproxy: Running packaging script: Running packaging script: Command exited with 2; Stdout: Target 'linux2628' was removed from HAProxy 2.0 due to being irrelevant and often wrong. Please use 'linux-glibc' instead or define your custom target by checking available options using 'make help TARGET=<your-target>'.
```

[0] <https://www.haproxy.org/download/2.4/src/CHANGELOG>

<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

We bump routing-release's BOSH package HA Proxy 1.8.13 → 2.5.4

* An explanation of the use cases your change solves

This fixes a compilation failure on the upcoming Ubuntu Jammy Jellyfish (22.04)-based stemcells, which are currently planned to replace the Xenial Xerus (16.04)-based stemcells.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

`bosh deploy` on Jammy stemcell compiles successfully.

* Expected result after the change

`bosh deploy` on Jammy stemcell compiles successfully.

* Current result before the change

Compilation fails with the following:

```
L Error: Action Failed get_task: Task 34dd3fc5-0f2c-4d79-5bdc-11d8f2c0c841 result: Compiling package haproxy: Running packaging script: Running packaging script: Command exited with 2; Truncated stdout: checking for equivalent simple type of off_t... 5 /* long */
```

* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run all the unit tests using `scripts/run-unit-tests-in-docker` (yes, I ran the tests, but there were **failures** both on the `develop` branch and on this branch; I am not versed enough to fix them, but **I offer my services for a day** of pairing to help address them if needed). 

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [X] (Optional) I have run CF Acceptance Tests on ~~bosh lite~~ vSphere, and I had the same number of pass/failures (149/16) as when I ran with the 0.229.0 version of the routing release. The failures were most likely caused by shortcomings in the test setup, most of which were CredHub-related. In other words, **these changes _seemed_ to work fine**.
