### PR TITLE
Add TLS health check for tcp-router

### DIFF
--- a/jobs/tcp_router/spec
+++ b/jobs/tcp_router/spec
@@ -67,6 +67,10 @@ properties:
   tcp_router.request_timeout_in_seconds:
     description: "Server and client timeouts in seconds"
     default: 300
+
+  tcp_router.enable_nontls_health_checks:
+    description: "Toggles on/off whether or not to listen for load balancer health check requests on the non-tls `tcp_router.health_check_port` port"
+    default: true
   tcp_router.health_check_port:
     description: "Load balancer in front of TCP Routers should be configured to check the health of TCP Router instances by establishing a TCP connection on this port"
     default: 80

--- a/jobs/tcp_router/spec
+++ b/jobs/tcp_router/spec
@@ -10,6 +10,7 @@ templates:
   routing_api_client_certificate.crt.erb: config/certs/routing-api/client.crt
   routing_api_client_private.key.erb: config/keys/routing-api/client.key
   routing_api_ca_certificate.crt.erb: config/certs/routing-api/ca_cert.crt
+  tcp_router_health_check_certificate.pem.erb: config/certs/health.pem
   haproxy.conf.erb: config/haproxy.conf
   haproxy.conf.template.erb: config/haproxy.conf.template
   bpm.yml.erb: config/bpm.yml
@@ -69,6 +70,13 @@ properties:
   tcp_router.health_check_port:
     description: "Load balancer in front of TCP Routers should be configured to check the health of TCP Router instances by establishing a TCP connection on this port"
     default: 80
+  tcp_router.tls_health_check_port:
+    description: "Load balancer in front of TCP Routers should be configured to check the health of TCP Router instances by establishing a TLS connection on this port"
+    default: 443
+  tcp_router.tls_health_check_cert:
+    description: "TLS certificate to use on the TCP Router's TLS health check port"
+  tcp_router.tls_health_check_key:
+    description: "TLS private key to use on the TCP Router's TLS health check port"
 
   tcp_router.fail_on_router_port_conflicts:
     description: "Fail the tcp router if routing_api.reserved_system_component_ports conflict with ports in existing router groups."

--- a/jobs/tcp_router/templates/haproxy.conf.erb
+++ b/jobs/tcp_router/templates/haproxy.conf.erb
@@ -4,6 +4,7 @@ global
     maxconn 64000
     spread-checks 4
     stats socket /var/vcap/data/tcp_router/config/haproxy.sock user vcap group vcap mode 600 level operator expose-fd listeners
+    ssl-default-bind-options ssl-min-ver TLSv1.2
 
 defaults
     log global
@@ -17,4 +18,9 @@ defaults
 listen health_check_http_url
     mode http
     bind :<%= p("tcp_router.health_check_port") %>
+    monitor-uri /health
+
+listen health_check_https_url
+    mode http
+    bind :<%= p("tcp_router.tls_health_check_port") %> ssl crt /var/vcap/jobs/tcp_router/config/certs/health.pem
     monitor-uri /health

--- a/jobs/tcp_router/templates/haproxy.conf.erb
+++ b/jobs/tcp_router/templates/haproxy.conf.erb
@@ -15,10 +15,12 @@ defaults
         timeout server <%= p("tcp_router.request_timeout_in_seconds").to_i * 1000 %>ms
     <% end %>
 
+<% if p("tcp_router.enable_nontls_health_checks") %>
 listen health_check_http_url
     mode http
     bind :<%= p("tcp_router.health_check_port") %>
     monitor-uri /health
+<% end %>
 
 listen health_check_https_url
     mode http

--- a/jobs/tcp_router/templates/haproxy.conf.template.erb
+++ b/jobs/tcp_router/templates/haproxy.conf.template.erb
@@ -4,6 +4,7 @@ global
     maxconn 64000
     spread-checks 4
     stats socket /var/vcap/data/tcp_router/config/haproxy.sock user vcap group vcap mode 600 level operator expose-fd listeners
+    ssl-default-bind-options ssl-min-ver TLSv1.2
 
 defaults
     log global
@@ -17,4 +18,9 @@ defaults
 listen health_check_http_url
     mode http
     bind :<%= p("tcp_router.health_check_port") %>
