### PR TITLE
Handle nil ca cert in ca_certs property list

### DIFF
--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -373,7 +373,7 @@ if p('router.ca_certs')
     raise 'ca_certs must be provided as an array of strings containing one or more certificates in PEM encoding'
   end
 
-  params['ca_certs'] = ca_certs.select{ |v| !v.strip.empty? }
+  params['ca_certs'] = ca_certs.select{ |v| !v.nil? && !v.strip.empty? }
 end
 
 if p('router.client_ca_certs')

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -678,6 +678,15 @@ describe 'gorouter' do
             end
           end
 
+          context 'when one of the certs is nil' do
+            before do
+              deployment_manifest_fragment['router']['ca_certs'] = [nil, 'test-certs']
+            end
+            it 'only keeps non-empty certs' do
+              expect(parsed_yaml['ca_certs']).to eq(['test-certs'])
+            end
+          end
+
           context 'when set to a multi-line string' do
             let(:test_certs) do
               '


### PR DESCRIPTION
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

In case if bosh variable was resolved to nil value one of ca_certs might be nil and deploy fails with error: undefined method `strip' for nil:NilClass

* An explanation of the use cases your change solves

Filter out nil values first before checking if they are empty

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

Provide a manifest where one of the certs bosh variable resolve to nil value

* Expected result after the change

Deploy succeeds

* Current result before the change

Deploy fails

* Links to any other associated PRs

https://github.com/cloudfoundry/routing-release/pull/297

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
