### PR TITLE
Add toggle to enable/disable non-tls LB health checks in gorouter

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -57,11 +57,15 @@ properties:
     default: router-status
   router.status.password:
     description: "Password for HTTP basic auth to the /varz and /routes endpoints."
+  router.status.enable_nontls_health_checks:
+    description: "Toggles whether or not gorouter will listen on a non-tls endpoint for load balancer health checks."
+    default: true
   router.status.routes.port:
     description: "Port used for the /routes endpoint (available on localhost-only)"
     default: 8082
   router.status.tls.port:
     description: "Port used for the TLS listener of the LB healthcheck endpoint"
+    default: 8443
   router.status.tls.certificate:
     description: "TLS Certificate used for the TLS listener of the LB healthcheck endpoint"
   router.status.tls.key:

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -51,7 +51,6 @@ access_log_file = p('router.write_access_logs_locally') ? '/var/vcap/sys/log/gor
 
 def status_tls
   tls = {}
-  if_p('router.status.tls.port') do
     if p('router.status.tls.certificate', "") == ""
       raise 'router.status.tls.certificate must be provided when router.status.tls.port is set'
     end
@@ -64,13 +63,13 @@ def status_tls
       'certificate' => p('router.status.tls.certificate'),
       'key' => p('router.status.tls.key'),
     }
-  end
   return tls
 end
 
 
 params = {
   'status' => {
+    'enable_nontls_health_checks' => p('router.status.enable_nontls_health_checks'),
     'port' => p('router.status.port'),
     'user' => p('router.status.user'),
     'pass' => p('router.status.password'),

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -117,6 +117,10 @@ describe 'gorouter' do
             'port' => 80,
             'user' => 'test',
             'password' => 'pass',
+            'tls' => {
+              'certificate' => TEST_CERT,
+              'key' => TEST_KEY,
+            }
           },
           'enable_ssl' => true,
           'tls_port' => 443,
@@ -1282,18 +1286,32 @@ describe 'gorouter' do
       end
     end
 
-    context 'when router.status.tls is specified' do
+    context 'when router.status.enable_nontls_health_checks is disabled' do
       before do
-        deployment_manifest_fragment['router']['status']['tls'] = {
-          'port' => 8443,
-          'certificate' => TEST_CERT,
-          'key' => 'test-key',
-        }
+        deployment_manifest_fragment['router']['status']['enable_nontls_health_checks'] = false
       end
+
+      it 'disables nont-tls health checks in gorouter' do
+        expect(parsed_yaml['status']['enable_nontls_health_checks']).to eq false
+      end
+    end
+
+    context 'when router.status.tls is specified' do
       it 'sets the tls port, cert, and key correctly' do
+        # port is default
+        # cert + key are provided in the default values for deployment_manifest_fragment
         expect(parsed_yaml['status']['tls']['port']).to eq 8443
         expect(parsed_yaml['status']['tls']['certificate']).to eq TEST_CERT
-        expect(parsed_yaml['status']['tls']['key']).to eq('test-key')
+        expect(parsed_yaml['status']['tls']['key']).to eq(TEST_KEY)
+      end
+
+      context 'and the tls port is specified' do
+        before do
+          deployment_manifest_fragment['router']['status']['tls']['port'] = 1234
+        end
+        it 'overrides the default' do
+        expect(parsed_yaml['status']['tls']['port']).to eq 1234
+        end
       end
 
       context 'but the certificate is not specified' do


### PR DESCRIPTION
(default on)

Update gorouter's default port for TLS LB health checks, as this is now always on, vs opt-in.

---
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

# What is this change about?

_In your own words, describe this proposed change and the problem it solves. If GitHub has prepopulated any text above here with info from your commit message, please clean it up and account for it in this section._

# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [ ] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

_If you have selected multiple of the above, it may be wise to consider splitting this PR into multiple PRs to decrease the time for minor changes + bugs to be resolved._

# Backwards Compatibility

_If this is a breaking change, or modifies currently expected behaviors of core functionality (request routing or request logging), how has the change been mitigated to be backwards compatible?_

_Should this feature be considered experimental for a period of time, and allow operators to opt-in? Should this apply immediately to all routing-release deployments?_

# How should this be tested?

_Are there any non-automated tests that should be performed against this change for validation? Please provide steps, and expected results for before + after the change._

# Additional Context

_Please provide any additional links or context (issues, other PRs, Slack discussions) to help understand this change._

# PR Checklist
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have made this pull request to the `develop` branch.
* [ ] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [ ] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

