### PR TITLE
feat: Add protocol field in route-registrar spec

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -101,6 +101,7 @@ properties:
         tls_port (required, integer, for http routes): Either `port` or `tls_port` are required; if both are provided, Gorouter will prefer tls_port.
           Requests for associated URIs will be forwarded over TLS by the router to this port.
           The IP is determined automatically from the host on which route-registrar is run.
+        protocol (optional, string): 'http1' or 'http2'. If not provided, Gorouter uses 'http1' as default.
         route_service_url (optional, string, for http routes): When valid route service URL is provided, Gorouter will proxy requests received for the uris above to the specified route service URL.
         server_cert_domain_san (conditional, string, for http routes): Required if tls_port is present.
           Gorouter will validate that the TLS certificate presented by the destination host contains this as a Subject Alternative Name (SAN).

--- a/jobs/route_registrar/templates/registrar_settings.json.erb
+++ b/jobs/route_registrar/templates/registrar_settings.json.erb
@@ -66,6 +66,10 @@
       raise "expected route_registrar.routes[#{index}].route.server_cert_domain_san when tls_port is provided"
     end
 
+    if route['protocol'] != nil && (route['protocol'] != 'http1' && route['protocol'] != 'http2')
+      raise "expected route_registrar.routes[#{index}].route.protocol to be http1 or http2 when protocol is provided"
+    end
+
     if route['prepend_instance_index']
       route['uris'].map! { |uri| "#{spec.index}-#{uri}" }
     end

--- a/spec/route_registar_templates_spec.rb
+++ b/spec/route_registar_templates_spec.rb
@@ -439,6 +439,25 @@ describe 'route_registrar' do
         expect { template.render(merged_manifest_properties, consumes: links) }.not_to raise_error
       end
     end
+
+    describe 'when protocol is provided' do
+      it 'uses configured protocol http1' do
+        merged_manifest_properties['route_registrar']['routes'][0]['protocol'] = 'http1'
+        rendered_hash = JSON.parse(template.render(merged_manifest_properties, consumes: links))
+        expect(rendered_hash['routes'][0]['protocol']).to eq('http1')
+      end
+      it 'uses configured protocol http2' do
+        merged_manifest_properties['route_registrar']['routes'][0]['protocol'] = 'http2'
+        rendered_hash = JSON.parse(template.render(merged_manifest_properties, consumes: links))
+        expect(rendered_hash['routes'][0]['protocol']).to eq('http2')
+      end
+      it 'raises error for invalid protocol' do
+        merged_manifest_properties['route_registrar']['routes'][0]['protocol'] = 'abc'
+        expect { template.render(merged_manifest_properties, consumes: links) }.to raise_error(
+          RuntimeError, 'expected route_registrar.routes[0].route.protocol to be http1 or http2 when protocol is provided'
+        )
+      end
+    end
   end
 end
 


### PR DESCRIPTION
* A short explanation of the proposed change: The current route-registrar spec has no option to define protocol for registered routes. It makes impossible to register a HTTP/2 route. The change enhances route-registrar spec with protocol property in order to support publishing HTTP/2 routes

* An explanation of the use cases your change solves: Related to https://github.com/cloudfoundry/routing-release/issues/320

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics): Route-registrar manifest change. If route.protocol is provided, the provided value should be used. Otherwise the protocol remains empty and Gorouter uses http1 route.

* Expected result after the change

* Current result before the change

* Links to any other associated PRs: https://github.com/cloudfoundry/route-registrar/pull/32

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
