### PR TITLE
Remove go 1.18 package

### DIFF
--- a/jobs/acceptance_tests/spec
+++ b/jobs/acceptance_tests/spec
@@ -7,7 +7,7 @@ templates:
   bpm.yml.erb: config/bpm.yml
 
 packages:
- - golang-1.18-linux
+ - golang-1.19-linux
  - acceptance_tests
  - rtr
  - cf-cli-6-linux

--- a/jobs/smoke_tests/spec
+++ b/jobs/smoke_tests/spec
@@ -7,7 +7,7 @@ templates:
   bpm.yml.erb: config/bpm.yml
 
 packages:
- - golang-1.18-linux
+ - golang-1.19-linux
  - acceptance_tests
  - cf-cli-6-linux
 

--- a/packages/acceptance_tests/spec
+++ b/packages/acceptance_tests/spec
@@ -3,7 +3,7 @@ name: acceptance_tests
 
 dependencies:
   - rtr
-  - golang-1.18-linux
+  - golang-1.19-linux
 
 files:
   - code.cloudfoundry.org/go.mod

--- a/packages/golang-1.18-linux/spec.lock
+++ b/packages/golang-1.18-linux/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1.18-linux
-fingerprint: 1b9cab9fe43325f2ca9b4c2cabe29313e49246e82542c9cbfc7b60b5ae807d80

--- a/packages/gorouter/spec
+++ b/packages/gorouter/spec
@@ -2,7 +2,7 @@
 name: gorouter
 
 dependencies:
-- golang-1.18-linux
+- golang-1.19-linux
 
 files:
   - jq/jq-1.6-linux64.tgz

--- a/packages/route_registrar/spec
+++ b/packages/route_registrar/spec
@@ -2,7 +2,7 @@
 name: route_registrar
 
 dependencies:
-- golang-1.18-linux
+- golang-1.19-linux
 
 files:
   - code.cloudfoundry.org/go.mod

--- a/packages/routing-api/spec
+++ b/packages/routing-api/spec
@@ -2,7 +2,7 @@
 name: routing-api
 
 dependencies:
-  - golang-1.18-linux
+  - golang-1.19-linux
 
 files:
   - code.cloudfoundry.org/go.mod

--- a/packages/routing_utils/spec
+++ b/packages/routing_utils/spec
@@ -2,7 +2,7 @@
 name: routing_utils
 
 dependencies:
-- golang-1.18-linux
+- golang-1.19-linux
 
 files:
   - routing_utils/pid_utils.sh

--- a/packages/rtr/spec
+++ b/packages/rtr/spec
@@ -2,7 +2,7 @@
 name: rtr
 
 dependencies:
-- golang-1.18-linux
+- golang-1.19-linux
 
 files:
   - code.cloudfoundry.org/go.mod

--- a/packages/tcp_router/spec
+++ b/packages/tcp_router/spec
@@ -2,7 +2,7 @@
 name: tcp_router
 
 dependencies:
-  - golang-1.18-linux
+  - golang-1.19-linux
 
 files:
   - code.cloudfoundry.org/go.mod


### PR DESCRIPTION
Remove go 1.18 package and use go 1.19 package

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X ] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
