### PR TITLE
Add option to enable concurrent reads and writes for HTTP/1

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -161,6 +161,9 @@ properties:
   router.enable_http2:
     description: Enables support for HTTP/2 ingress traffic to the Gorouter. Also enables the option to use the HTTP/2 protocol for traffic to specified backends.
     default: true
+  router.enable_http1_concurrent_read_write:
+    description: Enables concurrent request reads and response writes for HTTP/1 requests
+    default: false
   router.min_tls_version:
     description: Minimum accepted version of TLS protocol. All versions above this, up to the max_tls_version, will also be accepted. Valid values are TLSv1.0, TLSv1.1, TLSv1.2, and TLSv1.3.
     default: TLSv1.2

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -438,6 +438,7 @@ end
 
 params['disable_http'] = p('router.disable_http')
 params['enable_http2'] = p('router.enable_http2')
+params['enable_http1_concurrent_read_write'] = p('router.enable_http1_concurrent_read_write')
 
 if p('router.ca_certs')
   params['ca_certs'] = get_valid_ca_certs


### PR DESCRIPTION
# What is this change about?

Bump negroni to latest to get support for ResponseController in Go 1.20+ to enable full-duplex mode for HTTP/1 requests. See more: https://pkg.go.dev/net/http#ResponseController.EnableFullDuplex

Waiting on the [negroni release](https://github.com/urfave/negroni/issues/274#issuecomment-1949275126). Meanwhile bumped it to latest manually:

```
go get github.com/urfave/negroni/v3@master
go mod vendor
```

# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [X] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

# Backwards Compatibility

There should not be backwards compatibility issues since this is not an API change. This is an improvement for HTTP/1 requests.

# How should this be tested?

There is an automated test provided in this [PR](https://github.com/cloudfoundry/gorouter/pull/395) as well as some manual validation that can be performed.

# Additional Context

_Please provide any additional links or context (issues, other PRs, Slack discussions) to help understand this change._

# PR Checklist
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have made this pull request to the `develop` branch.
* [X] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [X] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