+    monitor-uri /health
+
+listen health_check_https_url
+    mode http
+    bind :<%= p("tcp_router.tls_health_check_port") %> ssl crt /var/vcap/jobs/tcp_router/config/certs/health.pem
     monitor-uri /health

--- a/jobs/tcp_router/templates/haproxy.conf.template.erb
+++ b/jobs/tcp_router/templates/haproxy.conf.template.erb
@@ -15,10 +15,12 @@ defaults
         timeout server <%= p("tcp_router.request_timeout_in_seconds").to_i * 1000 %>ms
     <% end %>
 
+<% if p("tcp_router.enable_nontls_health_checks") %>
 listen health_check_http_url
     mode http
     bind :<%= p("tcp_router.health_check_port") %>
     monitor-uri /health
+<% end %>
 
 listen health_check_https_url
     mode http

--- a/jobs/tcp_router/templates/tcp_router_health_check_certificate.pem.erb
+++ b/jobs/tcp_router/templates/tcp_router_health_check_certificate.pem.erb
@@ -1,0 +1,6 @@
+<% if_p("tcp_router.tls_health_check_key") do |key| -%>
+<%= key %>
+<% end.else { raise RuntimeError, "Please set tcp_router.tls_health_check_key in the tcp_router's job properties." } -%>
+<% if_p("tcp_router.tls_health_check_cert") do |cert| -%>
+<%= cert %>
+<% end.else { raise RuntimeError, "Please set tcp_router.tls_health_check_cert in the tcp_router's job properties." } -%>

--- a/spec/haproxy_config_spec.rb
+++ b/spec/haproxy_config_spec.rb
@@ -39,6 +39,16 @@ describe 'tcp_router haproxy configs' do
           expect(http_health_check).to include('monitor-uri /health')
         end
 
+        context 'when disabled' do
+          before do
+            properties['tcp_router']['enable_nontls_health_checks'] = false
+          end
+
+          it 'does not have a listener defined' do
+            expect(haproxy_config).to_not have_key('listen health_check_http_url')
+          end
+        end
+
         context 'when overriding the default port' do
           before do
             properties['tcp_router']['health_check_port'] = 8080

--- a/spec/haproxy_config_spec.rb
+++ b/spec/haproxy_config_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'bosh/template/test'
+
+describe 'tcp_router haproxy configs' do
+  let(:release_path) { File.join(File.dirname(__FILE__), '..') }
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(release_path) }
+  let(:tcp_router_job) { release.job('tcp_router') }
+  let(:properties) do
+    {
+      'tcp_router' => {
+        'oauth_secret' => '',
+      },
+      'uaa' => {
+        'tls_port' => 1000,
+      },
+      'routing_api' => {
+        'mtls_port' => 1337,
+        'reserved_system_component_ports' => [8080, 8081]
+      }
+    }
+  end
+
+  ["haproxy.conf", "haproxy.conf.template"].each do |file|
+    context "config/#{file}" do
+      let(:template) { tcp_router_job.template("config/#{file}") }
+
+      let(:haproxy_config) do
+        parse_haproxy_config(template.render(properties))
+      end
+
+      context 'the non-tls health check listener' do
+        let(:http_health_check) { haproxy_config['listen health_check_http_url'] }
+
+        it 'listens on port 80' do
+          expect(http_health_check).to include('mode http')
+          expect(http_health_check).to include('bind :80')
+          expect(http_health_check).to include('monitor-uri /health')
+        end
+
+        context 'when overriding the default port' do
+          before do
+            properties['tcp_router']['health_check_port'] = 8080
+          end
+
+          it 'updates the bind port' do
+            expect(http_health_check).to include('bind :8080')
+          end
+        end
+      end
+
+      context 'the tls health check listener' do
+        let(:https_health_check) { haproxy_config['listen health_check_https_url'] }
+
+        it 'is always on' do
+          expect(https_health_check).to include('mode http')
+          expect(https_health_check).to include('bind :443 ssl crt /var/vcap/jobs/tcp_router/config/certs/health.pem')
+          expect(https_health_check).to include('monitor-uri /health')
+        end
+
+        it 'requires tls 1.2 or above' do
+          expect(haproxy_config['global']).to include('ssl-default-bind-options ssl-min-ver TLSv1.2')
+        end
+
+        context 'when overriding the default port' do
+          before do
+            properties['tcp_router']['tls_health_check_port'] = 8443
+          end
+
+          it 'updates the bind port' do
+            expect(https_health_check).to include('bind :8443 ssl crt /var/vcap/jobs/tcp_router/config/certs/health.pem')
+          end
+        end
+      end
+    end
+  end
+end
+
+
+### The following code has been pulled from https://github.com/cloudfoundry/haproxy-boshrelease/blob/master/spec/spec_helper.rb
+# converts haproxy config into hash of arrays grouped
+# by top-level values eg
+# {
+#    "global" => [
+#       "nbproc 4",
+#       "daemon",
+#       "stats timeout 2m"
+#    ]
+# }
+def parse_haproxy_config(config) # rubocop:disable Metrics/AbcSize
+  # remove comments and empty lines
+  config = config.split(/\n/).reject { |l| l.empty? || l =~ /^\s*#.*$/ }.join("\n")
+
+  # split into top-level groups
+  config.split(/^([^\s].*)/).drop(1).each_slice(2).to_h do |group|
+    key = group[0]
+    properties = group[1]
+
+    # remove empty lines
+    properties = properties.split(/\n/).reject(&:empty?).join("\n")
+
+    # split and strip leading/trailing whitespace
+    properties = properties.split(/\n/).map(&:strip)
+
+    [key, properties]
+  end
+end

--- a/spec/tcp_router_templates_spec.rb
+++ b/spec/tcp_router_templates_spec.rb
@@ -24,6 +24,59 @@ describe 'tcp_router' do
     }
   end
 
