### PR TITLE
Add dedicated localhost-only port for serving the /routes endpoint to keep it separate from the public LB health endpoint

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -57,6 +57,9 @@ properties:
     default: router-status
   router.status.password:
     description: "Password for HTTP basic auth to the /varz and /routes endpoints."
+  router.status.routes.port:
+    description: "Port used for the /routes endpoint (available on localhost-only)"
+    default: 8082
   router.prometheus.port:
     description: "Port for the prometheus endpoint."
   router.prometheus.server_name:

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -54,6 +54,9 @@ params = {
     'port' => p('router.status.port'),
     'user' => p('router.status.user'),
     'pass' => p('router.status.password'),
+    'routes' => {
+      'port' => p('router.status.routes.port'),
+    },
   },
   'tracing' => {
     'enable_zipkin' => p('router.tracing.enable_zipkin'),

--- a/jobs/gorouter/templates/pre-start.erb
+++ b/jobs/gorouter/templates/pre-start.erb
@@ -30,6 +30,7 @@ tee_output_to_sys_log "${LOG_DIR}" "pre-start" <%= p("router.logging.format.time
     # the following ports are set in this release
     ports.append(p("router.port")) # has default. will always exist.
     ports.append(p("router.status.port")) # has default. will always exist.
+    ports.append(p("router.status.routes.port")) # has default. will always exist.
     ports.append(p("router.tls_port")) # has default. will always exist.
 
     if_p('router.prometheus.port') do |port|

--- a/jobs/gorouter/templates/retrieve-local-routes.erb
+++ b/jobs/gorouter/templates/retrieve-local-routes.erb
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-curl -s http://<%= p("router.status.user") %>:<%= p("router.status.password") %>@127.0.0.1:<%= p("router.status.port") %>/routes
+curl -s http://<%= p("router.status.user") %>:<%= p("router.status.password") %>@127.0.0.1:<%= p("router.status.routes.port") %>/routes

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -1267,6 +1267,20 @@ describe 'gorouter' do
         end
       end
     end
+
+    it 'sets the default router.status.routes.port' do
+      expect(parsed_yaml['status']['routes']['port']).to eq 8082
+    end
+
+    context 'when router.status.routes.port is specified' do
+      before do
+        deployment_manifest_fragment['router']['status']['routes'] = {'port' => 8888}
+      end
+
+      it 'overrides the default value' do
+        expect(parsed_yaml['status']['routes']['port']).to eq 8888
+      end
+    end
   end
 
   describe 'healthchecker.yml' do
@@ -1390,7 +1404,7 @@ describe 'gorouter' do
     context 'ip_local_reserved_ports' do
       it 'contains reserved ports in order' do
         rendered_template = template.render(properties)
-        ports = '81,442,2822,2825,3457,3458,3459,3460,3461,7070,8081,8853,9100,14726,14727,14821,14822,14823,14824,14829,14830,14922,15821,17003,53035,53080'
+        ports = '81,442,2822,2825,3457,3458,3459,3460,3461,7070,8081,8082,8853,9100,14726,14727,14821,14822,14823,14824,14829,14830,14922,15821,17003,53035,53080'
         expect(rendered_template).to include("\"#{ports}\" > /proc/sys/net/ipv4/ip_local_reserved_ports")
       end
 
@@ -1398,7 +1412,7 @@ describe 'gorouter' do
         it 'skips that port' do
           properties['router'].delete('prometheus')
           rendered_template = template.render(properties)
-          ports = '81,442,2822,2825,3457,3458,3459,3460,3461,8081,8853,9100,14726,14727,14821,14822,14823,14824,14829,14830,14922,15821,17003,53035,53080'
+          ports = '81,442,2822,2825,3457,3458,3459,3460,3461,8081,8082,8853,9100,14726,14727,14821,14822,14823,14824,14829,14830,14922,15821,17003,53035,53080'
           expect(rendered_template).to include("\"#{ports}\" > /proc/sys/net/ipv4/ip_local_reserved_ports")
         end
       end
@@ -1407,7 +1421,7 @@ describe 'gorouter' do
         it 'skips that port' do
           properties['router']['debug_address'] = 'meow'
           rendered_template = template.render(properties)
-          ports = '81,442,2822,2825,3457,3458,3459,3460,3461,7070,8081,8853,9100,14726,14727,14821,14822,14823,14824,14829,14830,14922,15821,53035,53080'
+          ports = '81,442,2822,2825,3457,3458,3459,3460,3461,7070,8081,8082,8853,9100,14726,14727,14821,14822,14823,14824,14829,14830,14922,15821,53035,53080'
           expect(rendered_template).to include("\"#{ports}\" > /proc/sys/net/ipv4/ip_local_reserved_ports")
         end
       end


### PR DESCRIPTION
This is part of a larger effort to remove unencrypted non-localhost TCP listeners from routing-release. Currently the listener for /routes on router.status.port listens on all interfaces, and sits alongside the deprecated /varz + /healthz endpoints, as well as the LB healthcheck endpoint.

To work toward the desired state, we're adding a localhost-only listener for /routes, and will turn router.status.port to only a LB-healthcheck endpoint.

https://www.pivotaltracker.com/story/show/186497108

---
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

# What is this change about?

_In your own words, describe this proposed change and the problem it solves. If GitHub has prepopulated any text above here with info from your commit message, please clean it up and account for it in this section._

# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [ ] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

_If you have selected multiple of the above, it may be wise to consider splitting this PR into multiple PRs to decrease the time for minor changes + bugs to be resolved._

# Backwards Compatibility

_If this is a breaking change, or modifies currently expected behaviors of core functionality (request routing or request logging), how has the change been mitigated to be backwards compatible?_

_Should this feature be considered experimental for a period of time, and allow operators to opt-in? Should this apply immediately to all routing-release deployments?_

# How should this be tested?

_Are there any non-automated tests that should be performed against this change for validation? Please provide steps, and expected results for before + after the change._

# Additional Context

_Please provide any additional links or context (issues, other PRs, Slack discussions) to help understand this change._

# PR Checklist
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have made this pull request to the `develop` branch.
* [ ] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [ ] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

