### PR TITLE
fix the sync-package-specs script

### DIFF
--- a/scripts/sync-package-specs
+++ b/scripts/sync-package-specs
@@ -3,7 +3,7 @@
 set -e
 
 # ensure gosub is installed (this will recompile it only if necessary)
-GO111MODULE=on go get github.com/vito/gosub
+GO111MODULE=on go install github.com/vito/gosub@latest
 
 function sync_package() {
   bosh_pkg=${1}


### PR DESCRIPTION
You can now run the script with go 1.18 and it doesn't fail :D 