+  describe 'config/certs/health.pem' do
+    let(:template) { job.template('config/certs/health.pem') }
+    let(:links) do
+      [
+        Bosh::Template::Test::Link.new(
+          name: 'routing_api',
+          properties: {
+            'routing_api' => {
+              'mtls_client_cert' => 'the mtls client cert from link'
+            }
+          }
+        )
+      ]
+    end
+
+    before do
+      merged_manifest_properties['tcp_router']['tls_health_check_key'] = 'tls health check key'
+      merged_manifest_properties['tcp_router']['tls_health_check_cert'] = 'tls health check cert'
+    end
+
+    it 'should render the key + cert in a pem file' do
+      rendered_template = template.render(merged_manifest_properties, consumes: links)
+      expect(rendered_template).to eq("tls health check key\ntls health check cert\n")
+    end
+
+    describe 'when tls_health_check_key is not provided' do
+      before do
+        merged_manifest_properties['tcp_router'].delete('tls_health_check_key')
+      end
+      it 'should error' do
+        expect do
+          template.render(merged_manifest_properties)
+        end.to raise_error(
+          RuntimeError,
+          "Please set tcp_router.tls_health_check_key in the tcp_router's job properties.",
+        )
+      end
+    end
+    describe 'when tls_health_check_key is not provided' do
+      before do
+        merged_manifest_properties['tcp_router'].delete('tls_health_check_cert')
+      end
+      it 'should error' do
+        expect do
+          template.render(merged_manifest_properties)
+        end.to raise_error(
+          RuntimeError,
+          "Please set tcp_router.tls_health_check_cert in the tcp_router's job properties.",
+        )
+      end
+    end
+  end
+
   describe 'config/certs/routing-api/client.crt' do
     let(:template) { job.template('config/certs/routing-api/client.crt') }
     let(:links) do


### PR DESCRIPTION
---

Adds a TLS health check listener for tcp-router, and enables operators to disable non-tls health checks for tcp-router.

# What type of change is this?

- [x] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [ ] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

Technically a breaking change/not backwards compatible from the routing-release perspective, as new properties have been added without defaults. However they will be provided via variables in cf-deployment.

# Backwards Compatibility

cf-deployment will be updated to provide the new properties.

# How should this be tested?


# Additional Context

https://www.pivotaltracker.com/story/show/186497091
https://www.pivotaltracker.com/story/show/186471705

# PR Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have made this pull request to the `develop` branch.
* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [x] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

