### PR TITLE
add gorouter as link; add gorouter backends ca to routing-api

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -30,6 +30,8 @@ packages:
 provides:
   - name: gorouter
     type: http-router
+    properties:
+    - router.backends.ca
 
 consumes:
 - name: nats
@@ -156,6 +158,8 @@ properties:
   router.only_trust_client_ca_certs:
     description: "When router.only_trust_client_ca_certs is true, router.client_ca_certs are the only trusted CA certs for client requests. When router.only_trust_client_ca_certs is false, router.client_ca_certs are trusted in addition to router.ca_certs and the CA certificates installed on the filesystem. This will have no affect if the `router.client_cert_validation` property is set to none."
     default: false
+  router.backends.ca:
+    description: Certificate authority that was used to sign certificates for TLS-registered backends. In PEM format.
   router.backends.cert_chain:
     description: Certificate chain used for client authentication to TLS-registered backends.  In PEM format.
   router.backends.private_key:

--- a/jobs/routing-api/spec
+++ b/jobs/routing-api/spec
@@ -56,6 +56,8 @@ consumes:
   - name: tcp_router
     type: tcp-router
     optional: true
+  - name: gorouter
+    type: http-router
 
 properties:
   routing_api.max_ttl:

--- a/jobs/routing-api/templates/api_mtls_client_ca.crt.erb
+++ b/jobs/routing-api/templates/api_mtls_client_ca.crt.erb
@@ -1,1 +1,6 @@
 <%= p("routing_api.mtls_ca") -%>
+<%if_link("gorouter") do |link| %>
+<%link.if_p("router.backends.ca") do |cert| %>
+<%=cert %>
+<% end %>
+<% end %>

--- a/spec/routing_api_templates_spec.rb
+++ b/spec/routing_api_templates_spec.rb
@@ -15,7 +15,7 @@ describe 'routing_api' do
   let(:merged_manifest_properties) do
     {
       'routing_api' => {
-        'mtls_ca' => 'the ca cert',
+        'mtls_ca' => 'a ca cert',
         'mtls_server_key' => 'the server key',
         'mtls_server_cert' => 'the server cert',
         'mtls_client_cert' => 'the client cert',
@@ -44,10 +44,9 @@ describe 'routing_api' do
 
   describe 'config/certs/routing-api/client_ca.crt' do
     let(:template) { job.template('config/certs/routing-api/client_ca.crt') }
-
     it 'renders the client ca cert' do
       client_ca = template.render(merged_manifest_properties)
-      expect(client_ca).to eq('the ca cert')
+      expect(client_ca.strip).to eq('a ca cert')
     end
 
     describe 'when the client ca is not provided' do
@@ -57,6 +56,64 @@ describe 'routing_api' do
 
       it 'should err' do
         expect { template.render(merged_manifest_properties) }.to raise_error Bosh::Template::UnknownProperty
+      end
+    end
+
+    describe 'when the gorouter link is present and includes the backends ca' do
+      let(:links) do
+        [
+          Bosh::Template::Test::Link.new(
+            name: 'gorouter',
+            properties: {
+              'router' => {
+                'backends' => {
+                  'ca' => 'gorouter backends ca cert'
+                }
+              }
+            }
+          )
+        ]
+      end
+      it 'renders the gorouter backends ca cert' do
+        client_ca = template.render(merged_manifest_properties, consumes: links)
+        expect(client_ca.strip).to eq("a ca cert\n\ngorouter backends ca cert")
+      end
+    end
+
+    describe 'when the link is present and does not include the backends ca cert' do
+      let(:links) do
+        [
+          Bosh::Template::Test::Link.new(
+            name: 'gorouter',
+            properties: {
+              'router' => {}
+            }
+          )
+        ]
+      end
+      it 'does not render the gorouter backends ca cert' do
+        client_ca = template.render(merged_manifest_properties, consumes: links)
+        expect(client_ca.strip).to eq('a ca cert')
+      end
+    end
+    describe 'when the link is present' do
+      let(:links) do
+        [
+          Bosh::Template::Test::Link.new(
+            name: 'gorouter',
+            properties: {
+              'router' => {
+                'backends' => {
+                  'ca' => 'gorouter backends ca cert'
+                }
+              }
+            }
+          )
+        ]
+      end
+      it 'renders the client ca cert' do
+        client_ca = template.render(merged_manifest_properties, consumes: links)
+        expect(client_ca.strip).to eq("a ca cert\n\ngorouter backends ca cert")
       end
     end
   end

--- a/spec/routing_api_templates_spec.rb
+++ b/spec/routing_api_templates_spec.rb
@@ -96,26 +96,6 @@ describe 'routing_api' do
         expect(client_ca.strip).to eq('a ca cert')
       end
     end
-    describe 'when the link is present' do
-      let(:links) do
-        [
-          Bosh::Template::Test::Link.new(
-            name: 'gorouter',
-            properties: {
-              'router' => {
-                'backends' => {
-                  'ca' => 'gorouter backends ca cert'
-                }
-              }
-            }
-          )
-        ]
-      end
-      it 'renders the client ca cert' do
-        client_ca = template.render(merged_manifest_properties, consumes: links)
-        expect(client_ca.strip).to eq("a ca cert\n\ngorouter backends ca cert")
-      end
-    end
   end
 
   describe 'config/certs/routing-api/server.crt' do


### PR DESCRIPTION
Release #1 for putting communication between gorouter (client) and routing-api (server) with mtls.

This PR simply prepares routing-api to trust gorouter by adding the gorouter backends CA to routing-api's list of trusted CA's. If CF-D/TAS is not updated to provide the gorouter cert in the manifest, there will be no user-facing change in behavior.

For context, route-registrar doesn't support passing certs for client-to-server validation (mtls), so we were not able to provide a cert to gorouter that routing-api already trusts. Fortunately gorouter already presents a cert chain for validation to backends, so we were able to give routing-api the CA for gorouter's pre-existingcerts. In the future, we may want to update route registrar to support supplying certs as part of route registration.

Tracker story: https://www.pivotaltracker.com/story/show/183523942
