### PR TITLE
Migrate router.max_header_bytes to router.max_header_kb

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -207,14 +207,13 @@ properties:
   router.route_services_timeout:
     description: "Expiry time of a route service signature in seconds"
     default: 60
-  router.max_header_bytes:
+  router.max_header_kb:
     description: |
-        This value controls the maximum number of bytes the gorouter will read
+        This value controls the maximum number of bytes (in KB) the gorouter will read
         parsing the request header's keys and values, including the request
-        line. It does not limit the size of the request body. An additional
-        padding of 4096 bytes is added to this value by go. Requests with
-        larger headers will result in a 431 status code.
-    default: 1048576 # 1Mb
+        line. It does not limit the size of the request body. Requests with
+        larger headers will result in a 431 status code. Must be between 1 and 1024kb.
+    default: 1024 # 1Mb
   router.extra_headers_to_log:
     description: "An array of headers that access log events will be annotated with. This only applies to headers on requests."
     default: []

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -28,11 +28,11 @@ def parse_ip (ip, var_name)
   end
 end
 
-def validate_max_header_bytes (bytes)
-  if bytes < 1 or bytes > 1024 * 1024
-    raise "Invalid router.max_header_bytes value. Must be between 1 and 1,048,576 bytes"
+def validate_max_header_kb (kb)
+  if kb < 1 or kb > 1024
+    raise "Invalid router.max_header_kb value. Must be between 1 and 1,024 kb"
   end
-  bytes
+  kb * 1024
 end
 
 parse_ip(p('router.debug_address'), 'router.debug_address')
@@ -89,7 +89,7 @@ params = {
   'route_services_hairpinning' => p('router.route_services_internal_lookup'),
   'route_services_hairpinning_allowlist' => p('router.route_services_internal_lookup_allowlist'),
   'extra_headers_to_log' => p('router.extra_headers_to_log'),
-  'max_header_bytes' => validate_max_header_bytes(p('router.max_header_bytes')),
+  'max_header_bytes' => validate_max_header_kb(p('router.max_header_kb')),
   'token_fetcher_max_retries' => 3,
   'token_fetcher_retry_interval' => '5s',
   'token_fetcher_expiration_buffer_time' => 30,

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -169,7 +169,7 @@ describe 'gorouter' do
           'route_services_secret_decrypt_only' => 'secret',
           'route_services_recommend_https' => false,
           'extra_headers_to_log' => 'test-header',
-          'max_header_bytes' => 1_048_576,
+          'max_header_kb' => 1_024,
           'enable_proxy' => false,
           'force_forwarded_proto_https' => false,
           'sanitize_forwarded_proto' => false,
@@ -250,8 +250,8 @@ describe 'gorouter' do
         end
       end
 
-      describe 'max_header_bytes' do
-        it 'should set max_header_bytes' do
+      describe 'max_header_kb' do
+        it 'should set max_header_kb' do
           expect(parsed_yaml['max_header_bytes']).to eq(1_048_576)
         end
       end
@@ -1071,22 +1071,22 @@ describe 'gorouter' do
         end
       end
 
-      context 'max_header_bytes' do
+      context 'max_header_kb' do
         context 'less than 1' do
           before do
-            deployment_manifest_fragment['router']['max_header_bytes'] = 0
+            deployment_manifest_fragment['router']['max_header_kb'] = 0
           end
           it 'throws an error' do
-            expect { parsed_yaml }.to raise_error(/Invalid router.max_header_bytes/)
+            expect { parsed_yaml }.to raise_error(/Invalid router.max_header_kb/)
           end
         end
 
         context 'greater than 1mb' do
           before do
-            deployment_manifest_fragment['router']['max_header_bytes'] = 1024 * 1024 + 1
+            deployment_manifest_fragment['router']['max_header_kb'] = 1024 + 1
           end
           it 'throws an error' do
-            expect { parsed_yaml }.to raise_error(/Invalid router.max_header_bytes/)
+            expect { parsed_yaml }.to raise_error(/Invalid router.max_header_kb/)
           end
         end
       end


### PR DESCRIPTION
Replaces painful `router.max_header_bytes` property with slightly less math intensive `router.max_header_kb`.