### PR TITLE
add nats.fail_if_using_nats_without_tls flag to route registrar

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -53,6 +53,13 @@ properties:
     description: "PEM-encoded certificate for the route-registrar to present to NATS for verification when connecting via TLS."
   nats.tls.client_key:
     description: "PEM-encoded private key for the route-registrar to present to NATS for verification when connecting via TLS."
+  nats.fail_if_using_nats_without_tls:
+    description: |
+        Connecting to nats (instead of nats-tls) is deprecated. The nats
+        process will be removed soon. Please migrate to using nats-tls as soon
+        as possible. If you must continue using nats for a short time you can
+        set this flag to false.
+    default: true
 
   host:
     description: (string, optional) By default, route_registrar will detect the IP of the VM and use it, in combination with port as the backend destination for each uri being registered. This property enables overriding the destination hostname or IP.

--- a/jobs/route_registrar/templates/registrar_settings.json.erb
+++ b/jobs/route_registrar/templates/registrar_settings.json.erb
@@ -1,9 +1,20 @@
 <%=
   require 'json'
 
+nats_err_msg = <<-TEXT
+Using nats (instead of nats-tls) is deprecated. The nats process will
+be removed soon. Please migrate to using nats-tls as soon as possible.
+If you must continue using nats for a short time you can set the
+nats.fail_if_using_nats_without_tls property on route_registrar to
+false.
+TEXT
   nats_link_name = 'nats'
   if p('nats.tls.enabled')
     nats_link_name = 'nats-tls'
+  else
+    if p('nats.fail_if_using_nats_without_tls')
+      raise nats_err_msg
+    end
   end
 
   nats_machines = nil


### PR DESCRIPTION
---
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

# What is this change about?

We want to totally get rid of the nats job in favor of nats-tls. But we know there are 3rd party routing-release users that use nats. We want to use this bosh property and template failure as a deprecation warning to make sure they migrate over to using nats-tls.

# What type of change is this?

- [x] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [ ] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

_If you have selected multiple of the above, it may be wise to consider splitting this PR into multiple PRs to decrease the time for minor changes + bugs to be resolved._

# Backwards Compatibility

_If this is a breaking change, or modifies currently expected behaviors of core functionality (request routing or request logging), how has the change been mitigated to be backwards compatible?_
Route registrar users can set the property to "false" to temporarily pause the error. Ultimately we want to get rid of the nats job entirely, which will be a big breaking change, but we hope to get people migrated to nats-tls before then.

_Should this feature be considered experimental for a period of time, and allow operators to opt-in? Should this apply immediately to all routing-release deployments?_
No.

# How should this be tested?

Template tests are included.

# Additional Context


# PR Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have made this pull request to the `develop` branch.
* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [x] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

