### PR TITLE
LB's CA Cert would be available by default

### DIFF
--- a/bin/prepare-cf-deployment-env.bash
+++ b/bin/prepare-cf-deployment-env.bash
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -eu
-set -o pipefail
-
-upload_cert_to_credhub


### PR DESCRIPTION
# What is this change about?

when an enviornment is spun up, we need LB's CA Cert for running route_services tests, so it makes sense to have that available by default

Context: https://github.com/cloudfoundry/wg-app-platform-runtime-ci/pull/11


# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [ ] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

_If you have selected multiple of the above, it may be wise to consider splitting this PR into multiple PRs to decrease the time for minor changes + bugs to be resolved._

# Backwards Compatibility

Yes


# How should this be tested?

# Additional Context

_Please provide any additional links or context (issues, other PRs, Slack discussions) to help understand this change._

# PR Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have made this pull request to the `develop` branch.
* [ ] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [ ] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

