### PR TITLE
Don't break route_registrar if multiple CAs are provided in the manifest

### DIFF
--- a/jobs/route_registrar/templates/ca.crt.erb
+++ b/jobs/route_registrar/templates/ca.crt.erb
@@ -1,3 +1,3 @@
 <% if_p('route_registrar.routing_api.ca_certs') do |value| %>
-<%= value.join('\n') %>
+<%= value.join("\n") %>
 <% end %>


### PR DESCRIPTION
Previously, when joining multiple CAs, the route-registrar job would join them with a literal `\n` rather than an actual newline. 