### PR TITLE
fix(gorouter): introduce strict rs signature validation flag

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -262,6 +262,9 @@ properties:
   router.route_services_timeout:
     description: "Expiry time of a route service signature in seconds"
     default: 60
+  router.route_services_strict_signature_validation:
+      description: "Enforce strict validation of a route service signature"
+      default: false
   router.max_header_kb:
     description: |
         This value controls the maximum number of bytes (in KB) the gorouter will read

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -306,10 +306,13 @@ if (route_service_attempts < 1 )
   raise 'router.route_services.max_attempts must maintain a minimum value of 1'
 end
 
+strict_signature_validation = p('router.route_services_strict_signature_validation')
+
 route_services = {
   'max_attempts' => route_service_attempts,
   'cert_chain' => route_services_cert_chain,
   'private_key' => route_services_private_key,
+  'strict_signature_validation' => strict_signature_validation,
 }
 
 params['route_services'] = route_services

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -188,7 +188,8 @@ describe 'gorouter' do
           'route_services' => {
             'max_attempts' => 3,
             'cert_chain' => ROUTE_SERVICES_CLIENT_TEST_CERT,
-            'private_key' => ROUTE_SERVICES_CLIENT_TEST_KEY
+            'private_key' => ROUTE_SERVICES_CLIENT_TEST_KEY,
+            'strict_signature_validation' => false
           },
           'frontend_idle_timeout' => 5,
           'ip_local_port_range' => '1024 65535',
@@ -656,6 +657,19 @@ describe 'gorouter' do
           it 'should not error and should not configure the properties' do
             expect(parsed_yaml['route_services']['cert_chain']).to eq('')
             expect(parsed_yaml['route_services']['private_key']).to eq('')
+          end
+        end
+        context 'when strict_signature_validation not set' do
+          it 'defaults to false' do
+            expect(parsed_yaml['route_services']['strict_signature_validation']).to eq(false)
+          end
+        end
+        context 'when strict_signature_validation enabled' do
+          before do
+            deployment_manifest_fragment['router']['route_services_strict_signature_validation'] = true
+          end
+          it 'parses to true' do
+            expect(parsed_yaml['route_services']['strict_signature_validation']).to eq(true)
           end
         end
       end


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Introduce a new property route_services_strict_signature_validation. If the value is set to true, gorouter must validate a route service signature.

Related to https://github.com/cloudfoundry/gorouter/pull/421


Backward Compatibility
---------------
Breaking Change? **No**

