### PR TITLE
bump lager

### DIFF
--- a/packages/acceptance_tests/spec
+++ b/packages/acceptance_tests/spec
@@ -18,6 +18,7 @@ files:
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/cfhttp/v2/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/clock/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/lagerctx/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/lagertest/*.go # gosub
   - code.cloudfoundry.org/routing-acceptance-tests/helpers/*.go # gosub

--- a/packages/gorouter/spec
+++ b/packages/gorouter/spec
@@ -70,6 +70,7 @@ files:
   - code.cloudfoundry.org/gorouter/test_util/rss/common/*.go # gosub
   - code.cloudfoundry.org/gorouter/varz/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/localip/*.go # gosub
   - code.cloudfoundry.org/routing-api/*.go # gosub
   - code.cloudfoundry.org/routing-api/models/*.go # gosub

--- a/packages/route_registrar/spec
+++ b/packages/route_registrar/spec
@@ -11,6 +11,7 @@ files:
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/cfhttp/v2/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/clock/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/lagerflags/*.go # gosub
   - code.cloudfoundry.org/multierror/*.go # gosub
   - code.cloudfoundry.org/route-registrar/*.go # gosub

--- a/packages/routing-api/spec
+++ b/packages/routing-api/spec
@@ -21,6 +21,7 @@ files:
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/go-loggregator/v8/rfc5424/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/lagerflags/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/locket/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/locket/cmd/locket/certauthority/*.go # gosub

--- a/packages/rtr/spec
+++ b/packages/rtr/spec
@@ -11,6 +11,7 @@ files:
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/cfhttp/v2/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/clock/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/lagerflags/*.go # gosub
   - code.cloudfoundry.org/routing-api/*.go # gosub
   - code.cloudfoundry.org/routing-api-cli/*.go # gosub

--- a/packages/tcp_router/spec
+++ b/packages/tcp_router/spec
@@ -34,6 +34,7 @@ files:
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/clock/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/debugserver/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/internal/truncate/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/lagerflags/*.go # gosub
   - code.cloudfoundry.org/routing-api/*.go # gosub
   - code.cloudfoundry.org/routing-api/models/*.go # gosub

--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -21,7 +21,7 @@ require (
 	code.cloudfoundry.org/debugserver v0.0.0-20210608171006-d7658ce493f4
 	code.cloudfoundry.org/eventhub v0.0.0-20210615172938-0b896ce72257
 	code.cloudfoundry.org/go-metric-registry v0.0.0-20220203232021-f2ac4dfd60ec
-	code.cloudfoundry.org/lager v2.0.0+incompatible
+	code.cloudfoundry.org/lager v1.1.1-0.20210922154813-2c3a201cafc6
 	code.cloudfoundry.org/localip v0.0.0-20210608161955-43c3ec713c20
 	code.cloudfoundry.org/locket v0.0.0-20211014150347-5712a0767913
 	code.cloudfoundry.org/tlsconfig v0.0.0-20210615191307-5d92ef3894a7

--- a/src/code.cloudfoundry.org/go.sum
+++ b/src/code.cloudfoundry.org/go.sum
@@ -27,6 +27,8 @@ code.cloudfoundry.org/go-metric-registry v0.0.0-20220203232021-f2ac4dfd60ec/go.m
 code.cloudfoundry.org/inigo v0.0.0-20210615140442-4bdc4f6e44d5 h1:XVhLtnvbIlLQh7L0KADVFjd2dfgXVcOpqPLpMtg/IZA=
 code.cloudfoundry.org/inigo v0.0.0-20210615140442-4bdc4f6e44d5/go.mod h1:1ZB1JCh2FAp+SqX79ve6dc8YREvbsziULEOncAilX4Q=
 code.cloudfoundry.org/lager v1.1.1-0.20210513163233-569157d2803b/go.mod h1:SF6BAZkl2+itWGVny2ILQCY9UNXIRwgi/m181VkHfrI=
+code.cloudfoundry.org/lager v1.1.1-0.20210922154813-2c3a201cafc6 h1:UgzXGTcp+Hi9qxZhqr0BF0IZEax6K/QPV60KRZOSTz0=
+code.cloudfoundry.org/lager v1.1.1-0.20210922154813-2c3a201cafc6/go.mod h1:0xN6bpO6rPnZcRia3JPEKyEEyGGj2SvLHbUXY82PWMc=
 code.cloudfoundry.org/lager v2.0.0+incompatible h1:WZwDKDB2PLd/oL+USK4b4aEjUymIej9My2nUQ9oWEwQ=
 code.cloudfoundry.org/lager v2.0.0+incompatible/go.mod h1:O2sS7gKP3HM2iemG+EnwvyNQK7pTSC6Foi4QiMp9sSk=
 code.cloudfoundry.org/localip v0.0.0-20210608161955-43c3ec713c20 h1:wUuKExmeHyMJ0m9g9HKjJjHn3US4j4kWrDxqUsSQmRg=

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/internal/truncate/package.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/internal/truncate/package.go
@@ -1,0 +1,1 @@
+package truncate // import "code.cloudfoundry.org/lager/internal/truncate"

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/internal/truncate/truncate.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/internal/truncate/truncate.go
@@ -1,0 +1,174 @@
+package truncate
+
+import (
+	"reflect"
+)
+
+// Value recursively walks through the value provided by `v` and truncates
+// any strings longer than `maxLength`.
+// Example:
+//	 type foobar struct{A string; B string}
+//   truncate.Value(foobar{A:"foo",B:"bar"}, 20) == foobar{A:"foo",B:"bar"}
+//   truncate.Value(foobar{A:strings.Repeat("a", 25),B:"bar"}, 20) == foobar{A:"aaaaaaaa-(truncated)",B:"bar"}
+func Value(v interface{}, maxLength int) interface{} {
+	rv := reflect.ValueOf(v)
+	tv := truncateValue(rv, maxLength)
+	if rv != tv {
+		return tv.Interface()
+	}
+	return v
+}
+
+func truncateValue(rv reflect.Value, maxLength int) reflect.Value {
+	if maxLength <= 0 {
+		return rv
+	}
+
+	switch rv.Kind() {
+	case reflect.Interface:
+		return truncateInterface(rv, maxLength)
+	case reflect.Ptr:
+		return truncatePtr(rv, maxLength)
+	case reflect.Struct:
+		return truncateStruct(rv, maxLength)
+	case reflect.Map:
+		return truncateMap(rv, maxLength)
+	case reflect.Array:
+		return truncateArray(rv, maxLength)
+	case reflect.Slice:
+		return truncateSlice(rv, maxLength)
+	case reflect.String:
+		return truncateString(rv, maxLength)
+	}
+	return rv
+}
+
+func truncateInterface(rv reflect.Value, maxLength int) reflect.Value {
+	tv := truncateValue(rv.Elem(), maxLength)
+	if tv != rv.Elem() {
+		return tv
+	}
+	return rv
+}
+
+func truncatePtr(rv reflect.Value, maxLength int) reflect.Value {
+	tv := truncateValue(rv.Elem(), maxLength)
+	if rv.Elem() != tv {
+		tvp := reflect.New(rv.Elem().Type())
+		tvp.Elem().Set(tv)
+		return tvp
+	}
+	return rv
+}
+
+func truncateStruct(rv reflect.Value, maxLength int) reflect.Value {
+	numFields := rv.NumField()
+	fields := make([]reflect.Value, numFields)
+	changed := false
+	for i := 0; i < numFields; i++ {
+		fv := rv.Field(i)
+		tv := truncateValue(fv, maxLength)
+		if fv != tv {
+			changed = true
+		}
+		fields[i] = tv
+	}
+	if changed {
+		nv := reflect.New(rv.Type()).Elem()
+		for i, fv := range fields {
+			nv.Field(i).Set(fv)
+		}
+		return nv
+	}
+	return rv
+}
+
+func truncateMap(rv reflect.Value, maxLength int) reflect.Value {
+	keys := rv.MapKeys()
+	truncatedMap := make(map[reflect.Value]reflect.Value)
+	changed := false
+	for _, key := range keys {
+		mapV := rv.MapIndex(key)
+		tv := truncateValue(mapV, maxLength)
+		if mapV != tv {
+			changed = true
+		}
+		truncatedMap[key] = tv
+	}
+	if changed {
+		nv := reflect.MakeMap(rv.Type())
+		for k, v := range truncatedMap {
+			nv.SetMapIndex(k, v)
+		}
+		return nv
+	}
+	return rv
+
+}
+
+func truncateArray(rv reflect.Value, maxLength int) reflect.Value {
+	return truncateList(rv, maxLength, func(size int) reflect.Value {
+		arrayType := reflect.ArrayOf(size, rv.Index(0).Type())
+		return reflect.New(arrayType).Elem()
+	})
+}
+
+func truncateSlice(rv reflect.Value, maxLength int) reflect.Value {
+	return truncateList(rv, maxLength, func(size int) reflect.Value {
+		return reflect.MakeSlice(rv.Type(), size, size)
+	})
+}
+
+func truncateList(rv reflect.Value, maxLength int, newList func(size int) reflect.Value) reflect.Value {
+	size := rv.Len()
+	truncatedValues := make([]reflect.Value, size)
+	changed := false
+	for i := 0; i < size; i++ {
+		elemV := rv.Index(i)
+		tv := truncateValue(elemV, maxLength)
+		if elemV != tv {
+			changed = true
+		}
+		truncatedValues[i] = tv
+	}
+	if changed {
+		nv := newList(size)
+		for i, v := range truncatedValues {
+			nv.Index(i).Set(v)
+		}
+		return nv
+	}
+	return rv
+}
+
+func truncateString(rv reflect.Value, maxLength int) reflect.Value {
+	s := String(rv.String(), maxLength)
+	if s != rv.String() {
+		return reflect.ValueOf(s)
+	}
+	return rv
+
+}
+
+const truncated = "-(truncated)"
+const lenTruncated = len(truncated)
+
+// String truncates long strings from the middle, but leaves strings shorter
+// than `maxLength` untouched.
+// If the string is shorter than the string "-(truncated)" and the string
+// exceeds `maxLength`, the output will not be truncated.
+// Example:
+//   truncate.String(strings.Repeat("a", 25), 20) == "aaaaaaaa-(truncated)"
+//   truncate.String("foobar", 20) == "foobar"
+//   truncate.String("foobar", 5) == "foobar"
+func String(s string, maxLength int) string {
+	if maxLength <= 0 || len(s) < lenTruncated || len(s) <= maxLength {
+		return s
+	}
+
+	strBytes := []byte(s)
+	truncatedBytes := []byte(truncated)
+	prefixLength := maxLength - lenTruncated
+	prefix := strBytes[0:prefixLength]
+	return string(append(prefix, truncatedBytes...))
+}

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/json_redacter.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/json_redacter.go
@@ -22,7 +22,7 @@ func NewJSONRedacter(keyPatterns []string, valuePatterns []string) (*JSONRedacte
 		keyPatterns = []string{"[Pp]wd", "[Pp]ass"}
 	}
 	if valuePatterns == nil {
-		valuePatterns = []string{awsAccessKeyIDPattern, awsSecretAccessKeyPattern, cryptMD5Pattern, cryptSHA256Pattern, cryptSHA512Pattern, privateKeyHeaderPattern}
+		valuePatterns = DefaultValuePatterns()
 	}
 	ret := &JSONRedacter{}
 	for _, v := range keyPatterns {
@@ -108,4 +108,8 @@ func handleError(err error) []byte {
 		panic(err)
 	}
 	return content
+}
+
+func DefaultValuePatterns() []string {
+	return []string{awsAccessKeyIDPattern, awsSecretAccessKeyPattern, cryptMD5Pattern, cryptSHA256Pattern, cryptSHA512Pattern, privateKeyHeaderPattern}
 }

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/lagerflags/redact_secrets.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/lagerflags/redact_secrets.go
@@ -1,0 +1,14 @@
+package lagerflags
+
+import "strings"
+
+type RedactPatterns []string
+
+func (p *RedactPatterns) String() string {
+	return strings.Join(*p, ",")
+}
+
+func (p *RedactPatterns) Set(value string) error {
+	*p = append(*p, value)
+	return nil
+}

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/lagerflags/timeformat.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/lagerflags/timeformat.go
@@ -1,0 +1,57 @@
+package lagerflags
+
+import (
+	"errors"
+	"fmt"
+)
+
+type TimeFormat int
+
+const (
+	FormatUnixEpoch TimeFormat = iota
+	FormatRFC3339
+)
+
+func (t TimeFormat) MarshalJSON() ([]byte, error) {
+	if FormatUnixEpoch <= t && t <= FormatRFC3339 {
+		return []byte(`"` + t.String() + `"`), nil
+	}
+	return nil, fmt.Errorf("invalid TimeFormat: %d", t)
+}
+
+// Set implements the flag.Getter interface
+func (t TimeFormat) Get(s string) interface{} { return t }
+
+// Set implements the flag.Value interface
+func (t *TimeFormat) Set(s string) error {
+	switch s {
+	case "unix-epoch", "0":
+		*t = FormatUnixEpoch
+	case "rfc3339", "1":
+		*t = FormatRFC3339
+	default:
+		return errors.New(`invalid TimeFormat: "` + s + `"`)
+	}
+	return nil
+}
+
+func (t *TimeFormat) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+	// unqote
+	if len(data) >= 2 && data[0] == '"' && data[len(data)-1] == '"' {
+		data = data[1 : len(data)-1]
+	}
+	return t.Set(string(data))
+}
+
+func (t TimeFormat) String() string {
+	switch t {
+	case FormatUnixEpoch:
+		return "unix-epoch"
+	case FormatRFC3339:
+		return "rfc3339"
+	}
+	return "invalid"
+}

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/models.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/models.go
@@ -47,8 +47,11 @@ type rfc3339Time time.Time
 const rfc3339Nano = "2006-01-02T15:04:05.000000000Z07:00"
 
 func (t rfc3339Time) MarshalJSON() ([]byte, error) {
-	stamp := fmt.Sprintf(`"%s"`, time.Time(t).UTC().Format(rfc3339Nano))
-	return []byte(stamp), nil
+	// Use AppendFormat to avoid slower string operations, instead we only
+	// operate on a byte slice
+	// Avoid creating a new copy of t with a cast, instead use type conversion
+	stamp := append((time.Time)(t).UTC().AppendFormat([]byte{'"'}, rfc3339Nano), '"')
+	return stamp, nil
 }
 
 func (t *rfc3339Time) UnmarshalJSON(data []byte) error {
@@ -77,20 +80,22 @@ func (log LogFormat) ToJSON() []byte {
 	return content
 }
 
+type prettyLogFormat struct {
+	Timestamp rfc3339Time `json:"timestamp"`
+	Level     string      `json:"level"`
+	Source    string      `json:"source"`
+	Message   string      `json:"message"`
+	Data      Data        `json:"data"`
+	Error     error       `json:"-"`
+}
+
 func (log LogFormat) toPrettyJSON() []byte {
 	t := log.time
 	if t.IsZero() {
 		t = parseTimestamp(log.Timestamp)
 	}
 
-	prettyLog := struct {
-		Timestamp rfc3339Time `json:"timestamp"`
-		Level     string      `json:"level"`
-		Source    string      `json:"source"`
-		Message   string      `json:"message"`
-		Data      Data        `json:"data"`
-		Error     error       `json:"-"`
-	}{
+	prettyLog := prettyLogFormat{
 		Timestamp: rfc3339Time(t),
 		Level:     log.LogLevel.String(),
 		Source:    log.Source,

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/reconfigurable_sink.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/reconfigurable_sink.go
@@ -1,6 +1,8 @@
 package lager
 
-import "sync/atomic"
+import (
+	"sync/atomic"
+)
 
 type ReconfigurableSink struct {
 	sink Sink

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/truncating_sink.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/truncating_sink.go
@@ -1,0 +1,32 @@
+package lager
+
+import "code.cloudfoundry.org/lager/internal/truncate"
+
+type truncatingSink struct {
+	sink                Sink
+	maxDataStringLength int
+}
+
+// NewTruncatingSink returns a sink that truncates strings longer than the max
+// data string length
+// Example:
+//   writerSink := lager.NewWriterSink(os.Stdout, lager.INFO)
+//   sink := lager.NewTruncatingSink(testSink, 20)
+//   logger := lager.NewLogger("test")
+//   logger.RegisterSink(sink)
+//   logger.Info("message", lager.Data{"A": strings.Repeat("a", 25)})
+func NewTruncatingSink(sink Sink, maxDataStringLength int) Sink {
+	return &truncatingSink{
+		sink:                sink,
+		maxDataStringLength: maxDataStringLength,
+	}
+}
+
+func (sink *truncatingSink) Log(log LogFormat) {
+	truncatedData := Data{}
+	for k, v := range log.Data {
+		truncatedData[k] = truncate.Value(v, sink.maxDataStringLength)
+	}
+	log.Data = truncatedData
+	sink.sink.Log(log)
+}

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/writer_sink.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/writer_sink.go
@@ -31,9 +31,11 @@ func (sink *writerSink) Log(log LogFormat) {
 		return
 	}
 
+	// Convert to json outside of critical section to minimize time spent holding lock
+	message := append(log.ToJSON(), '\n')
+
 	sink.writeL.Lock()
-	sink.writer.Write(log.ToJSON())
-	sink.writer.Write([]byte("\n"))
+	sink.writer.Write(message)
 	sink.writeL.Unlock()
 }
 
@@ -55,8 +57,10 @@ func (sink *prettySink) Log(log LogFormat) {
 		return
 	}
 
+	// Convert to json outside of critical section to minimize time spent holding lock
+	message := append(log.toPrettyJSON(), '\n')
+
 	sink.writeL.Lock()
-	sink.writer.Write(log.toPrettyJSON())
-	sink.writer.Write([]byte("\n"))
+	sink.writer.Write(message)
 	sink.writeL.Unlock()
 }

--- a/src/code.cloudfoundry.org/vendor/modules.txt
+++ b/src/code.cloudfoundry.org/vendor/modules.txt
@@ -43,9 +43,10 @@ code.cloudfoundry.org/go-metric-registry
 code.cloudfoundry.org/go-metric-registry/testhelpers
 # code.cloudfoundry.org/inigo v0.0.0-20210615140442-4bdc4f6e44d5
 ## explicit
-# code.cloudfoundry.org/lager v2.0.0+incompatible
-## explicit
+# code.cloudfoundry.org/lager v1.1.1-0.20210922154813-2c3a201cafc6
+## explicit; go 1.17
 code.cloudfoundry.org/lager
+code.cloudfoundry.org/lager/internal/truncate
 code.cloudfoundry.org/lager/lagerctx
 code.cloudfoundry.org/lager/lagerflags
 code.cloudfoundry.org/lager/lagertest


### PR DESCRIPTION
* when we switched to go.mod we got an older version of lager
* this older version had a bug that made it not respect the timeFormat flag
* this means logs were in (_gasp_) EPOCH instead of rfc3339
* long live human readable timestamps

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
