### PR TITLE
feat: Add per-route options to route_registrar spec

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -125,7 +125,8 @@ properties:
           with error, the route is unregistered.
         router_group (required, string, for tcp routes): Name of the router group to which the TCP route should be added.
         external_port (required, string, for tcp routes): Port that the TCP router will listen on.
-        server_cert_domain_name_modifier (optional, string, for sni routes): a regex replace to help with complicated hostnames
+        server_cert_domain_name_modifier (optional, string, for sni routes): a regex replace to help with complicated hostnames.
+        options (optional, object, for http routes): Custom per-route options
 
       health_check object
         name (required, string): Human-readable reference for the healthcheck
@@ -134,6 +135,9 @@ properties:
         timeout (optional, string): The healthcheck script must exit within this timeout, otherwise
           the script is terminated with `SIGKILL` and the route is unregistered. Value is a string (e.g. "10s") and must parse to a positive time duration i.e. "-5s" is not permitted. Must be less than the value of `registration_interval`.
           Default: Half of the value of `registration_interval`
+
+      options object
+        lb_algo (optional, string): Load balancing algorithm for routing incoming requests to the backend: 'round-robin' or 'least-connection'. In cases where this option is not specified, the algorithm defined in gorouter spec is applied.
 
     example: |
       - name: my-service
@@ -150,6 +154,8 @@ properties:
           script_path: /path/to/script
           timeout: 5s
         route_service_url: https://my-oauth-proxy-route-service.example.com
+        options:
+          lb_algo: least-connection
       - name: my-tls-endpoint
         tls_port: 12346
         server_cert_domain_san: "my-tls-endpoint.internal.com"

--- a/jobs/route_registrar/templates/registrar_settings.json.erb
+++ b/jobs/route_registrar/templates/registrar_settings.json.erb
@@ -81,6 +81,12 @@ TEXT
       raise "expected route_registrar.routes[#{index}].route.protocol to be http1 or http2 when protocol is provided"
     end
 
+    if route['options'] != nil
+      if (route['options']['lb_algo'] != nil && route['options']['lb_algo'] != 'least-connection' && route['options']['lb_algo'] != 'round-robin')
+        raise "expected route_registrar.routes[#{index}].route.options.lb_algo to be least-connection or round-robin when provided"
+      end
+    end
+
     if route['prepend_instance_index']
       route['uris'].map! { |uri| "#{spec.index}-#{uri}" }
     end


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
- Add route-registrar spec property for custom per-route option load balancing algorithm. It is possible to choose between `round-robin` and `least-connection`.
- Implementation of custom options in route-registrar: [route-registrar#40](https://github.com/cloudfoundry/route-registrar/pull/40)
- Change according to [RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0027-generic-per-route-features.md)


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
