### PR TITLE
Bump routing-release from go 1.20 → 1.21

### DIFF
--- a/jobs/acceptance_tests/spec
+++ b/jobs/acceptance_tests/spec
@@ -7,7 +7,7 @@ templates:
   bpm.yml.erb: config/bpm.yml
 
 packages:
- - golang-1.20-linux
+ - golang-1.21-linux
  - acceptance_tests
  - rtr
  - cf-cli-8-linux

--- a/jobs/smoke_tests/spec
+++ b/jobs/smoke_tests/spec
@@ -7,7 +7,7 @@ templates:
   bpm.yml.erb: config/bpm.yml
 
 packages:
- - golang-1.20-linux
+ - golang-1.21-linux
  - acceptance_tests
  - cf-cli-8-linux
 

--- a/packages/acceptance_tests/spec
+++ b/packages/acceptance_tests/spec
@@ -3,7 +3,7 @@ name: acceptance_tests
 
 dependencies:
   - rtr
-  - golang-1.20-linux
+  - golang-1.21-linux
 
 files:
   - code.cloudfoundry.org/go.mod

--- a/packages/golang-1.20-linux/spec.lock
+++ b/packages/golang-1.20-linux/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1.20-linux
-fingerprint: 29f2024e7d815be0694944c3c3c9512914a36a31d5fa1b2cbd2452c8d331ce90

--- a/packages/gorouter/spec
+++ b/packages/gorouter/spec
@@ -2,7 +2,7 @@
 name: gorouter
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 
 files:
   - jq/jq-1.6-linux64.tgz

--- a/packages/route_registrar/spec
+++ b/packages/route_registrar/spec
@@ -2,7 +2,7 @@
 name: route_registrar
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 
 files:
   - code.cloudfoundry.org/go.mod

--- a/packages/routing-api/spec
+++ b/packages/routing-api/spec
@@ -2,7 +2,7 @@
 name: routing-api
 
 dependencies:
-  - golang-1.20-linux
+  - golang-1.21-linux
 
 files:
   - code.cloudfoundry.org/go.mod

--- a/packages/routing_utils/spec
+++ b/packages/routing_utils/spec
@@ -2,7 +2,7 @@
 name: routing_utils
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 
 files:
   - routing_utils/pid_utils.sh

--- a/packages/rtr/spec
+++ b/packages/rtr/spec
@@ -2,7 +2,7 @@
 name: rtr
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 
 files:
   - code.cloudfoundry.org/go.mod

--- a/packages/tcp_router/spec
+++ b/packages/tcp_router/spec
@@ -2,7 +2,7 @@
 name: tcp_router
 
 dependencies:
-  - golang-1.20-linux
+  - golang-1.21-linux
 
 files:
   - code.cloudfoundry.org/go.mod


### PR DESCRIPTION
# What is this change about?

This is a  follow up to these commits:
- https://github.com/cloudfoundry/routing-release/commit/fa98f47bce255ba59aff9fdcd7baf295f73b1d5c
- https://github.com/cloudfoundry/routing-release/commit/b8d980d5add03d76aef40ac0149d873446929da0

This commit modifies the packaging and job specs to make use of the new `golang-1.21-linux` package and removes the old `golang-1.20-linux` package.

# Additional Context

