### PR TITLE
Add toggle to allow empty `Content-Length` headers

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -599,6 +599,14 @@ properties:
             street_address: []
             postal_code: []
     default: []
+
   healthchecker.failure_counter_file:
     description: "File used by the healthchecker to monitor consecutive failures."
     default: /var/vcap/data/gorouter/counters/consecutive_healthchecker_failures.count
+
+  go.httplaxcontentlength:
+    description: |
+        Environment Flag to temporarily allow requests containing an invalid, empty `Content-Length` header for backwards compatibility.
+        This toggle allows operators to add the `GODEBUG` field `httplaxcontentlength=1`, as allowable per the [go 1.22 release documentation](https://tip.golang.org/doc/go1.22#minor_library_changes).
+        Defaults to `false` as the default behavior in go 1.22+ is to reject these requests.
+    default: false

--- a/jobs/gorouter/templates/bpm.yml.erb
+++ b/jobs/gorouter/templates/bpm.yml.erb
@@ -26,5 +26,9 @@ bpm = {
   ]
 }
 
+if p('go.httplaxcontentlength') == true
+      bpm['processes'][0]['env']['GODEBUG'] << ',httplaxcontentlength=1'
+end
+
 YAML.dump(bpm)
 %>

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -1643,7 +1643,7 @@ describe 'gorouter' do
       context 'when go.HTTPLaxContentLength is enabled' do
         before do
           deployment_manifest_fragment['go'] = {
-            'httplaxcontentlength' => true,
+            'httplaxcontentlength' => true
           }
         end
 

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -1628,6 +1628,31 @@ describe 'gorouter' do
       end
     end
   end
+
+  describe 'bpm' do
+    let(:deployment_manifest_fragment) { {} }
+    let(:template) { job.template('config/bpm.yml') }
+    let(:rendered_template) { template.render(deployment_manifest_fragment) }
+    subject(:parsed_yaml) { YAML.safe_load(rendered_template) }
+
+    context 'GODEBUG' do
+      it 'defaults to netdns=cgo' do
+        expect(parsed_yaml['processes'][0]['env']['GODEBUG']).to eq('netdns=cgo')
+      end
+
+      context 'when go.HTTPLaxContentLength is enabled' do
+        before do
+          deployment_manifest_fragment['go'] = {
+            'httplaxcontentlength' => true,
+          }
+        end
+
+        it 'sets httplaxcontentlength=1 correctly' do
+          expect(parsed_yaml['processes'][0]['env']['GODEBUG']).to eq('netdns=cgo,httplaxcontentlength=1')
+        end
+      end
+    end
+  end
 end
 
 # rubocop:enable Layout/LineLength


### PR DESCRIPTION
# What is this change about?

In go 1.22, they are changing the default behavior in the `net/http` standard library to **REJECT** requests and responses containing an invalid, empty `Content-Length` header.
Source: https://tip.golang.org/doc/go1.22#minor_library_changes

As per the authors,
> The previous behavior may be restored by setting GODEBUG field httplaxcontentlength=1.

This commit enables operators to set this GODEBUG field by configuring `gorouter`'s `go.httplaxcontentlength` property.

By default, this property will be disabled and gorouter will begin to reject requests that contain invlaid, empty `Content-Length` headers.

[#187125229](https://www.pivotaltracker.com/story/show/187125229)

# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [X] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

_If you have selected multiple of the above, it may be wise to consider splitting this PR into multiple PRs to decrease the time for minor changes + bugs to be resolved._

# Backwards Compatibility

This PR enables us to provide backwards compatible behavior when we upgrade to go 1.22

# How should this be tested?

There are template tests.

# Additional Context

_Please provide any additional links or context (issues, other PRs, Slack discussions) to help understand this change._

# PR Checklist
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have made this pull request to the `develop` branch.
* [X] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [X] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

