### PR TITLE
Add toggle to enable/disable the varz/healthz/routes endpoints on the nontls health listener port

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -60,6 +60,12 @@ properties:
   router.status.enable_nontls_health_checks:
     description: "Toggles whether or not gorouter will listen on a non-tls endpoint for load balancer health checks."
     default: true
+  router.status.enable_deprecated_varz_healthz_endpoints:
+    description: |
+      Toggles whether or not gorouter will respond to the deprecated /healthz,
+      /varz, and /routes endpoints on its non-tls load balancer status port.
+      Requires 'router.status.enable_nontls_health_checks' to be true.
+    default: false
   router.status.routes.port:
     description: "Port used for the /routes endpoint (available on localhost-only)"
     default: 8082

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -70,6 +70,7 @@ end
 params = {
   'status' => {
     'enable_nontls_health_checks' => p('router.status.enable_nontls_health_checks'),
+    'enable_deprecated_varz_healthz_endpoints' => p('router.status.enable_deprecated_varz_healthz_endpoints'),
     'port' => p('router.status.port'),
     'user' => p('router.status.user'),
     'pass' => p('router.status.password'),

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -1296,6 +1296,21 @@ describe 'gorouter' do
       end
     end
 
+    context 'when router.status.enable_deprecated_varz_healthz_endpoints is enabled' do
+      before do
+        deployment_manifest_fragment['router']['status']['enable_deprecated_varz_healthz_endpoints'] = true
+      end
+      it 'enables healthz/varz endpoints in gorouter' do
+        expect(parsed_yaml['status']['enable_deprecated_varz_healthz_endpoints']).to eq true
+      end
+    end
+
+    context 'router.status.enable_deprecated_varz_healthz_endpoints is disabled by default' do
+      it 'enables healthz/varz endpoints in gorouter' do
+        expect(parsed_yaml['status']['enable_deprecated_varz_healthz_endpoints']).to eq false
+      end
+    end
+
     context 'when router.status.tls is specified' do
       it 'sets the tls port, cert, and key correctly' do
         # port is default


### PR DESCRIPTION
… nontls health listener port

---
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

# What is this change about?

_In your own words, describe this proposed change and the problem it solves. If GitHub has prepopulated any text above here with info from your commit message, please clean it up and account for it in this section._

# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [ ] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

_If you have selected multiple of the above, it may be wise to consider splitting this PR into multiple PRs to decrease the time for minor changes + bugs to be resolved._

# Backwards Compatibility

_If this is a breaking change, or modifies currently expected behaviors of core functionality (request routing or request logging), how has the change been mitigated to be backwards compatible?_

_Should this feature be considered experimental for a period of time, and allow operators to opt-in? Should this apply immediately to all routing-release deployments?_

# How should this be tested?

_Are there any non-automated tests that should be performed against this change for validation? Please provide steps, and expected results for before + after the change._

# Additional Context

_Please provide any additional links or context (issues, other PRs, Slack discussions) to help understand this change._

# PR Checklist
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have made this pull request to the `develop` branch.
* [ ] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [ ] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

