### PR TITLE
fix: Enable syslog forwarding for gorouter

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -274,6 +274,15 @@ properties:
   router.enable_log_attempts_details:
     description: "Log additional fields in the access log that provide more details on the specific timings and attempts performed towards endpoints."
     default: false
+  router.logging.syslog_tag:
+    description: "Tag to use when writing syslog messages"
+    default: "vcap.gorouter"
+  router.logging.syslog_addr:
+    description: "Address of a syslog server to send access logs"
+    default: "localhost:514"
+  router.logging.syslog_network:
+    description: "Network protocol to use when connecting to the syslog server. Valid values are 'tcp', 'udp', <empty>. When choosing an empty string value, the local syslog daemon is used."
+    default: "udp"
   router.logging.format.timestamp:
     description: |
       Format for timestamp in component logs. Valid values are 'rfc3339', 'deprecated', and 'unix-epoch'."
@@ -492,6 +501,9 @@ properties:
   router.write_access_logs_locally:
     description: "Enables writing access log to local disk."
     default: true
+  router.enable_access_log_streaming:
+    description: "Enables streaming access log to syslog server."
+    default: false
   router.suspend_pruning_if_nats_unavailable:
     description: |
       Suspend pruning of routes when NATs is unavailable and maintain the

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -110,6 +110,7 @@ params = {
   'sticky_sessions_for_auth_negotiate' => p('router.sticky_sessions_for_auth_negotiate'),
   'access_log' => {
     'file' => access_log_file,
+    'enable_streaming' => p('router.enable_access_log_streaming')
   },
   'publish_start_message_interval' => '30s',
   'prune_stale_droplets_interval' => '30s',
@@ -374,7 +375,9 @@ if timestamp_format == 'deprecated'
 end
 
 params['logging'] = {
-  'syslog' => 'vcap.gorouter',
+  'syslog' => p('router.logging.syslog_tag'),
+  'syslog_addr' => p('router.logging.syslog_addr'),
+  'syslog_network' => p('router.logging.syslog_network'),
   'level' => p('router.logging_level'),
   'loggregator_enabled' => true,
   'metron_address' => "localhost:#{p('metron.port')}",

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -1214,7 +1214,7 @@ describe 'gorouter' do
           end
         end
 
-        fcontext 'when the timestamp format is set to deprecated' do
+        context 'when the timestamp format is set to deprecated' do
           before do
             deployment_manifest_fragment['router']['logging'] = { 'format' => { 'timestamp' => 'deprecated' } }
           end
@@ -1246,6 +1246,46 @@ describe 'gorouter' do
           end
           it 'it properly sets the value' do
             expect(parsed_yaml['logging']['enable_attempts_details']).to eq(true)
+          end
+        end
+
+        context 'when access log streaming via syslog is enabled' do
+          before do
+            deployment_manifest_fragment['router']['write_access_logs_locally'] = false
+            deployment_manifest_fragment['router']['enable_access_log_streaming'] = true
+          end
+          it 'it properly sets the value' do
+            expect(parsed_yaml['access_log']['file']).to eq('')
+            expect(parsed_yaml['access_log']['enable_streaming']).to eq(true)
+          end
+          it 'it properly sets default values' do
+            expect(parsed_yaml['logging']['syslog']).to eq('vcap.gorouter')
+            expect(parsed_yaml['logging']['syslog_addr']).to eq('localhost:514')
+            expect(parsed_yaml['logging']['syslog_network']).to eq('udp')
+          end
+          context 'when syslog tag is set' do
+            before do
+              deployment_manifest_fragment['router']['logging'] = { 'syslog_tag' => 'funny.cat' }
+            end
+            it 'it properly sets the value' do
+              expect(parsed_yaml['logging']['syslog']).to eq('funny.cat')
+            end
+          end
+          context 'when syslog address is set' do
+            before do
+              deployment_manifest_fragment['router']['logging'] = { 'syslog_addr' => '10.0.1.2:1234' }
+            end
+            it 'it properly sets the value' do
+              expect(parsed_yaml['logging']['syslog_addr']).to eq('10.0.1.2:1234')
+            end
+          end
+          context 'when syslog network protocol is set' do
+            before do
+              deployment_manifest_fragment['router']['logging'] = { 'syslog_network' => 'tcp' }
+            end
+            it 'it properly sets default values' do
+              expect(parsed_yaml['logging']['syslog_network']).to eq('tcp')
+            end
           end
         end
       end


### PR DESCRIPTION
# What is this change about?

Gorouter already supports sending access logs to syslog, though the necessary properties haven't been exposed until now. This PR adds job specs for gorouter that make use of the feature.

# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [x] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

_If you have selected multiple of the above, it may be wise to consider splitting this PR into multiple PRs to decrease the time for minor changes + bugs to be resolved._

# Backwards Compatibility

The feature should be fully backwards compatible.

# How should this be tested?

1. set `router.write_access_logs_locally` to `false`
2. set `router.enable_access_log_streaming` to `true`
3. adjust `router.logging.syslog_*` properties as needed
4. Deploy
5. Gorouter should no longer write an access_log file but send it to syslog instead

# Additional Context

Companion [gorouter PR](https://github.com/cloudfoundry/gorouter/pull/399)

# PR Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have made this pull request to the `develop` branch.
* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [x] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

