### PR TITLE
fix(nats-client): set route-service-url during route load

### DIFF
--- a/src/routing_utils/nats_client/main.go
+++ b/src/routing_utils/nats_client/main.go
@@ -348,6 +348,7 @@ func loadRoutes(natsConn *nats.Conn, filename string) error {
 				Tags:                    route.Tags,
 				App:                     route.Tags["app_id"],
 				StaleThresholdInSeconds: route.TTL,
+				RouteServiceURL:         route.RouteServiceUrl,
 				PrivateInstanceID:       route.PrivateInstanceId,
 				IsolationSegment:        route.IsolationSegment,
 				ServerCertDomainSAN:     route.ServerCertDomainSAN,


### PR DESCRIPTION
* A short explanation of the proposed change:
During testing I found out that we forgot to set a the route-service-url while loading routes from a file.

* An explanation of the use cases your change solves
Route-service-URL is now set in the endpoint pool after load.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
