### PR TITLE
fix: Don't retry more often than endpoints available

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -194,8 +194,9 @@ properties:
   router.backends.max_attempts:
     description: |
       Maximum number of attempts on failing requests against backend routes.
+      The number of attempts per request is limited by the number of endpoints on the route, regardless of this setting.
       This includes CF apps and route-registrar endpoints.
-      A value of 0 implies indefinite retries, i.e. retry until success or endpoint list is exhausted.
+      The minimum value for this setting is 1. This prevents gorouter from getting blocked by indefinite retries.
     default: 3
   router.backends.ca:
     description: Certificate authority that was used to sign certificates for TLS-registered backends. In PEM format.

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -275,8 +275,8 @@ end
 backend_attempts = 3
 if_p('router.backends.max_attempts') { |val| backend_attempts = val }
 
-if (backend_attempts < 0 )
-  raise 'router.backends.max_attempts cannot be negative'
+if (backend_attempts < 1 )
+  raise 'router.backends.max_attempts must maintain a minimum value of 1'
 end
 
 backends = {

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -673,8 +673,8 @@ describe 'gorouter' do
           before do
             deployment_manifest_fragment['router']['backends']['max_attempts'] = 0
           end
-          it 'should configure the property with indefinite retries' do
-            expect(parsed_yaml['backends']['max_attempts']).to eq(0)
+          it 'should error' do
+            expect { raise parsed_yaml }.to raise_error(RuntimeError, 'router.backends.max_attempts must maintain a minimum value of 1')
           end
         end
         context 'when max_attempts is negative' do
@@ -682,7 +682,7 @@ describe 'gorouter' do
             deployment_manifest_fragment['router']['backends']['max_attempts'] = -1
           end
           it 'should error' do
-            expect { raise parsed_yaml }.to raise_error(RuntimeError, 'router.backends.max_attempts cannot be negative')
+            expect { raise parsed_yaml }.to raise_error(RuntimeError, 'router.backends.max_attempts must maintain a minimum value of 1')
           end
         end
         context 'when both cert_chain and private_key are provided' do


### PR DESCRIPTION
# What is this change about?

Fixes [issue 385](https://github.com/cloudfoundry/routing-release/issues/385)

- Companion PR to [gorouter PR 397](https://github.com/cloudfoundry/gorouter/pull/397)
- Remove unlimited retries as it is dangerous. (BREAKING CHANGE, users have to maintain a minimum value of 1 for `max_attempts` now)
- Do not retry more often than endpoints available on the route

# What type of change is this?

- [x] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [ ] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

_If you have selected multiple of the above, it may be wise to consider splitting this PR into multiple PRs to decrease the time for minor changes + bugs to be resolved._

# Backwards Compatibility

_If this is a breaking change, or modifies currently expected behaviors of core functionality (request routing or request logging), how has the change been mitigated to be backwards compatible?_

- Users need to maintain a minimum value of 1 for `router.backends.max_attempts` now.

_Should this feature be considered experimental for a period of time, and allow operators to opt-in? Should this apply immediately to all routing-release deployments?_

- No, because broken apps that produce retry-able errors in combination with unlimited retries can cause Gorouter to lock up forever. It should be applied to all routing-release deployments.

# How should this be tested?

See test procedure in https://github.com/cloudfoundry/gorouter/pull/397

# Additional Context

See [this slack thread](https://cloudfoundry.slack.com/archives/C01ABMVNE9E/p1706708731540059) for background info.

# PR Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have made this pull request to the `develop` branch.
* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [x] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

