### PR TITLE
Gorouter healthchecker retries connection instead of monit

### DIFF
--- a/jobs/gorouter/monit
+++ b/jobs/gorouter/monit
@@ -10,6 +10,6 @@ check process gorouter-healthchecker
   start program "/var/vcap/jobs/bpm/bin/bpm start gorouter -p gorouter-healthchecker"
     with timeout 65 seconds
   stop program "/var/vcap/jobs/bpm/bin/bpm stop gorouter -p gorouter-healthchecker"
-  if 2 restarts within 3 cycles then exec "/var/vcap/jobs/gorouter/bin/restart-gorouter"
+  if 1 restarts within 1 cycles then exec "/var/vcap/jobs/gorouter/bin/restart-gorouter"
   depends on gorouter
   group vcap


### PR DESCRIPTION
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

Instead of involving monit poll cycles, retry in healthchecker before failing. Reconfigure monit to restart gorouter whenever healthchecker fails.

* An explanation of the use cases your change solves

When gorouter hangs, healthchecker should trigger the gorouter restart instead of just failing indefinitely.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

`kill -s SIGSTOP <GOROUTER_PID>`

* Expected result after the change

see that healthchecker fails within 30s and monit restarts gorouter immediately

* Current result before the change

gorouter is never restarted

* Links to any other associated PRs

https://github.com/cloudfoundry/gorouter/pull/320

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
