### PR TITLE
[PG4TAS-405] Add additional_bpm_mount_paths to route_registrar job spec

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -131,6 +131,7 @@ properties:
         name (required, string): Human-readable reference for the healthcheck
         script_path (required, string): Path to script that will be run periodically to determine
           service health
+        additional_bpm_mount_paths (optional, array of strings): Additional directories to be mounted in the bpm config for the route_registrar job.
         timeout (optional, string): The healthcheck script must exit within this timeout, otherwise
           the script is terminated with `SIGKILL` and the route is unregistered. Value is a string (e.g. "10s") and must parse to a positive time duration i.e. "-5s" is not permitted. Must be less than the value of `registration_interval`.
           Default: Half of the value of `registration_interval`

--- a/jobs/route_registrar/templates/bpm.yml.erb
+++ b/jobs/route_registrar/templates/bpm.yml.erb
@@ -19,6 +19,7 @@ bpm = {
 }
 
 paths = []
+additional_paths = []
 routes = p('route_registrar.routes')
 routes.each do |route|
   if route['health_check']
@@ -26,6 +27,9 @@ routes.each do |route|
     matched = /(^\/var\/vcap\/jobs\/[^\/]*)\/.*/.match(route['health_check']['script_path'])
     if matched
       paths << matched[1]
+    end
+    if route['health_check']['additional_bpm_mount_paths']
+      additional_paths << route['health_check']['additional_bpm_mount_paths']
     end
   end
 end
@@ -37,9 +41,13 @@ unless paths.empty?
     }
   }
 
-   paths.each do |path|
+  paths.each do |path|
      unsafe['unsafe']['unrestricted_volumes'] << {"path" =>  path, "allow_executions" => true}
      unsafe['unsafe']['unrestricted_volumes'] << {"path" => path.sub('jobs', 'data')}
+  end
+
+  additional_paths.each do |path|
+    unsafe['unsafe']['unrestricted_volumes'] << {"path" =>  path, "allow_executions" => true}
   end
 
   bpm['processes'][0].merge!(unsafe)


### PR DESCRIPTION
---
<!-- Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with: -->

# What is this change about?

This change adds a new field in the `route_registrar` job's `health-check` object in its spec file: `additional_bpm_mount_paths`. Using this array of strings, the `route_registrar` job users can specify additional directories to be mounted in the bpm config yaml of the job. This is needed because sometimes the access to `/var/vcap/job` and `/var/vcap/data/` directories of a specific job is not sufficient for a healthcheck script to run.

# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [x] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

_If you have selected multiple of the above, it may be wise to consider splitting this PR into multiple PRs to decrease the time for minor changes + bugs to be resolved._

# Backwards Compatibility

The change is backwards compatible. No existing deployments configuration should break due to this change.

I don't think it should be considered experimental for some period. I think it should go in next major/minor release.
This doesn't need to apply immediately to all routing-release deployments.

# How should this be tested?

_Are there any non-automated tests that should be performed against this change for validation? Please provide steps, and expected results for before + after the change._

# Additional Context

_Please provide any additional links or context (issues, other PRs, Slack discussions) to help understand this change._

# PR Checklist
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have made this pull request to the `develop` branch.
* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [x] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

