### PR TITLE
remove empty values in ca cert list

### DIFF
--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -373,7 +373,7 @@ if p('router.ca_certs')
     raise 'ca_certs must be provided as an array of strings containing one or more certificates in PEM encoding'
   end
 
-  params['ca_certs'] = ca_certs
+  params['ca_certs'] = ca_certs.select{ |v| !v.strip.empty? }
 end
 
 if p('router.client_ca_certs')

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -669,6 +669,15 @@ describe 'gorouter' do
             end
           end
 
+          context 'when one of the certs is empty' do
+            before do
+              deployment_manifest_fragment['router']['ca_certs'] = [' ', 'test-certs']
+            end
+            it 'only keeps non-empty certs' do
+              expect(parsed_yaml['ca_certs']).to eq(['test-certs'])
+            end
+          end
+
           context 'when set to a multi-line string' do
             let(:test_certs) do
               '


### PR DESCRIPTION
* A short explanation of the proposed change:

Ignore  empty ca certificate passed to ca_certs property. Before #297 if one of the certs was empty gorouter was still able to add them if there is at least one non-empty certs. Now with the array it adds them one by one and fails if one of them is empty.

* An explanation of the use cases your change solves

One of the certs is empty, e.g. bosh variable was resolved as empty.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

Add an empty ca_cert to list.

* Expected result after the change

Gorouter successfully deploys

* Current result before the change

Gorouter fails during deploy

* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