I tested that the new packaged compiled without issue:
```
$ bosh -d compilation-workspace export-release 'routing/0.278.0+dev.1' 'ubuntu-jammy/1.117'
...
Task 38 | 21:44:37 | Preparing package compilation: Finding packages to compile (00:00:00)
Task 38 | 21:44:37 | Compiling packages: haproxy/0299c2fc6fc05efbf771bfa060c0a2710c28ce8e06a861c021bc8e40eacb826c
Task 38 | 21:44:37 | Compiling packages: cf-cli-8-linux/7fdc3224d0ad03e5eb5debcd2c97922f7e10f786593a002251af9dd5e5adc5b5
Task 38 | 21:44:37 | Compiling packages: routing-golang-1-linux/b09468ac73cd3350333a35eb09c980c6a06c5465be0e1ba430da62757dc10a04
Task 38 | 21:44:37 | Compiling packages: golang-1.21-linux/5f8410048c01132524ba5d6c608c89fbe8f84de70be8fcafe10cb9490bcd813d
Task 38 | 21:45:40 | Compiling packages: cf-cli-8-linux/7fdc3224d0ad03e5eb5debcd2c97922f7e10f786593a002251af9dd5e5adc5b5 (00:01:03)
Task 38 | 21:45:58 | Compiling packages: golang-1.21-linux/5f8410048c01132524ba5d6c608c89fbe8f84de70be8fcafe10cb9490bcd813d (00:01:21)
Task 38 | 21:45:58 | Compiling packages: routing-api/02208e8e29a1b6a9f5f826a2322edfa945c0005f5da5707bc52453a23169f97e
Task 38 | 21:45:58 | Compiling packages: route_registrar/08d828e66c75c53f594d18b8ea819600d260229dd6e55a83b643e54640d4f986
Task 38 | 21:45:58 | Compiling packages: gorouter/fe6c71a6c6a36e7a7a5c59bd7847c9501060acb032a5a853de50625c29797014
Task 38 | 21:45:58 | Compiling packages: tcp_router/2912070b5fa2803d3b9c3a8d7e49456bc921be500170e111cca6cb6eafcc7e87
Task 38 | 21:46:18 | Compiling packages: routing-golang-1-linux/b09468ac73cd3350333a35eb09c980c6a06c5465be0e1ba430da62757dc10a04 (00:01:41)
Task 38 | 21:46:18 | Compiling packages: routing_utils/4a4907e5cd8d5eecf5444a897a4032987fa7edb8787efdb1d72a9e8a0d189140
Task 38 | 21:46:47 | Compiling packages: gorouter/fe6c71a6c6a36e7a7a5c59bd7847c9501060acb032a5a853de50625c29797014 (00:00:49)
Task 38 | 21:46:47 | Compiling packages: rtr/162fc334a951c461102b821aeed1830bc28ab0d4e5cf8d4f9cd77e2ce926cc93
Task 38 | 21:46:51 | Compiling packages: routing-api/02208e8e29a1b6a9f5f826a2322edfa945c0005f5da5707bc52453a23169f97e (00:00:53)
Task 38 | 21:46:51 | Compiling packages: routing-healthchecker/dd3ad48dff9709bd19d58a00455fd39719adf392db8050a46b0d95ffea94406d
Task 38 | 21:46:53 | Compiling packages: routing_utils/4a4907e5cd8d5eecf5444a897a4032987fa7edb8787efdb1d72a9e8a0d189140 (00:00:35)
Task 38 | 21:47:03 | Compiling packages: rtr/162fc334a951c461102b821aeed1830bc28ab0d4e5cf8d4f9cd77e2ce926cc93 (00:00:16)
Task 38 | 21:47:03 | Compiling packages: acceptance_tests/0d33aaaf7d37db006fbb9d46935436ca8f5dac7afe024558fce7ab32d38e952b
Task 38 | 21:47:17 | Compiling packages: route_registrar/08d828e66c75c53f594d18b8ea819600d260229dd6e55a83b643e54640d4f986 (00:01:19)
Task 38 | 21:47:17 | Compiling packages: tcp_router/2912070b5fa2803d3b9c3a8d7e49456bc921be500170e111cca6cb6eafcc7e87 (00:01:19)
Task 38 | 21:47:27 | Compiling packages: routing-healthchecker/dd3ad48dff9709bd19d58a00455fd39719adf392db8050a46b0d95ffea94406d (00:00:36)
Task 38 | 21:47:31 | Compiling packages: haproxy/0299c2fc6fc05efbf771bfa060c0a2710c28ce8e06a861c021bc8e40eacb826c (00:02:54)
Task 38 | 21:48:03 | Compiling packages: acceptance_tests/0d33aaaf7d37db006fbb9d46935436ca8f5dac7afe024558fce7ab32d38e952b (00:01:00)
Task 38 | 21:48:28 | copying packages: acceptance_tests/0d33aaaf7d37db006fbb9d46935436ca8f5dac7afe024558fce7ab32d38e952b (00:00:00)
...
...

Task 38 Started  Tue Aug 29 21:44:37 UTC 2023
Task 38 Finished Tue Aug 29 21:48:31 UTC 2023
Task 38 Duration 00:03:54
Task 38 done

Succeeded
```