### PR TITLE
Add flag to reuse backend connection for requests expecting 100-Continue

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -306,6 +306,9 @@ properties:
   router.keep_alive_probe_interval:
     default: 1s
     description: Interval between TCP keep alive probes. Value is a string (e.g. "10s")
+  router.keep_alive_100_continue_requests:
+    description: "If set gorouter reuses backend connection for requests expecting 100-Continue"
+    default: false
   router.force_forwarded_proto_https:
     description: "Enables setting X-Forwarded-Proto header if SSL termination happened upstream and incorrectly set the header value. When this property is set to true gorouter sets the header X-Forwarded-Proto to https. When this value set to false, gorouter set the header X-Forwarded-Proto to the protocol of the incoming request"
     default: false

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -259,6 +259,7 @@ if p("router.max_idle_connections") && p("router.max_idle_connections") > 0
 else
   params['disable_keep_alives'] = true
 end
+params['keep_alive_100_continue_requests'] = p('router.keep_alive_100_continue_requests')
 
 if p('router.tracing.enable_w3c')
   params['tracing']['w3c_tenant_id'] = p('router.tracing.w3c_tenant_id') == '' ? nil : p('router.tracing.w3c_tenant_id')


### PR DESCRIPTION
Summary
This PR is follow-up for https://github.com/cloudfoundry/gorouter/pull/418 to allow operators to turn off closing connections for 100-Continue requests.


Backward Compatibility
---------------
Breaking Change? **No**