### PR TITLE
Add config option for enabling/disabling sticky sessions on auth nego…

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -123,6 +123,9 @@ properties:
   router.sticky_session_cookie_names:
     description: "The names of the cookies to use for handling sticky sessions"
     default: [ "JSESSIONID" ]
+  router.sticky_sessions_for_auth_negotiate:
+    description: "Controls whether or not gorouter will apply sticky sessions to request/response flows using 'Authorization: Negotiate'"
+    default: false
   router.drain_wait:
     description: |
       Delay in seconds after shut down is initiated before server stops listening.

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -107,6 +107,7 @@ params = {
   'debug_addr' => p('router.debug_address'),
   'secure_cookies' => p('router.secure_cookies'),
   'sticky_session_cookie_names' => p('router.sticky_session_cookie_names'),
+  'sticky_sessions_for_auth_negotiate' => p('router.sticky_sessions_for_auth_negotiate'),
   'access_log' => {
     'file' => access_log_file,
   },

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -403,6 +403,21 @@ describe 'gorouter' do
           end
         end
       end
+      describe 'sticky_sessions_for_auth_negotiate' do
+        context 'when no value is provided' do
+          it 'should be false' do
+            expect(parsed_yaml['sticky_sessions_for_auth_negotiate']).to eq(false)
+          end
+        end
+        context 'when it is enabled' do
+          before do
+            deployment_manifest_fragment['router']['sticky_sessions_for_auth_negotiate'] = true
+          end
+          it 'should be true' do
+            expect(parsed_yaml['sticky_sessions_for_auth_negotiate']).to eq(true)
+          end
+        end
+      end
       describe 'client_cert_validation' do
         context 'when no override is provided' do
           it 'should default to none' do


### PR DESCRIPTION
---
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

# What is this change about?

Adds a config option to routing_release to control gorouter's ability to enable sticky sessions for request flows using `Authorization: negotiate`.

# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [x] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

_If you have selected multiple of the above, it may be wise to consider splitting this PR into multiple PRs to decrease the time for minor changes + bugs to be resolved._

# Backwards Compatibility

Off by default

# How should this be tested?

No

# Additional Context

https://github.com/cloudfoundry/gorouter/pull/392
https://github.com/cloudfoundry/gorouter/pull/393

# PR Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have made this pull request to the `develop` branch.
* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [x] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

