### PR TITLE
Rspec lint the gorouter template tests

### DIFF
--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -173,7 +173,7 @@ describe 'gorouter' do
           'enable_proxy' => false,
           'force_forwarded_proto_https' => false,
           'sanitize_forwarded_proto' => false,
-          'hop_by_hop_headers_to_filter' => ["X-ME", "X-Foo"],
+          'hop_by_hop_headers_to_filter' => %w[X-ME X-Foo],
           'suspend_pruning_if_nats_unavailable' => false,
           'max_idle_connections' => 100,
           'keep_alive_probe_interval' => '1s',
@@ -371,7 +371,7 @@ describe 'gorouter' do
 
       describe 'hop_by_hop_headers_to_filter' do
         it 'should set hop_by_hop_headers_to_filter' do
-          expect(parsed_yaml['hop_by_hop_headers_to_filter']).to eq(["X-ME","X-Foo"])
+          expect(parsed_yaml['hop_by_hop_headers_to_filter']).to eq(%w[X-ME X-Foo])
         end
       end
 


### PR DESCRIPTION
# What is this change about?

In https://github.com/cloudfoundry/routing-release/pull/331, we added some new template tests. They pass but contained some minor linting issues.

Fixes:
```
spec/gorouter_templates_spec.rb:176:45: C: [Correctable] Style/WordArray: Use %w or %W for an array of words.
          'hop_by_hop_headers_to_filter' => ["X-ME", "X-Foo"],
                                            ^^^^^^^^^^^^^^^^^
spec/gorouter_templates_spec.rb:176:46: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
          'hop_by_hop_headers_to_filter' => ["X-ME", "X-Foo"],
                                             ^^^^^^
spec/gorouter_templates_spec.rb:176:54: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
          'hop_by_hop_headers_to_filter' => ["X-ME", "X-Foo"],
                                                     ^^^^^^^
spec/gorouter_templates_spec.rb:374:69: C: [Correctable] Style/WordArray: Use %w or %W for an array of words.
          expect(parsed_yaml['hop_by_hop_headers_to_filter']).to eq(["X-ME","X-Foo"])
                                                                    ^^^^^^^^^^^^^^^^
spec/gorouter_templates_spec.rb:374:70: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
          expect(parsed_yaml['hop_by_hop_headers_to_filter']).to eq(["X-ME","X-Foo"])
                                                                     ^^^^^^
spec/gorouter_templates_spec.rb:374:76: C: [Correctable] Layout/SpaceAfterComma: Space missing after comma.
          expect(parsed_yaml['hop_by_hop_headers_to_filter']).to eq(["X-ME","X-Foo"])
                                                                           ^
spec/gorouter_templates_spec.rb:374:77: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
          expect(parsed_yaml['hop_by_hop_headers_to_filter']).to eq(["X-ME","X-Foo"])

```
# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [ ] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [X] `[Bug Fix]`: the change addresses a defect

_If you have selected multiple of the above, it may be wise to consider splitting this PR into multiple PRs to decrease the time for minor changes + bugs to be resolved._

# Backwards Compatibility

N / A

# How should this be tested?

This fixes an issue in CI.

