### PR TITLE
ignore junk certs for backwards compatibility

### DIFF
--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -35,6 +35,16 @@ def validate_max_header_kb (kb)
   kb * 1024
 end
 
+def get_valid_ca_certs
+  ca_certs = p('router.ca_certs')
+
+  if !ca_certs.is_a?(Array)
+    raise 'ca_certs must be provided as an array of strings containing one or more certificates in PEM encoding'
+  end
+
+  ca_certs.select{ |v| !v.nil? && !v.strip.empty? && v.length > 50 }
+end
+
 parse_ip(p('router.debug_address'), 'router.debug_address')
 
 access_log_file = p('router.write_access_logs_locally') ? '/var/vcap/sys/log/gorouter/access.log' : ''
@@ -368,12 +378,7 @@ params['disable_http'] = p('router.disable_http')
 params['enable_http2'] = p('router.enable_http2')
 
 if p('router.ca_certs')
-  ca_certs = p('router.ca_certs')
-  if !ca_certs.is_a?(Array)
-    raise 'ca_certs must be provided as an array of strings containing one or more certificates in PEM encoding'
-  end
-
-  params['ca_certs'] = ca_certs.select{ |v| !v.nil? && !v.strip.empty? }
+  params['ca_certs'] = get_valid_ca_certs
 end
 
 if p('router.client_ca_certs')
@@ -381,6 +386,8 @@ if p('router.client_ca_certs')
   if !client_ca_certs.is_a?(String)
     raise 'client_ca_certs must be provided as a single string block'
   end
+
+  ca_certs = get_valid_ca_certs
 
   if p('router.only_trust_client_ca_certs') == false && ca_certs
     client_ca_certs += "\n" + ca_certs.join("\n")

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -159,7 +159,7 @@ describe 'gorouter' do
           'min_tls_version' => 'TLSv1.2',
           'max_tls_version' => 'TLSv1.2',
           'disable_http' => false,
-          'ca_certs' => ['test-certs'],
+          'ca_certs' => [TEST_CERT],
           'cipher_suites' => 'test-suites',
           'forwarded_client_cert' => ['test-cert'],
           'isolation_segments' => '[is1]',
@@ -617,15 +617,14 @@ describe 'gorouter' do
 
             context 'when only_trust_client_ca_certs is false' do
               before do
-                deployment_manifest_fragment['router']['client_ca_certs'] = 'cool potato'
-                deployment_manifest_fragment['router']['ca_certs'] = ['lame rhutabega']
+                deployment_manifest_fragment['router']['client_ca_certs'] = TEST_CERT
+                deployment_manifest_fragment['router']['ca_certs'] = [TEST_CERT2, 'cert-too-short']
                 deployment_manifest_fragment['router']['only_trust_client_ca_certs'] = false
               end
 
-              it 'client_ca_certs do contain ca_certs' do
-                expect(parsed_yaml['client_ca_certs']).to include('cool potato')
-                expect(parsed_yaml['client_ca_certs']).to include('lame rhutabega')
-                expect(parsed_yaml['client_ca_certs']).to include("cool potato\nlame rhutabega")
+              it 'client_ca_certs contain only valid ca_certs' do
+                expect(parsed_yaml['client_ca_certs']).to_not include('cert-too-short')
+                expect(parsed_yaml['client_ca_certs']).to eq("#{TEST_CERT}\n#{TEST_CERT2}")
               end
 
               it 'sets only_trust_client_ca_certs to false' do
@@ -638,7 +637,7 @@ describe 'gorouter' do
         context 'ca_certs' do
           context 'when correct ca_certs is provided' do
             it 'should configure the property' do
-              expect(parsed_yaml['ca_certs']).to eq(['test-certs'])
+              expect(parsed_yaml['ca_certs']).to eq([TEST_CERT])
             end
           end
 
@@ -671,19 +670,28 @@ describe 'gorouter' do
 
           context 'when one of the certs is empty' do
             before do
-              deployment_manifest_fragment['router']['ca_certs'] = [' ', 'test-certs']
+              deployment_manifest_fragment['router']['ca_certs'] = [' ', TEST_CERT]
             end
             it 'only keeps non-empty certs' do
-              expect(parsed_yaml['ca_certs']).to eq(['test-certs'])
+              expect(parsed_yaml['ca_certs']).to eq([TEST_CERT])
             end
           end
 
           context 'when one of the certs is nil' do
             before do
-              deployment_manifest_fragment['router']['ca_certs'] = [nil, 'test-certs']
+              deployment_manifest_fragment['router']['ca_certs'] = [nil, TEST_CERT]
             end
             it 'only keeps non-empty certs' do
-              expect(parsed_yaml['ca_certs']).to eq(['test-certs'])
+              expect(parsed_yaml['ca_certs']).to eq([TEST_CERT])
+            end
+          end
+
+          context 'when one of the certs is less than 50 char' do
+            before do
+              deployment_manifest_fragment['router']['ca_certs'] = ['meow-meow-meow-meow', TEST_CERT]
+            end
+            it 'only keeps longer value certs' do
+              expect(parsed_yaml['ca_certs']).to eq([TEST_CERT])
             end
           end
 


### PR DESCRIPTION
In [0.248.0](https://github.com/cloudfoundry/routing-release/releases/tag/v0.248.0) we started handing ca_certs as a list. Before that time if you entered some junk in the string for ca_certs everything, somehow, would not fail. In 0.248.0 and later an invalid cert (like "meow" for instance) would fail. Adding this check to throw out certs less than 50 characters for backwards compatibility. 