### PR TITLE
feat: Add route_services_internal_server_port property.

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -243,6 +243,9 @@ properties:
   router.route_services_internal_lookup_allowlist:
     description: "a list of host names for route services that should be resolved internally. Each entry can be a fully qualified domain name or DNS wildcard (i.e. wildcard on 1 segment of a subdomain). If the list is empty, it is not in effect and internal lookup will be attempted for all host names, which can lead to CVE-2019-3789. Please turn on internal lookup only with an allowlist."
     default: []
+  router.route_services_internal_server_port:
+    description: "Gorouter will use this port for internal route services."
+    default: 7070
   router.route_services_secret_decrypt_only:
     description: "To rotate keys, add your new key here and deploy. Then swap this key with the value of route_services_secret and deploy again."
     default: ""

--- a/jobs/gorouter/templates/pre-start.erb
+++ b/jobs/gorouter/templates/pre-start.erb
@@ -32,6 +32,7 @@ tee_output_to_sys_log "${LOG_DIR}" "pre-start" <%= p("router.logging.format.time
     ports.append(p("router.status.port")) # has default. will always exist.
     ports.append(p("router.status.routes.port")) # has default. will always exist.
     ports.append(p("router.tls_port")) # has default. will always exist.
+    ports.append(p("router.route_services_internal_server_port")) # has default. will always exist.
 
     if_p('router.status.tls.port') do |port|
         ports.append(port)

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -1509,7 +1509,7 @@ describe 'gorouter' do
       { 'router' => {
         'port' => 81,
         'status' => { 'port' => 8081, 'tls' => {'port' => 8443}, },
-        'prometheus' => { 'port' => 7070 },
+        'prometheus' => { 'port' => 7777 },
         'tls_port' => 442,
         'debug_address' => '127.0.0.1:17003'
       } }
@@ -1518,7 +1518,7 @@ describe 'gorouter' do
     context 'ip_local_reserved_ports' do
       it 'contains reserved ports in order' do
         rendered_template = template.render(properties)
-        ports = '81,442,2822,2825,3457,3458,3459,3460,3461,7070,8081,8082,8443,8853,9100,14726,14727,14821,14822,14823,14824,14829,14830,14922,15821,17003,53035,53080'
+        ports = '81,442,2822,2825,3457,3458,3459,3460,3461,7070,7777,8081,8082,8443,8853,9100,14726,14727,14821,14822,14823,14824,14829,14830,14922,15821,17003,53035,53080'
         expect(rendered_template).to include("\"#{ports}\" > /proc/sys/net/ipv4/ip_local_reserved_ports")
       end
 
@@ -1526,7 +1526,7 @@ describe 'gorouter' do
         it 'skips that port' do
           properties['router'].delete('prometheus')
           rendered_template = template.render(properties)
-          ports = '81,442,2822,2825,3457,3458,3459,3460,3461,8081,8082,8443,8853,9100,14726,14727,14821,14822,14823,14824,14829,14830,14922,15821,17003,53035,53080'
+          ports = '81,442,2822,2825,3457,3458,3459,3460,3461,7070,8081,8082,8443,8853,9100,14726,14727,14821,14822,14823,14824,14829,14830,14922,15821,17003,53035,53080'
           expect(rendered_template).to include("\"#{ports}\" > /proc/sys/net/ipv4/ip_local_reserved_ports")
         end
       end
@@ -1535,7 +1535,15 @@ describe 'gorouter' do
         it 'skips that port' do
           properties['router']['debug_address'] = 'meow'
           rendered_template = template.render(properties)
-          ports = '81,442,2822,2825,3457,3458,3459,3460,3461,7070,8081,8082,8443,8853,9100,14726,14727,14821,14822,14823,14824,14829,14830,14922,15821,53035,53080'
+          ports = '81,442,2822,2825,3457,3458,3459,3460,3461,7070,7777,8081,8082,8443,8853,9100,14726,14727,14821,14822,14823,14824,14829,14830,14922,15821,53035,53080'
+          expect(rendered_template).to include("\"#{ports}\" > /proc/sys/net/ipv4/ip_local_reserved_ports")
+        end
+      end
+      context 'when route_services_internal_server_port is set to a non-default value' do
+        it 'uses that port' do
+          properties['router']['route_services_internal_server_port'] = 7272
+          rendered_template = template.render(properties)
+          ports = '81,442,2822,2825,3457,3458,3459,3460,3461,7272,7777,8081,8082,8443,8853,9100,14726,14727,14821,14822,14823,14824,14829,14830,14922,15821,17003,53035,53080'
           expect(rendered_template).to include("\"#{ports}\" > /proc/sys/net/ipv4/ip_local_reserved_ports")
         end
       end


### PR DESCRIPTION
# What is this change about?

Fixes #342 

- Removes randomly selected port for internal route service server
- Sets a dedicated port (default: 7070)

# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [x] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

_If you have selected multiple of the above, it may be wise to consider splitting this PR into multiple PRs to decrease the time for minor changes + bugs to be resolved._

# Backwards Compatibility

_If this is a breaking change, or modifies currently expected behaviors of core functionality (request routing or request logging), how has the change been mitigated to be backwards compatible?_
Yes. The port change should be transparent as it is only used internally and only opened on localhost.

_Should this feature be considered experimental for a period of time, and allow operators to opt-in? Should this apply immediately to all routing-release deployments?_
No.

# How should this be tested?

_Are there any non-automated tests that should be performed against this change for validation? Please provide steps, and expected results for before + after the change._
- Spec tests have been provided
- Unit and integration tests have been adjusted in companion PR

# Additional Context

_Please provide any additional links or context (issues, other PRs, Slack discussions) to help understand this change._

- Companion [Gorouter PR](https://github.com/cloudfoundry/gorouter/pull/389)

# PR Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have made this pull request to the `develop` branch.
* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [x] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

