### PR TITLE
Add healthchecker package to sync-package-specs file

### DIFF
--- a/packages/gorouter/spec
+++ b/packages/gorouter/spec
@@ -12,8 +12,9 @@ files:
   - code.cloudfoundry.org/gorouter/**/*.{go,golden,proto,c,h,}
   - code.cloudfoundry.org/gorouter/LICENSE
   - code.cloudfoundry.org/gorouter/NOTICE
-  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/cf-networking-helpers/healthchecker/**/*.go
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/lagerflags/**/*.go
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/cf-networking-helpers/healthchecker/config/*.go # gosub
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/cf-networking-helpers/healthchecker/watchdog/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/cfhttp/v2/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/clock/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/debugserver/*.go # gosub
@@ -70,12 +71,14 @@ files:
   - code.cloudfoundry.org/gorouter/test_util/rss/common/*.go # gosub
   - code.cloudfoundry.org/gorouter/varz/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/*.go # gosub
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/lagerflags/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/localip/*.go # gosub
   - code.cloudfoundry.org/routing-api/*.go # gosub
   - code.cloudfoundry.org/routing-api/models/*.go # gosub
   - code.cloudfoundry.org/routing-api/uaaclient/*.go # gosub
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/tlsconfig/*.go # gosub
   - code.cloudfoundry.org/trace-logger/*.go # gosub
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/cf-networking-helpers/healthchecker/cmd/healthchecker/*.go # gosub
   - code.cloudfoundry.org/vendor/github.com/armon/go-proxyproto/*.go # gosub
   - code.cloudfoundry.org/vendor/github.com/beorn7/perks/quantile/*.go # gosub
   - code.cloudfoundry.org/vendor/github.com/bmizerany/pat/*.go # gosub

--- a/scripts/sync-package-specs
+++ b/scripts/sync-package-specs
@@ -42,7 +42,9 @@ function sync_package() {
 sync_package tcp_router        -app code.cloudfoundry.org/cf-tcp-router/... &
 sync_package routing-api       -app code.cloudfoundry.org/routing-api/cmd/... &
 sync_package rtr               -app code.cloudfoundry.org/routing-api-cli/... &
-sync_package gorouter          -app code.cloudfoundry.org/gorouter/... &
+sync_package gorouter \
+  -app code.cloudfoundry.org/gorouter/... \
+  -app code.cloudfoundry.org/vendor/code.cloudfoundry.org/cf-networking-helpers/healthchecker/cmd/healthchecker &
 sync_package route_registrar   -app code.cloudfoundry.org/route-registrar/... &
 sync_package acceptance_tests \
   -test code.cloudfoundry.org/routing-acceptance-tests/... \


### PR DESCRIPTION
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

Instead of manually adding healthcheck package add it to the list of gorouter sync packages in scripts/sync-package-specs file.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
