### PR TITLE
add the hair pinning allowlist property to the gorouter spec

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -196,7 +196,7 @@ properties:
     description: "setting this property to true causes gorouter to bypass another trip through the load balancer when directing traffic to a route service that is a known route by the gorouter."
     default: false
   router.route_services_internal_lookup_allowlist:
-    description: "a list of host names for route services that should be resolved internally. Each entry can be a fully qualified domain name or DNS wildcard (i.e. wildcard on 1 segment of a   subdomain). If the list is empty, it is not in effect and internal lookup will be attempted for all host names, which can lead to CVE-2019-3789. Please turn on internal lookup only with an allowlist."
+    description: "a list of host names for route services that should be resolved internally. Each entry can be a fully qualified domain name or DNS wildcard (i.e. wildcard on 1 segment of a subdomain). If the list is empty, it is not in effect and internal lookup will be attempted for all host names, which can lead to CVE-2019-3789. Please turn on internal lookup only with an allowlist."
     default: []
   router.route_services_secret_decrypt_only:
     description: "To rotate keys, add your new key here and deploy. Then swap this key with the value of route_services_secret and deploy again."

--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -195,6 +195,9 @@ properties:
   router.route_services_internal_lookup:
     description: "setting this property to true causes gorouter to bypass another trip through the load balancer when directing traffic to a route service that is a known route by the gorouter."
     default: false
+  router.route_services_internal_lookup_allowlist:
+    description: "a list of host names for route services that should be resolved internally. Each entry can be a fully qualified domain name or DNS wildcard (i.e. wildcard on 1 segment of a   subdomain). If the list is empty, it is not in effect and internal lookup will be attempted for all host names, which can lead to CVE-2019-3789. Please turn on internal lookup only with an allowlist."
+    default: []
   router.route_services_secret_decrypt_only:
     description: "To rotate keys, add your new key here and deploy. Then swap this key with the value of route_services_secret and deploy again."
     default: ""

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -79,6 +79,7 @@ params = {
   'route_services_secret_decrypt_only' => p('router.route_services_secret_decrypt_only'),
   'route_services_recommend_https' => p('router.route_services_recommend_https'),
   'route_services_hairpinning' => p('router.route_services_internal_lookup'),
+  'route_services_hairpinning_allowlist' => p('router.route_services_internal_lookup_allowlist'),
   'extra_headers_to_log' => p('router.extra_headers_to_log'),
   'token_fetcher_max_retries' => 3,
   'token_fetcher_retry_interval' => '5s',

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -374,6 +374,22 @@ describe 'gorouter' do
         end
       end
 
+      context 'route_services_internal_lookup_allowlist' do
+        it 'defaults to empty array' do
+          expect(parsed_yaml['route_services_hairpinning_allowlist']).to eq([])
+        end
+
+        context 'when set to a list' do
+          before do
+            deployment_manifest_fragment['router']['route_services_internal_lookup_allowlist'] = ['route-service.com', '*.example.com']
+          end
+
+          it 'parses to the same list' do
+            expect(parsed_yaml['route_services_hairpinning_allowlist']).to eq(['route-service.com', '*.example.com'])
+          end
+        end
+      end
+
       context 'html_error_template' do
         it 'is not set by default' do
           expect(parsed_yaml['html_error_template_file']).to be_nil


### PR DESCRIPTION
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

This change adds a host name allowlist for route service hairpinning, see Gorouter PR [#324](https://github.com/cloudfoundry/gorouter/pull/324).

All other points are discussed there as well.

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite