### PR TITLE
Downgrade current version cf-cli-8-linux bosh pkg

### DIFF
--- a/.final_builds/packages/cf-cli-8-linux/index.yml
+++ b/.final_builds/packages/cf-cli-8-linux/index.yml
@@ -3,4 +3,8 @@ builds:
     version: 7f74e3b6498df62fa50a16a85aa3d7de54fc5f0acea023afa01c70f42e1ed556
     blobstore_id: e9a1779e-eb7c-4f9f-6541-f9dd6a82000b
     sha1: sha256:8f9a7107f3f80f07f52b8475c522e797638a1f1de2172d2fc5fb7c70293d5440
+  7fdc3224d0ad03e5eb5debcd2c97922f7e10f786593a002251af9dd5e5adc5b5:
+    version: 7fdc3224d0ad03e5eb5debcd2c97922f7e10f786593a002251af9dd5e5adc5b5
+    blobstore_id: 685cbe05-834b-49b4-7a64-d5549f476504
+    sha1: sha256:4756446413db640299dd7da7fee287d3c20564fe5fc2233c0ebc1ce6bf5bedc1
 format-version: "2"

--- a/packages/cf-cli-8-linux/spec.lock
+++ b/packages/cf-cli-8-linux/spec.lock
@@ -1,2 +1,2 @@
 name: cf-cli-8-linux
-fingerprint: 7f74e3b6498df62fa50a16a85aa3d7de54fc5f0acea023afa01c70f42e1ed556
+fingerprint: 7fdc3224d0ad03e5eb5debcd2c97922f7e10f786593a002251af9dd5e5adc5b5


### PR DESCRIPTION
## A short explanation of the proposed change:
Version 1.46.0 of the cf-cli-release is erroneous. See this commit: https://github.com/bosh-packages/cf-cli-release/commit/c06568002e66d2593c81f9272f3b88fadd659c14

We will need to wait until they fix and release an actual v1.46.0 before we can upgrade again.

For now we are going to downgrade to `v1.44.0` of the bosh package. https://github.com/bosh-packages/cf-cli-release/blob/c06568002e66d2593c81f9272f3b88fadd659c14/releases/cf-cli/cf-cli-1.44.0.yml#L50-L54


## An explanation of the use cases your change solves
The BOSH release refers to a package that the original authors did not intend to distribute. If we release with this package version we will be using an unsupported version and may deal with bosh package issues down the road during the upgrade of `routing-release` from a later version.

## Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
None. This should just compile/deploy without issue.

## Expected result after the change
* `develop` branch of `routing-release` contains `cf-cli-8-linux` package from `v1.44.0` tag of `cf-cli-release`, safe to distribute when we finalize a new `routing-release`


## Current result before the change
* `develop` branch of `routing-release` contains unsupported `cf-cli-8-linux` package from `v1.45.0` tag of `cf-cli-release`

