### PR TITLE
Add optional websocket_dial_timeout property to routing release.

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -366,8 +366,13 @@ properties:
   endpoint_dial_timeout_in_seconds:
     description: |
       Maximum time in seconds for gorouter to establish a TCP connection with a backend. This timeout comes before `tls_handshake_timeout_in_seconds`
-      and `request_timeout_in_seconds`. This timeout also applies as a read timeout for websocket requests.
+      and `request_timeout_in_seconds`.
     default: 5
+  websocket_dial_timeout_in_seconds:
+    description: |
+      Maximum time in seconds for gorouter to establish a websocket upgrade for the websocket ForwardIO connection with a backend. 
+      This timeout comes before `tls_handshake_timeout_in_seconds` and `request_timeout_in_seconds`. When not set, defaults to `endpoint_dial_timeout_in_seconds`.
+    default: endpoint_dial_timeout_in_seconds
   tls_handshake_timeout_in_seconds:
     description: |
       Maximum time in seconds for gorouter to establish a TLS connection with a backend container. This timeout is for establishing

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -64,6 +64,7 @@ params = {
   'healthcheck_user_agent' => p('router.healthcheck_user_agent'),
   'endpoint_timeout' => "#{p('request_timeout_in_seconds')}s",
   'endpoint_dial_timeout' => "#{p('endpoint_dial_timeout_in_seconds')}s",
+  'websocket_dial_timeout' => "#{p('websocket_dial_timeout_in_seconds') != "endpoint_dial_timeout_in_seconds" ? p('websocket_dial_timeout_in_seconds') : p('endpoint_dial_timeout_in_seconds')}s",
   'tls_handshake_timeout' => "#{p('tls_handshake_timeout_in_seconds')}s",
   'start_response_delay_interval' => "#{p('router.requested_route_registration_interval_in_seconds')}s",
   'load_balancer_healthy_threshold' => "#{p('router.load_balancer_healthy_threshold')}s",

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -194,6 +194,7 @@ describe 'gorouter' do
         'golang' => {},
         'request_timeout_in_seconds' => 100,
         'endpoint_dial_timeout_in_seconds' => 6,
+        # the websocket_dial_timeout_in_seconds will default to the value of endpoint_dial_timeout_in_seconds if not set
         'tls_handshake_timeout_in_seconds' => 9,
         'routing_api' => {
           'enabled' => false,
@@ -463,8 +464,19 @@ describe 'gorouter' do
       describe 'connection and request timeouts' do
         it 'should configure properly' do
           expect(parsed_yaml['endpoint_dial_timeout']).to eq('6s')
+          expect(parsed_yaml['websocket_dial_timeout']).to eq('6s')
           expect(parsed_yaml['tls_handshake_timeout']).to eq('9s')
           expect(parsed_yaml['endpoint_timeout']).to eq('100s')
+        end
+      end
+
+      describe 'explicitly set websocket_dial_timeout' do
+        before do
+          deployment_manifest_fragment['websocket_dial_timeout_in_seconds'] = 8
+        end
+        it 'should configure properly' do
+          expect(parsed_yaml['endpoint_dial_timeout']).to eq('6s')
+          expect(parsed_yaml['websocket_dial_timeout']).to eq('8s')
         end
       end
 


### PR DESCRIPTION

<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

Allows setting the websocket dial timeout independent of the `endpoint_dial_timeout`.

When the value is not set, it defaults to the value of `endpoint_dial_timeout` and retains previous behaviour, before this property was available / exposed.

* Links to any other associated PRs

https://github.com/cloudfoundry/gorouter/pull/325

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
