### PR TITLE
Add Otel Collector port to list of reserved ports

### DIFF
--- a/jobs/gorouter/templates/pre-start.erb
+++ b/jobs/gorouter/templates/pre-start.erb
@@ -17,6 +17,7 @@ tee_output_to_sys_log "${LOG_DIR}" "pre-start" <%= p("router.logging.format.time
     loggregator_agent_port = 3459
     metrics_agent_port = 3461
     monit_port = 2822
+    otel_collector_port = 3462
     syslog_agent_port = 3460
 
     ports.append(bosh_agent_port)
@@ -24,6 +25,7 @@ tee_output_to_sys_log "${LOG_DIR}" "pre-start" <%= p("router.logging.format.time
     ports.append(forwarder_agent_port)
     ports.append(loggregator_agent_port)
     ports.append(monit_port)
+    ports.append(otel_collector_port)
     ports.append(syslog_agent_port)
     ports.append(metrics_agent_port)
 


### PR DESCRIPTION
# What is this change about?

Deployments may now include a new `otel-collector` job listening on a new port. We'd like to ensure that this port is marked as reserved so that it is not claimed as an ephemeral port which might make the collector error on startup.

# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [X] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

# Backwards Compatibility

This reduces the set of ephemeral ports available by 1, which should not have a real-world impact.

# How should this be tested?

Run:

```
$ bosh ssh router/0
$ cat /proc/sys/net/ipv4/ip_local_reserved_ports
```

Port 3462 should be listed in the ranges output.

# Additional Context

See the [community RFC](https://github.com/cloudfoundry/community/blob/3ec376e4345787bc0e9e25e7965c5083b63db822/toc/rfc/rfc-0018-aggregate-metric-egress-with-opentelemetry-collector.md) for more background.

# PR Checklist
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have made this pull request to the `develop` branch.
* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#in-a-docker-container) using `scripts/run-unit-tests-in-docker`.
* [X] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).
