### PR TITLE
Add save and load route table feature to nats-client

### DIFF
--- a/docs/nats-client.md
+++ b/docs/nats-client.md
@@ -1,128 +1,112 @@
-# Session Affinity
+# NATS Client
 
 ## What is it?
 
-Session affinity, also known as sticky sessions, enables requests from a
-particular client to always reach the same application instance when multiple
-app instances are deployed. This allows apps to store data specific to a user
-session.
+Gorouter is loosely coupled with user apps via the NATS message bus. They share common subjects like `router.register` and `router.unregister` where apps publish their routes 
+while gorouter subscribes to them.
 
-## Architecture
+If developers want to debug a certain scenario, usually they have to set up applications and NATS in such a way that it reproduces
+the scenario inside gorouter. This can be cumbersome and tedious, as one has to fully deploy Cloud Foundry, push the apps, scale them up
+and then maybe tweak NATS or the IaaS provider to reproduce a network error or other issues.
 
+To mitigate this problem, `nats_client` was created. It has the following features:
+
+- Subscribe to NATS subjects and stream them to the shell to see what's received by gorouter
+- Publish messages to NATS subjects to inject events such as `router.register` and `router.unregister`
+- Save the current route table of a gorouter to a json file. The file may then be inspected and / or changed
+- Load a previously saved route table into gorouter via NATS
+
+## Where is it?
+
+After you have deployed `routing` you will find two files on a `gorouter` VM:
+- `/var/vcap/packages/routing_utils/bin/nats_client` (the actual NATS client binary)
+- `/var/vcap/jobs/gorouter/bin/nats_client` (a wrapper script calling the binary with the gorouter's config file)
+
+## How to use it
+Show the usage help by running:
+```shell
+/var/vcap/jobs/gorouter/bin/nats_client --help
+
+Usage:
+/var/vcap/jobs/gorouter/bin/nats_client [COMMAND]
+
+COMMANDS:
+  sub          [SUBJECT] [MESSAGE]
+               (Default) Streams NATS messages from server with provided SUBJECT. Default SUBJECT is 'router.*'
+               Example: /var/vcap/jobs/gorouter/bin/nats_client sub 'router.*'
+
+  pub          [SUBJECT] [MESSAGE]
+               Publish the provided message JSON to SUBJECT subscription. SUBJECT and MESSAGE are required
+               Example: /var/vcap/jobs/gorouter/bin/nats_client pub router.register '{"host":"172.217.6.68","port":80,"uris":["bar.example.com"]}'
+
+  save         <FILE>
+               Save this gorouter's route table to a json file.
+               Example: /var/vcap/jobs/gorouter/bin/nats_client save routes.json'
+
+  load         <FILE>
+               Load routes from a json file into this gorouter.
+               Example: /var/vcap/jobs/gorouter/bin/nats_client load routes.json'
 ```
-+-----------+                                   +-----------+                                    +-----------+
-|           |                                   |           |                                    |           |
-|           | 1. Sends request                  |           | 2. Gorouter forwards to app/1      |           |
-|           | +-------------------------------> |           | +--------------------------------> |           |
-|           |                                   |           |                                    |           |
-|           |                                   |           |                                    |           |
-|           | 4. Gorouter adds __VCAP_ID__      |           | 3. App adds JSESSIONID cookie      |           |
-| End User  |    cookie to response             | Gorouter  | to response                        |   app/1   |
-|           | <-------------------------------+ |           | <--------------------------------+ |           |
-|           |                                   |           |                                    |           |
-|           |                                   |           |                                    |           |
-|           | 5. Sends subsequent request       |           | 6. Gorouter routes to the same app |           |
-|           |    with __VCAP_ID__ cookie	|           | instance (app/1)                   |           |
-|           | +-------------------------------> |           | +--------------------------------> |           |
-+-----------+                                   +-----------+                                    +-----------+
 
+### Streaming NATS Messages
+By default, `nats_client` will subscribe to `router.*` subjects:
+```shell
+/var/vcap/jobs/gorouter/bin/nats_client
+
+Subscribing to router.*
+new message with subject: router.register
+{"uris":["some-app.cf.mydomain.com"],"host":"10.1.3.7","port":3000,"tags":null,"private_instance_id":"abea5c4c-4c91-4827-7156-2e9496512903"}
+new message with subject: router.register
+{"uris":["another-app.cf.mydomain.com","*.another-app.cf.my-domain.com"],"host":"10.1.1.73","port":8083,"tls_port":8083,"tags":null,"private_instance_id":"efcc4e10-f705-423c-6ec4-b25e9d4fa327","server_cert_domain_san":"another-app.cf.my-domain.com"}
+(...)
 ```
 
+### Publishing NATS Messages
+You may use the `nats_client` to publish messages such as `router.register` to simulate a CF app starting up:
+```shell
+/var/vcap/jobs/gorouter/bin/nats_client pub router.register '{"host":"httpstat.us","tls_port":443,"server_cert_domain_san":"httpstat.us", "uris":["httpstat.us"]}'
 
-In the simplest case, an end user can start a sticky session by setting the
-`__VCAP_ID__` cookie to desired app instance guid. Gorouter will inspect the
-cookie on the request and forward the request to the correct app instance.
-However, it is unlikely that the end user will know the desired app instance
-guid that they want to send traffic to.
+Publishing message to router.register
+Done
+```
 
-In the most common case, an app initiates a sticky session. In order for an app
-to start a sticky session, the app must return a sticky session cookie in its
-response (Step 3 in the diagram). The default sticky session cookie name is
-`JSESSIONID`. You can configure the cookie names that the routing tier uses for
-sticky sessions by editing the `router.sticky_session_cookie_names` config key
-in the deployment manifest.
-
-When Gorouter receives a response from an app with `JSESSIONID` set, then
-Gorouter will set the `__VCAP_ID__` cookie to the instance guid of the
-responding app with the same expiry as that of `JSESSIONID` (Step 4 in the diagram).
-In subsequent requests, the end user should include the `__VCAP_ID__` cookie
-(Step 5 in the diagram), which is done automatically in web browsers.
-When an end user sens a request to Gorouter with the `__VCAP_ID__` cookie,
-Gorouter will forward the request to the same application instance that
-originally responded (Step 6 in the diagram).
+You can then test the new route and see if the backend can be reached using:
+```shell
+curl http://localhost:8081/200 -H "Host: httpstat.us"
+200 OK%
+```
+(the above example assumes you have gorouter running locally without TLS)
 
 
-## Try it out!
+### Saving the Route Table to Disk
+The `save` command will allow you to store the current route able as a json file.
+```shell
+/var/vcap/jobs/gorouter/bin/nats_client save routes.json
 
-Using the example [Dora app](https://github.com/cloudfoundry/cf-acceptance-tests/tree/db3503add82d01163318d5d1c5f30603efb81055/assets/dora#sticky-sessions),
-you can try sticky sessions for yourself!!!!
+Saving route table to routes.json
+Done
+```
+You can then view and edit the route table to your needs.
 
-## FAQ
+### Loading a Route Table from Disk
+Once you have prepared a route table json file you can load it using the `load` command
+```shell
+/var/vcap/jobs/gorouter/bin/nats_client load routes.json
 
-### What happens when the app instance guid set in the `__VCAP_ID__` cookie is not valid?
+Loading route table from routes.json
+Done
+```
+The routes will not be loaded directly but the contents of `routes.json` will be transformed into `router.register` messages and published to gorouter via NATS in order.
 
-The request will not fail. Gorouter will forward the request to another app instance for
-that route.
+**NOTICE:**
+*Be aware that non-TLS routes that don't get refreshed continuously will be pruned again.*
 
-### What happens if `JSESSIONID` is set on a request from an end user, but `__VCAP_ID__` is not?
-
-The Gorouter will forward request to a random app instance. It does not route
-based on the value of the `JESSIONID` cookie.
-
-### How is `X-CF-App-Instance` header different from sticky sessions?
-
-Using the `X-CF-App-Instance` header a user can route to a specific app _index_.
-For example, an app developer might be trying to debug the 3rd instance of their
-app, which is mysteriously failing. With this header, they can send traffic only
-to the 3rd instance. See [these
-docs](https://docs.cloudfoundry.org/concepts/http-routing.html#app-instance-routing)
-for more information on how to use this header.
-
-### Is `vcap_request_id` related to sticky sessions?
-
-Nope. The `vcap_request_id` header is a random guid that is set by Gorouter on every
-request through the system. The header is used for tracing and correlating specific
-requests. It is not related to the `__VCAP_ID__` cookie, despite the naming
-similarity.
-
-### What happens when I restart my browser?
-
-Restarting your browser will likely clear the `__VCAP_ID__` cookie, effectively
-ending the sticky session. Restarting the browser might or might not clear the
-`JSESSIONID` cookie.  Since the `__VCAP_ID__` cookie is the only header inspected
-for forwarding sticky session requests, only sending the `JSESSIONID` will not
-result in sticky session behavior and may actually result in undesired behavior.
-
-### How can I use a route service (a platform-deployed reverse proxy) in front of an application that relies on sticky sessions?
-Routing Release 0.211.0+: Sticky sessions will now work with platform deployed route services.
-Sticky sessions will continue to work for non-CF deployed route services.
-
-Routing Release <0.211.0: If you deploy a reverse proxy to the platform in front of your app, the backend
-app must return the `JSESSIONID` on every response in order to sticky sessions to
-work.
-
-### How can I tell if I got routed to a different instance than I was expecting?
-
-If the app instance requested in the `__VCAP_ID__` does not exist, then the
-Gorouter will route to another instance of the app. If you want to determine
-when this happens, the app can compare the `__VCAP_ID__` in the response to the
-one in the request.
-
-
-### What about attributes?
-The `__VCAP_ID__` cookie will take _some_ of the attributes from the `JSESSIONID` cookie that is set by the app. [See code here](https://github.com/cloudfoundry/gorouter/blob/379860daa83a162ffe0b6039eafb7c8bfa1eaccf/proxy/round_tripper/proxy_round_tripper.go#L312-L355).
-#### Expiry 
-The `__VCAP_ID__` cookie will always have the same expiry attribute as the `JSESSIONID` cookie that is set by the app.
-#### Samesite 
-The `__VCAP_ID__` cookie will always have the same samesite attribute as the `JSESSIONID` cookie that is set by the app.
-#### Secure 
-The secure attribute on the `__VCAP_ID__` cookie is controlled by two levers: what is set on the `JSESSIONID` cookie by the app and the value of the [router.secure_cookies](https://github.com/cloudfoundry/routing-release/blob/f03f47b1dfe43a90e0717afd0d111e017e8d0fe1/jobs/gorouter/spec#L67-L69) bosh property.
-| router.secure_cookies | `JSESSIONID` is secure? | `__VCAP_ID__` is secure? |
-|-----------------------|-----------------------|------------------------|
-| false | true | true |
-| false | false | false |
-| true | true | true|
-| true | false | true |
-
-#### Max Age 
-If the max age attribute on the `JSESSIONID` cookie that is set by the app is less than 0, then the same value will be set on the `__VCAP_ID__`.
+## When to use it
+There are many scenarios where you may use `nats_client` to debug gorouter issues:
+- Debug retries of failing endpoints
+- Test different kinds of backend errors (e.g. dial timeout, TLS handshake issues, app misbehaving etc.)
+- Debug load balancing algorithms
+- Set up large deployments with hundreds of apps and thousands of routes, without having to actually deploy all of them
+- Simulate outages where large numbers of backends no longer respond (e.g. AZ outages)
+- Simulate NATS outages where apps have moved elsewhere but gorouter didn't get the proper `router.unregister` message
+- etc.

--- a/docs/nats-client.md
+++ b/docs/nats-client.md
@@ -1,0 +1,128 @@
+# Session Affinity
+
+## What is it?
+
+Session affinity, also known as sticky sessions, enables requests from a
+particular client to always reach the same application instance when multiple
+app instances are deployed. This allows apps to store data specific to a user
+session.
+
+## Architecture
+
+```
++-----------+                                   +-----------+                                    +-----------+
+|           |                                   |           |                                    |           |
+|           | 1. Sends request                  |           | 2. Gorouter forwards to app/1      |           |
+|           | +-------------------------------> |           | +--------------------------------> |           |
+|           |                                   |           |                                    |           |
+|           |                                   |           |                                    |           |
+|           | 4. Gorouter adds __VCAP_ID__      |           | 3. App adds JSESSIONID cookie      |           |
+| End User  |    cookie to response             | Gorouter  | to response                        |   app/1   |
+|           | <-------------------------------+ |           | <--------------------------------+ |           |
+|           |                                   |           |                                    |           |
+|           |                                   |           |                                    |           |
+|           | 5. Sends subsequent request       |           | 6. Gorouter routes to the same app |           |
+|           |    with __VCAP_ID__ cookie	|           | instance (app/1)                   |           |
+|           | +-------------------------------> |           | +--------------------------------> |           |
++-----------+                                   +-----------+                                    +-----------+
+
+```
+
+
+In the simplest case, an end user can start a sticky session by setting the
+`__VCAP_ID__` cookie to desired app instance guid. Gorouter will inspect the
+cookie on the request and forward the request to the correct app instance.
+However, it is unlikely that the end user will know the desired app instance
+guid that they want to send traffic to.
+
+In the most common case, an app initiates a sticky session. In order for an app
+to start a sticky session, the app must return a sticky session cookie in its
+response (Step 3 in the diagram). The default sticky session cookie name is
+`JSESSIONID`. You can configure the cookie names that the routing tier uses for
+sticky sessions by editing the `router.sticky_session_cookie_names` config key
+in the deployment manifest.
+
+When Gorouter receives a response from an app with `JSESSIONID` set, then
+Gorouter will set the `__VCAP_ID__` cookie to the instance guid of the
+responding app with the same expiry as that of `JSESSIONID` (Step 4 in the diagram).
+In subsequent requests, the end user should include the `__VCAP_ID__` cookie
+(Step 5 in the diagram), which is done automatically in web browsers.
+When an end user sens a request to Gorouter with the `__VCAP_ID__` cookie,
+Gorouter will forward the request to the same application instance that
+originally responded (Step 6 in the diagram).
+
+
+## Try it out!
+
+Using the example [Dora app](https://github.com/cloudfoundry/cf-acceptance-tests/tree/db3503add82d01163318d5d1c5f30603efb81055/assets/dora#sticky-sessions),
+you can try sticky sessions for yourself!!!!
+
+## FAQ
+
+### What happens when the app instance guid set in the `__VCAP_ID__` cookie is not valid?
+
+The request will not fail. Gorouter will forward the request to another app instance for
+that route.
+
+### What happens if `JSESSIONID` is set on a request from an end user, but `__VCAP_ID__` is not?
+
+The Gorouter will forward request to a random app instance. It does not route
+based on the value of the `JESSIONID` cookie.
+
+### How is `X-CF-App-Instance` header different from sticky sessions?
+
+Using the `X-CF-App-Instance` header a user can route to a specific app _index_.
+For example, an app developer might be trying to debug the 3rd instance of their
+app, which is mysteriously failing. With this header, they can send traffic only
+to the 3rd instance. See [these
+docs](https://docs.cloudfoundry.org/concepts/http-routing.html#app-instance-routing)
+for more information on how to use this header.
+
+### Is `vcap_request_id` related to sticky sessions?
+
+Nope. The `vcap_request_id` header is a random guid that is set by Gorouter on every
+request through the system. The header is used for tracing and correlating specific
+requests. It is not related to the `__VCAP_ID__` cookie, despite the naming
+similarity.
+
+### What happens when I restart my browser?
+
+Restarting your browser will likely clear the `__VCAP_ID__` cookie, effectively
+ending the sticky session. Restarting the browser might or might not clear the
+`JSESSIONID` cookie.  Since the `__VCAP_ID__` cookie is the only header inspected
+for forwarding sticky session requests, only sending the `JSESSIONID` will not
+result in sticky session behavior and may actually result in undesired behavior.
+
+### How can I use a route service (a platform-deployed reverse proxy) in front of an application that relies on sticky sessions?
+Routing Release 0.211.0+: Sticky sessions will now work with platform deployed route services.
+Sticky sessions will continue to work for non-CF deployed route services.
+
+Routing Release <0.211.0: If you deploy a reverse proxy to the platform in front of your app, the backend
+app must return the `JSESSIONID` on every response in order to sticky sessions to
+work.
+
+### How can I tell if I got routed to a different instance than I was expecting?
+
+If the app instance requested in the `__VCAP_ID__` does not exist, then the
+Gorouter will route to another instance of the app. If you want to determine
+when this happens, the app can compare the `__VCAP_ID__` in the response to the
+one in the request.
+
+
+### What about attributes?
+The `__VCAP_ID__` cookie will take _some_ of the attributes from the `JSESSIONID` cookie that is set by the app. [See code here](https://github.com/cloudfoundry/gorouter/blob/379860daa83a162ffe0b6039eafb7c8bfa1eaccf/proxy/round_tripper/proxy_round_tripper.go#L312-L355).
+#### Expiry 
+The `__VCAP_ID__` cookie will always have the same expiry attribute as the `JSESSIONID` cookie that is set by the app.
+#### Samesite 
+The `__VCAP_ID__` cookie will always have the same samesite attribute as the `JSESSIONID` cookie that is set by the app.
+#### Secure 
+The secure attribute on the `__VCAP_ID__` cookie is controlled by two levers: what is set on the `JSESSIONID` cookie by the app and the value of the [router.secure_cookies](https://github.com/cloudfoundry/routing-release/blob/f03f47b1dfe43a90e0717afd0d111e017e8d0fe1/jobs/gorouter/spec#L67-L69) bosh property.
+| router.secure_cookies | `JSESSIONID` is secure? | `__VCAP_ID__` is secure? |
+|-----------------------|-----------------------|------------------------|
+| false | true | true |
+| false | false | false |
+| true | true | true|
+| true | false | true |
+
+#### Max Age 
+If the max age attribute on the `JSESSIONID` cookie that is set by the app is less than 0, then the same value will be set on the `__VCAP_ID__`.

--- a/src/routing_utils/nats_client/.gitignore
+++ b/src/routing_utils/nats_client/.gitignore
@@ -1,0 +1,3 @@
+gorouter.yml
+routes.json
+nats_client


### PR DESCRIPTION
* A short explanation of the proposed change:
- Added "save" and "load" functionality to the nats client in `routing_utils`
- The "save" function stores a gorouter's routing table in a json file
- The "load" function plays back the json file by registering all routes with gorouter again


* An explanation of the use cases your change solves
The main purpose of this functionality is to be able to easily load scenarios where the route table is in a specific state.
This is helpful in debugging problems like the ones mentioned [here](https://github.com/cloudfoundry/routing-release/issues/292) and [here](https://github.com/cloudfoundry/routing-release/issues/285) or [here](https://github.com/cloudfoundry/routing-release/issues/279)

Developers can simply craft a route table as desired instead of having to tweak apps and NATS to behave in such a way that the issue is reproduced.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

1. Deploy nats and gorouter as described in the [README.md](https://github.com/cloudfoundry/gorouter#start)
2. Provide a minimal `gorouter.yml` config file for the nats-client to read. If you started gorouter without a config file, you may use this one:
```
---

status:
  port: 8082
  user:
  pass:

nats:
  tls_enabled: false
  hosts:
  - hostname: localhost
    port: 4222
```
3. Add a few routes. You may use the nats-client or simply curl to send some `router.register` NATS messages.
4. Save the current route table using
```
./nats_client gorouter.yml save routes.json
Saving route table to routes.json
Done
```
5. You should now have a `routes.json` file with a pretty-printed output of the `/routes` endpoint of gorouter. It could look like this:
```
{
  "api.cf.my.domain.com": [
    {
      "address": "10.0.65.66:9024",
      "private_instance_id": "767a8085-3e34-47d6-47b3-1ac87020edad",
      "protocol": "http1",
      "server_cert_domain_san": "api.cf.my.domain.com",
      "tags": {
        "component": "CloudController"
      },
      "tls": true,
      "ttl": 120
    }
  ],
  "cf-app.cf.my.domain.com": [
    {
      "address": "10.0.73.0:61015",
      "private_instance_id": "32e285ab-9b42-4de8-7141-3b87",
      "protocol": "http1",
      "server_cert_domain_san": "32e285ab-9b42-4de8-7141-3b87",
      "tags": {
        "app_id": "e74be186-20f5-4ea8-844b-77895c477c10",
        "app_name": "cf-app",
        "component": "route-emitter",
        "instance_id": "0",
        "organization_id": "bc578e33-bce1-4bce-91c3-a302bcb27ee3",
        "organization_name": "ACME",
        "process_id": "e74be186-20f5-4ea8-844b-77895c477c10",
        "process_instance_id": "32e285ab-9b42-4de8-7141-3b87",
        "process_type": "web",
        "source_id": "e74be186-20f5-4ea8-844b-77895c477c10",
        "space_id": "e646f0e9-1aa3-41f3-b177-9427ec5e7c84",
        "space_name": "dev"
      },
      "tls": true,
      "ttl": 120
    },
(...)
}
```
6. You may now edit the `routes.json` file, e.g. add another route or change an existing one, add more endpoints etc. Be aware that this only works well with TLS routes as non-TLS routes will be pruned shortly after.
7. Use the nats-client to upload the changed routes to gorouter:
```
./nats_client gorouter.yml load routes.json
Loading route table from routes.json
Done
```
8. You can then test the changed routes by curling them, e.g. if you changed the route to `cf-app.cf.my.domain.com`:
```
curl -v http://localhost:8081 -H "Host: cf-app.cf.my.domain.com"
(...)
```
9. You should see the effects in the behavior of gorouter. It will use the changed route instead. Be aware that your changes may be overwritten by route-emitters of the app you changed. So for best results it is recommended to inject a new route that does not exist on any app. 

* Expected result after the change

nats-client can save and restore gorouter route tables using NATS.

* Current result before the change

nats-client can only publish and subscribe to NATS.

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
