### PR TITLE
Enable Access Logs for requests of size between max_header_bytes and 1MB

### DIFF
--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -28,6 +28,13 @@ def parse_ip (ip, var_name)
   end
 end
 
+def validate_max_header_bytes (bytes)
+  if bytes < 1 or bytes > 1024 * 1024
+    raise "Invalid router.max_header_bytes value. Must be between 1 and 1,048,576 bytes"
+  end
+  bytes
+end
+
 parse_ip(p('router.debug_address'), 'router.debug_address')
 
 access_log_file = p('router.write_access_logs_locally') ? '/var/vcap/sys/log/gorouter/access.log' : ''
@@ -82,7 +89,7 @@ params = {
   'route_services_hairpinning' => p('router.route_services_internal_lookup'),
   'route_services_hairpinning_allowlist' => p('router.route_services_internal_lookup_allowlist'),
   'extra_headers_to_log' => p('router.extra_headers_to_log'),
-  'max_header_bytes' => p('router.max_header_bytes'),
+  'max_header_bytes' => validate_max_header_bytes(p('router.max_header_bytes')),
   'token_fetcher_max_retries' => 3,
   'token_fetcher_retry_interval' => '5s',
   'token_fetcher_expiration_buffer_time' => 30,

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -1070,6 +1070,26 @@ describe 'gorouter' do
           end
         end
       end
+
+      context 'max_header_bytes' do
+        context 'less than 1' do
+          before do
+            deployment_manifest_fragment['router']['max_header_bytes'] = 0
+          end
+          it 'throws an error' do
+            expect { parsed_yaml }.to raise_error(/Invalid router.max_header_bytes/)
+          end
+        end
+
+        context 'greater than 1mb' do
+          before do
+            deployment_manifest_fragment['router']['max_header_bytes'] = 1024 * 1024 + 1
+          end
+          it 'throws an error' do
+            expect { parsed_yaml }.to raise_error(/Invalid router.max_header_bytes/)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This change enforces a 1MB limit on max_header_bytes and enables access logging for requests that are greater than the configured value, but less than 1MB. Improves the logging and ability to audit requests


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
