### PR TITLE
Add buffer to RegistrationInterval when generating tcp route TTLs

### DIFF
--- a/jobs/route_registrar/templates/registrar_settings.json.erb
+++ b/jobs/route_registrar/templates/registrar_settings.json.erb
@@ -94,8 +94,15 @@
     ca_certs: '/var/vcap/jobs/route_registrar/config/certs/ca.crt',
     client_cert_path: '/var/vcap/jobs/route_registrar/config/routing_api/certs/client.crt',
     client_private_key_path: '/var/vcap/jobs/route_registrar/config/routing_api/keys/client_private.key',
-    server_ca_cert_path: '/var/vcap/jobs/route_registrar/config/routing_api/certs/server_ca.crt'
+    server_ca_cert_path: '/var/vcap/jobs/route_registrar/config/routing_api/certs/server_ca.crt',
+    max_ttl: '120s',
   }
+  if_link('routing_api') do |link|
+    link.if_p('routing_api.max_ttl') do |prop|
+      routing_api[:max_ttl] = prop
+    end
+  end
+
   if_p('route_registrar.routing_api.api_url') do |prop|
     if_link('routing_api') do |link|
       if link.p('routing_api.enabled_api_endpoints') == "mtls" and not prop.start_with?('https')

--- a/jobs/routing-api/spec
+++ b/jobs/routing-api/spec
@@ -43,6 +43,7 @@ provides:
   - routing_api.mtls_client_key
   - routing_api.reserved_system_component_ports
   - routing_api.enabled_api_endpoints
+  - routing_api.max_ttl
   - uaa.ca_cert
   - skip_ssl_validation
 - name: routing_api_db

--- a/scripts/run-all-component-tests.sh
+++ b/scripts/run-all-component-tests.sh
@@ -3,11 +3,16 @@
 set -e
 
 PACKAGE="$1"
+SUB_PACKAGE="$2"
 
 if [[ -n "${PACKAGE}" ]]; then
   pushd "./src/code.cloudfoundry.org/${PACKAGE}"
     echo "Testing component: ${PACKAGE}"
-    ./bin/test -flakeAttempts 3
+    if [[ -n "${SUB_PACKAGE}" ]]; then
+      ./bin/test -flakeAttempts 3 ${SUB_PACKAGE}
+    else
+      ./bin/test -flakeAttempts 3
+    fi
   popd
 else
   for component in gorouter cf-tcp-router multierror route-registrar routing-api routing-api-cli uaa-go-client; do

--- a/scripts/run-unit-tests
+++ b/scripts/run-unit-tests
@@ -3,6 +3,7 @@ set -ex -o pipefail
 
 BASEDIR="$(dirname "$0")"
 PACKAGE="$1"
+SUB_PACKAGE="$2"
 
 function printStatus {
   local last_exit_status=$?
@@ -16,5 +17,5 @@ function printStatus {
 trap printStatus EXIT
 
 ${BASEDIR}/setup-test-environment.sh
-${BASEDIR}/run-all-component-tests.sh "$PACKAGE"
+${BASEDIR}/run-all-component-tests.sh "$PACKAGE" "$SUB_PACKAGE"
 

--- a/scripts/run-unit-tests-in-docker
+++ b/scripts/run-unit-tests-in-docker
@@ -5,9 +5,13 @@ ROUTING_RELEASE_DIR="${BASEDIR}/.."
 
 # COMPONENT takes only single package name
 COMPONENT=$1
+PACKAGE=$2
 IMAGE="cloudfoundry/cf-routing-pipeline"
 MOUNT_DIR="/routing-release"
 RUN_UNIT_TESTS="cd ${MOUNT_DIR}; source .envrc; scripts/run-unit-tests ${COMPONENT}"
+if [[ -n "$PACKAGE" ]]; then
+  RUN_UNIT_TESTS="cd ${MOUNT_DIR}; source .envrc; scripts/run-unit-tests ${COMPONENT} ${PACKAGE}"
+fi
 
 docker pull "${IMAGE}"
 docker run -it \

--- a/spec/route_registar_templates_spec.rb
+++ b/spec/route_registar_templates_spec.rb
@@ -339,6 +339,20 @@ describe 'route_registrar' do
             expect(rendered_hash['routing_api']['api_url']).to eq('https://other-routing-api.service.cf.internal:3001')
           end
         end
+
+        context 'when max_ttl is not provided in the link' do
+          it 'renders with the default' do
+            rendered_hash = JSON.parse(template.render(merged_manifest_properties, consumes: links))
+            expect(rendered_hash['routing_api']['max_ttl']).to eq('120s')
+          end
+        end
+        context 'when max_ttl is provided in the link' do
+          it 'uses the link value' do
+            links[0].properties['routing_api']['max_ttl'] = '100s'
+            rendered_hash = JSON.parse(template.render(merged_manifest_properties, consumes: links))
+            expect(rendered_hash['routing_api']['max_ttl']).to eq('100s')
+          end
+        end
       end
     end
 
@@ -367,7 +381,8 @@ describe 'route_registrar' do
             'skip_ssl_validation' => false,
             'client_cert_path' => '/var/vcap/jobs/route_registrar/config/routing_api/certs/client.crt',
             'client_private_key_path' => '/var/vcap/jobs/route_registrar/config/routing_api/keys/client_private.key',
-            'server_ca_cert_path' => '/var/vcap/jobs/route_registrar/config/routing_api/certs/server_ca.crt'
+            'server_ca_cert_path' => '/var/vcap/jobs/route_registrar/config/routing_api/certs/server_ca.crt',
+            'max_ttl' => '120s'
           },
           'nats_mtls_config' => {
             'enabled' => false,


### PR DESCRIPTION
## Current Behavior
Currently the route registrar sends routes with a TTL that is identical to the registration interval for the routing-api. This results in routes being pruned and a split second later being added again. This causes the tcp router to unnecessarily create new haproxies.

## New behavior
Add buffer to RegistrationInterval when generating tcp route TTLs to prevent this race condition. It also makes sure that the calculated ttl does not exceed the maxTTL from the routing-api.

related PR: https://github.com/cloudfoundry/route-registrar/pull/27