### PR TITLE
Default the routing_api.enabled_api_endpoints to mtls

### DIFF
--- a/jobs/routing-api/spec
+++ b/jobs/routing-api/spec
@@ -95,7 +95,7 @@ properties:
 
   routing_api.enabled_api_endpoints:
     description: "Protocols that the routing api will listen on. Possible values: 'mtls', or 'both' (mTLS + HTTP)"
-    default: "both"
+    default: "mtls"
   routing_api.mtls_port:
     description: "Port on which Routing API is running, listening with mTLS."
     default: 3001

--- a/spec/routing_api_templates_spec.rb
+++ b/spec/routing_api_templates_spec.rb
@@ -195,7 +195,7 @@ describe 'routing_api' do
                                     },
                                     'api' => {
                                       'listen_port' => 3000,
-                                      'http_enabled' => true,
+                                      'http_enabled' => false,
                                       'mtls_listen_port' => 3001,
                                       'mtls_client_ca_file' => '/var/vcap/jobs/routing-api/config/certs/routing-api/client_ca.crt',
                                       'mtls_server_cert_file' => '/var/vcap/jobs/routing-api/config/certs/routing-api/server.crt',


### PR DESCRIPTION
# What is this change about?

Switch the default for routing_api.enabled_api_endpoints from "both" to "mtls" to prefer secure endpoints

# What type of change is this?

- [x] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [ ] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

# Backwards Compatibility

This should be backwards compatible since this property can be switched back to "both" by operator.

# How should this be tested?

Deploy routing-release without setting `routing_api.enabled_api_endpoints` and see that the value of `enabled_api_endpoints` in routing-api job is set to "mtls"

# PR Checklist
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have made this pull request to the `develop` branch.
* [ ] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [X] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

