### PR TITLE
Bump go version in go.mod to 1.21

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org
 
-go 1.20
+go 1.21.0
 
 replace github.com/uber-go/zap => github.com/uber-go/zap v0.0.0-20161222040304-a5783ee4b216
 


### PR DESCRIPTION
This is in preparation for using 1.21 features

---
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

# What is this change about?

The change updates the Go version in the go.mod file to 1.21. This is in preparation for https://github.com/cloudfoundry/gorouter/pull/375

# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [X] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

_If you have selected multiple of the above, it may be wise to consider splitting this PR into multiple PRs to decrease the time for minor changes + bugs to be resolved._

# Backwards Compatibility

The change is backwards compatible.

# How should this be tested?

This change will be tested implicitly with the next build but should not have any impact, as the Go version used for building is 1.21 already.

# Additional Context

This is in preparation for https://github.com/cloudfoundry/gorouter/pull/375

# PR Checklist
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have made this pull request to the `develop` branch.
* [X] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [X] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

