### PR TITLE
Adapt gorouter spec for changing router.ca_certs back to an array

### DIFF
--- a/docs/limiting-trusted-cas-for-gorouter.md
+++ b/docs/limiting-trusted-cas-for-gorouter.md
@@ -27,8 +27,8 @@ With `only_trust_client_ca_certs: false`, all the certs in `router.ca_certs`, `r
 
 ```
 router:
-  ca_certs: |
-   a-cert-named-apple
+  ca_certs:
+    - a-cert-named-apple
   client_ca_certs: |
    a-cert-named-cucumber
   only_trust_client_ca_certs: false
@@ -59,8 +59,8 @@ With `only_trust_client_ca_certs: true`, _only_ the certs configured in `router.
 
 ```
 router:
-  ca_certs: |
-   a-cert-named-apple
+  ca_certs:
+   - a-cert-named-apple
   client_ca_certs: |
    a-cert-named-cucumber
   only_trust_client_ca_certs: true

--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -149,7 +149,7 @@ properties:
           -----BEGIN RSA PRIVATE KEY-----
           -----END RSA PRIVATE KEY-----
   router.ca_certs:
-    description: "Required. String of concatenated certificate authorities in PEM format, used to validate server certificates provided by remote systems. Gorouter also trust certificates signed by well-known CAs and by CA certificates installed on the filesystem. These CA certificates are also used to validate client certificates when router.only_trust_client_ca_certs is false."
+    description: "Required. List of Strings of concatenated certificate authorities in PEM format, used to validate server certificates provided by remote systems. Gorouter also trust certificates signed by well-known CAs and by CA certificates installed on the filesystem. These CA certificates are also used to validate client certificates when router.only_trust_client_ca_certs is false."
   router.client_ca_certs:
     description: "Required. String of concatenated certificate authorities in PEM format, used to validate certificates provided by remote systems. By default, Gorouter will trust certificates signed by well-known CAs and by CA certificates installed on the filesystem."
     default: ""

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -369,8 +369,8 @@ params['enable_http2'] = p('router.enable_http2')
 
 if p('router.ca_certs')
   ca_certs = p('router.ca_certs')
-  if !ca_certs.is_a?(String)
-    raise 'ca_certs must be provided as a single string block'
+  if !ca_certs.is_a?(Array)
+    raise 'ca_certs must be provided as an array of strings containing one or more certificates in PEM encoding'
   end
 
   params['ca_certs'] = ca_certs
@@ -382,8 +382,8 @@ if p('router.client_ca_certs')
     raise 'client_ca_certs must be provided as a single string block'
   end
 
-  if p('router.only_trust_client_ca_certs') == false
-    client_ca_certs += ca_certs
+  if p('router.only_trust_client_ca_certs') == false && ca_certs
+    client_ca_certs += "\n" + ca_certs.join("\n")
   end
 
   params['client_ca_certs'] = client_ca_certs

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -159,7 +159,7 @@ describe 'gorouter' do
           'min_tls_version' => 'TLSv1.2',
           'max_tls_version' => 'TLSv1.2',
           'disable_http' => false,
-          'ca_certs' => 'test-certs',
+          'ca_certs' => ['test-certs'],
           'cipher_suites' => 'test-suites',
           'forwarded_client_cert' => ['test-cert'],
           'isolation_segments' => '[is1]',
@@ -602,7 +602,7 @@ describe 'gorouter' do
             context 'when only_trust_client_ca_certs is true' do
               before do
                 deployment_manifest_fragment['router']['client_ca_certs'] = 'cool potato'
-                deployment_manifest_fragment['router']['ca_certs'] = 'lame rhutabega'
+                deployment_manifest_fragment['router']['ca_certs'] = ['lame rhutabega']
                 deployment_manifest_fragment['router']['only_trust_client_ca_certs'] = true
               end
 
@@ -618,13 +618,14 @@ describe 'gorouter' do
             context 'when only_trust_client_ca_certs is false' do
               before do
                 deployment_manifest_fragment['router']['client_ca_certs'] = 'cool potato'
-                deployment_manifest_fragment['router']['ca_certs'] = 'lame rhutabega'
+                deployment_manifest_fragment['router']['ca_certs'] = ['lame rhutabega']
                 deployment_manifest_fragment['router']['only_trust_client_ca_certs'] = false
               end
 
               it 'client_ca_certs do contain ca_certs' do
                 expect(parsed_yaml['client_ca_certs']).to include('cool potato')
                 expect(parsed_yaml['client_ca_certs']).to include('lame rhutabega')
+                expect(parsed_yaml['client_ca_certs']).to include("cool potato\nlame rhutabega")
               end
 
               it 'sets only_trust_client_ca_certs to false' do
@@ -637,7 +638,7 @@ describe 'gorouter' do
         context 'ca_certs' do
           context 'when correct ca_certs is provided' do
             it 'should configure the property' do
-              expect(parsed_yaml['ca_certs']).to eq('test-certs')
+              expect(parsed_yaml['ca_certs']).to eq(['test-certs'])
             end
           end
 
@@ -650,21 +651,21 @@ describe 'gorouter' do
             end
           end
 
-          context 'when a simple array is provided' do
+          context 'when a string is provided' do
             before do
-              deployment_manifest_fragment['router']['ca_certs'] = ['some-tls-cert']
+              deployment_manifest_fragment['router']['ca_certs'] = 'some-tls-cert'
             end
             it 'raises error' do
-              expect { parsed_yaml }.to raise_error(RuntimeError, 'ca_certs must be provided as a single string block')
+              expect { parsed_yaml }.to raise_error(RuntimeError, 'ca_certs must be provided as an array of strings containing one or more certificates in PEM encoding')
             end
           end
 
-          context 'when an empty array is provided' do
+          context 'when an empty string is provided' do
             before do
-              deployment_manifest_fragment['router']['ca_certs'] = []
+              deployment_manifest_fragment['router']['ca_certs'] = ""
             end
             it 'raises error' do
-              expect { parsed_yaml }.to raise_error(RuntimeError, 'ca_certs must be provided as a single string block')
+              expect { parsed_yaml }.to raise_error(RuntimeError, 'ca_certs must be provided as an array of strings containing one or more certificates in PEM encoding')
             end
           end
 
@@ -686,10 +687,10 @@ describe 'gorouter' do
             end
 
             before do
-              deployment_manifest_fragment['router']['ca_certs'] = test_certs
+              deployment_manifest_fragment['router']['ca_certs'] = [test_certs]
             end
             it 'successfully configures the property' do
-              expect(parsed_yaml['ca_certs']).to eq(test_certs)
+              expect(parsed_yaml['ca_certs']).to eq([test_certs])
             end
           end
         end


### PR DESCRIPTION
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

Adaptation of the gorouter configuration file and spec tests to https://github.com/cloudfoundry/gorouter/pull/316.

* An explanation of the use cases your change solves

See https://github.com/cloudfoundry/gorouter/pull/316

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

it's a change in the cf-deployment and in the way how CA certificates are set on the gorouter.

* Expected result after the change

CA certificates for the gorouter can be configured as list, and concatenated via opsfile.

* Current result before the change

the CA certificates for the gorouter is currently a string containing certificates in PEM format.

* Links to any other associated PRs

https://github.com/cloudfoundry/gorouter/pull/316

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
