### PR TITLE
Allow route_registrar nats_server_ca to be configured via spec not on…

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -53,6 +53,8 @@ properties:
     description: "PEM-encoded certificate for the route-registrar to present to NATS for verification when connecting via TLS."
   nats.tls.client_key:
     description: "PEM-encoded private key for the route-registrar to present to NATS for verification when connecting via TLS."
+  nats.tls.ca_cert:
+    description: "The certificate authority certificate used for the route registrar"
   nats.fail_if_using_nats_without_tls:
     description: |
         Connecting to nats (instead of nats-tls) is deprecated. The nats

--- a/jobs/route_registrar/templates/nats_server_ca.crt.erb
+++ b/jobs/route_registrar/templates/nats_server_ca.crt.erb
@@ -1,5 +1,17 @@
-<% if_link('nats-tls') do |nats_link| %>
-<% nats_link.if_p('nats.external.tls.ca') do |ca_cert| %>
-<%= ca_cert %>
-<% end %>
-<% end %>
+<%=
+  def nats_tls_ca
+    if_p('nats.tls.ca_cert') do |prop|
+      return prop
+    end.else do
+      if_link('nats-tls') do |nats_link|
+        nats_link.if_p('nats.external.tls.ca') do |ca_cert|
+          return ca_cert
+        end
+      end
+    end
+
+    return ''
+  end
+
+  nats_tls_ca
+-%>


### PR DESCRIPTION
…ly fetched from bosh link

---
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

# What is this change about?

This PR ensures that it is possible to configure the `nats_server_ca` via the spec and not only via Bosh Links. 

# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [X] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

_If you have selected multiple of the above, it may be wise to consider splitting this PR into multiple PRs to decrease the time for minor changes + bugs to be resolved._

# Backwards Compatibility

_If this is a breaking change, or modifies currently expected behaviors of core functionality (request routing or request logging), how has the change been mitigated to be backwards compatible?_

_Should this feature be considered experimental for a period of time, and allow operators to opt-in? Should this apply immediately to all routing-release deployments?_

# How should this be tested?

_Are there any non-automated tests that should be performed against this change for validation? Please provide steps, and expected results for before + after the change._

# Additional Context

_Please provide any additional links or context (issues, other PRs, Slack discussions) to help understand this change._

https://cloudfoundry.slack.com/archives/C01ABMVNE9E/p1704971257271489

# PR Checklist
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have made this pull request to the `develop` branch.
* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [X] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

