### PR TITLE
Pass availability zone to route registrar

### DIFF
--- a/jobs/route_registrar/templates/registrar_settings.json.erb
+++ b/jobs/route_registrar/templates/registrar_settings.json.erb
@@ -152,6 +152,7 @@ TEXT
     host: host,
     routes: routes,
     routing_api: routing_api,
+    availability_zone: spec.az,
   }
   JSON.pretty_generate(config)
 %>

--- a/spec/route_registar_templates_spec.rb
+++ b/spec/route_registar_templates_spec.rb
@@ -416,7 +416,8 @@ describe 'route_registrar' do
             'cert_path' => '/var/vcap/jobs/route_registrar/config/nats/certs/client.crt',
             'key_path' => '/var/vcap/jobs/route_registrar/config/nats/certs/client_private.key',
             'ca_path' => '/var/vcap/jobs/route_registrar/config/nats/certs/server_ca.crt'
-          }
+          },
+          'availability_zone' => 'az1',
         )
       end
     end


### PR DESCRIPTION


[#187326055](https://www.pivotaltracker.com/story/show/187326055)

# What is this change about?

Pass availability zone to route registrar so that it can include it in the registration message to Gorouter for AZ-aware routing

# What type of change is this?

- [ ] `[Breaking Change]`: the change removes a feature or introduces a behavior change to core functionality (request routing, request logging)
- [X] `[Minor Feature/Improvement]`:  the change introduces a new feature or improvement that doesn't alter core behavior
- [ ] `[Bug Fix]`: the change addresses a defect

# Backwards Compatibility

Backwards compatible since this is a separate field and Gorouter handles when it is empty.

# How should this be tested?

* Deploy Gorouter in Locally-Optimitic mode and 3 AZs.
* Scale cloud controller to 3 instances. Verify after deploy each instance is in different AZ.
* SSH to Gorouter in AZ-1 and curl it:
```
curl -H "Host: api.sys.cf-app.com" localhost:80
```
* See that only cloud-controller in AZ-1 gets requests. SSH into cloud-controller and watch its nginx access logs. See that other cloud-controllers don't get requests via these logs.

# Additional Context

https://www.pivotaltracker.com/story/show/187326055

# PR Checklist
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have made this pull request to the `develop` branch.
* [X] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).
* [X] I have given thought to the backward-compatibility requirements of this change, and listed any mitigations above.
* [ ] (Optional) I have [run Routing Acceptance Tests and Routing Smoke Tests](https://github.com/cloudfoundry/routing-acceptance-tests/tree/e2a5b4eebc7e60615afb10ddbd250c5de73aa9fa#running-test-suites).
* [ ] (Optional) I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests#test-setup).

