### PR TITLE
Use forked negroni/v3 to work around HTTP Status Code issue  with 100 continues

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -10,6 +10,9 @@ replace github.com/codegangsta/cli => github.com/codegangsta/cli v1.6.0
 
 replace github.com/cactus/go-statsd-client => github.com/cactus/go-statsd-client v2.0.2-0.20150911070441-6fa055a7b594+incompatible
 
+// Use forked negroni to work around https://github.com/cloudfoundry/routing-release/issues/409 until https://github.com/urfave/negroni/pull/277 is merged
+replace github.com/urfave/negroni/v3 => github.com/geofffranks/negroni/v3 v3.0.0-20240514190444-68130a0ac8eb
+
 require (
 	code.cloudfoundry.org/bbs v0.0.0-20240418184526-a7ed0dccd9f7
 	code.cloudfoundry.org/cfhttp/v2 v2.0.1


### PR DESCRIPTION


- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Needed until https://github.com/urfave/negroni/pull/277 is merged, to resolve https://github.com/cloudfoundry/routing-release/issues/409.


Backward Compatibility
---------------
Breaking Change? **Yes/No**
No, fixes a regression.