### PR TITLE
fix(gorouter): add missing system component ports to reserved ports list

### DIFF
--- a/jobs/gorouter/templates/pre-start.erb
+++ b/jobs/gorouter/templates/pre-start.erb
@@ -7,25 +7,25 @@ source /var/vcap/packages/routing_utils/syslog_utils.sh
 tee_output_to_sys_log "${LOG_DIR}" "pre-start" <%= p("router.logging.format.timestamp") %>
 
 <%
-    ports = []
 
-    # the following ports are not available via bosh links and are fragile
-    # or they are available via a link, but they are in an addon, so links don't work
-    bosh_agent_port = 2825
-    bosh_dns_ports = [8853, 53080]
-    forwarder_agent_port = 3458
-    loggregator_agent_port = 3459
-    metrics_agent_port = 3461
-    monit_port = 2822
-    syslog_agent_port = 3460
-
-    ports.append(bosh_agent_port)
-    ports.concat(bosh_dns_ports)
-    ports.append(forwarder_agent_port)
-    ports.append(loggregator_agent_port)
-    ports.append(monit_port)
-    ports.append(syslog_agent_port)
-    ports.append(metrics_agent_port)
+    # The following ports are manually specified for one of the following
+    # reasons:
+    # * Not available via bosh links and fragile.
+    # * From bosh add-ons, so bosh links don't work.
+    ports = [
+        2822, # Monit
+        2825, # Bosh Agent
+        3457, 14829, # UDP Forwarder
+        3458, 14823, # Forwarder Agent
+        3459, 14824, # Loggregator Agent
+        3460, 14822, # Syslog Agent
+        3461, 14726, 14727, # Metrics Agent
+        8853, 53080, # Bosh DNS
+        14821, # Prom Scraper
+        14830, # OTel Collector
+        15821, # Metrics Discovery Registrar
+        53035, # System Metrics Agent
+    ]
 
     # the following ports are set in this release
     ports.append(p("router.port")) # has default. will always exist.


### PR DESCRIPTION
---
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

# What is this change about?

GoRouter was missing some of the system component ports that we'd like to be reserved from being claimed as ephemeral ports.

# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [ ] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [x] `[Bug Fix]`: the change addresses a defect

# Backwards Compatibility

This reduces the set of ephemeral ports available by 10, which should not have any discernible impact.

# How should this be tested?

Run:

```
$ bosh ssh router/0
$ cat /proc/sys/net/ipv4/ip_local_reserved_ports
```

The new ports should be included in the ranges output.

# Additional Context

See the [community RFC](https://github.com/cloudfoundry/community/blob/3ec376e4345787bc0e9e25e7965c5083b63db822/toc/rfc/rfc-0018-aggregate-metric-egress-with-opentelemetry-collector.md) for more background.

# PR Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have made this pull request to the `develop` branch.
* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#in-a-docker-container) using `scripts/run-unit-tests-in-docker`.
* [x] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

