### PR TITLE
feat(gorouter): provide option to log more details

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -236,6 +236,9 @@ properties:
   router.logging_level:
     description: "Log level for router"
     default: "info"
+  router.enable_log_attempts_details:
+    description: "Log additional fields in the access log that provide more details on the specific timings and attempts performed towards endpoints."
+    default: false
   router.logging.format.timestamp:
     description: |
       Format for timestamp in component logs. Valid values are 'rfc3339', 'deprecated', and 'unix-epoch'."

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -336,6 +336,7 @@ params['logging'] = {
   'disable_log_forwarded_for' => p('router.disable_log_forwarded_for'),
   'disable_log_source_ip' => p('router.disable_log_source_ip'),
   'redact_query_params' => p('router.redact_query_parameters'),
+  'enable_attempts_details' => p('router.enable_log_attempts_details'),
   'format' => {
     'timestamp' => timestamp_format,
   },

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -1062,6 +1062,21 @@ describe 'gorouter' do
             expect { parsed_yaml }.to raise_error(RuntimeError, "'meow' is not a valid timestamp format for the property 'router.logging.format.timestamp'. Valid options are: 'rfc3339', 'deprecated', and 'unix-epoch'.")
           end
         end
+
+        context 'when enable_detailed_attempts_logging is not provided' do
+          it 'it defaults to false' do
+            expect(parsed_yaml['logging']['enable_attempts_details']).to eq(false)
+          end
+        end
+
+        context 'when enable_detailed_attempts_logging is set to true' do
+          before do
+            deployment_manifest_fragment['router']['enable_log_attempts_details'] = true
+          end
+          it 'it properly sets the value' do
+            expect(parsed_yaml['logging']['enable_attempts_details']).to eq(true)
+          end
+        end
       end
 
       context 'tracing' do


### PR DESCRIPTION
This commit bumps gorouter to include the new feature flag that allows logging of additional fields in the access log. Those fields provide additional information on the attempts that were performed and the timings of the request. The feature flag is exposed in the gorouter job as `router.log_attempts_details` and defaults to false.

To-Do: bump gorouter once the PR got merged


* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `develop` branch
* [X] I have run all the unit tests using `scripts/run-unit-tests-in-docker`
* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite
* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
