### PR TITLE
Migrate back to upstream negroni after https://github.com/urfave/negroni/pull/277 was merged

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -10,9 +10,6 @@ replace github.com/codegangsta/cli => github.com/codegangsta/cli v1.6.0
 
 replace github.com/cactus/go-statsd-client => github.com/cactus/go-statsd-client v2.0.2-0.20150911070441-6fa055a7b594+incompatible
 
-// Use forked negroni to work around https://github.com/cloudfoundry/routing-release/issues/409 until https://github.com/urfave/negroni/pull/277 is merged
-replace github.com/urfave/negroni/v3 => github.com/geofffranks/negroni/v3 v3.0.0-20240514190444-68130a0ac8eb
-
 require (
 	code.cloudfoundry.org/bbs v0.0.0-20240521125508-20d3971ce31b
 	code.cloudfoundry.org/cfhttp/v2 v2.1.0

--- a/src/code.cloudfoundry.org/go.sum
+++ b/src/code.cloudfoundry.org/go.sum
@@ -739,8 +739,6 @@ github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzP
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/geofffranks/negroni/v3 v3.0.0-20240514190444-68130a0ac8eb h1:0OTAn/jD+HjgiPEKHzt70R4KsY+1GfOp7f7y58W0GlU=
-github.com/geofffranks/negroni/v3 v3.0.0-20240514190444-68130a0ac8eb/go.mod h1:jWvnX03kcSjDBl/ShB0iHvx5uOs7mAzZXW+JvJ5XYAs=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
 github.com/go-fonts/latin-modern v0.2.0/go.mod h1:rQVLdDMK+mK1xscDwsqM5J8U2jrRa3T0ecnM9pNujks=
@@ -1064,6 +1062,8 @@ github.com/uber-go/atomic v1.1.0 h1:Gu4ORRQiHXJvKAHRN5OKzswnjkNjrRkNGxUPnbtSklw=
 github.com/uber-go/atomic v1.1.0/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
 github.com/uber-go/zap v0.0.0-20161222040304-a5783ee4b216 h1:BOf50qt5z70bo4WpdYgSDHRFbuubqPuaxZ7atAGPMiI=
 github.com/uber-go/zap v0.0.0-20161222040304-a5783ee4b216/go.mod h1:GY+83l3yxBcBw2kmHu/sAWwItnTn+ynxHCRo+WiIQOY=
+github.com/urfave/negroni/v3 v3.1.1 h1:6MS4nG9Jk/UuCACaUlNXCbiKa0ywF9LXz5dGu09v8hw=
+github.com/urfave/negroni/v3 v3.1.1/go.mod h1:jWvnX03kcSjDBl/ShB0iHvx5uOs7mAzZXW+JvJ5XYAs=
 github.com/vito/go-sse v1.0.0 h1:e6/iTrrvy8BRrOwJwmQmlndlil+TLdxXvHi55ZDzH6M=
 github.com/vito/go-sse v1.0.0/go.mod h1:2wkcaQ+jtlZ94Uve8gYZjFpL68luAjssTINA2hpgcZs=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=

--- a/src/code.cloudfoundry.org/vendor/github.com/urfave/negroni/v3/CHANGELOG.md
+++ b/src/code.cloudfoundry.org/vendor/github.com/urfave/negroni/v3/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 **ATTN**: This project uses [semantic versioning](http://semver.org/).
 
+## [3.1.1] - [2024-06-04]
+
+### Fixed
+
+- Writing an HTTP 1xx status codes no longer results in a 200 being sent in
+  addition given the expectation is that a follow-up status code will be written
+  later. The exception is `101 Switching Protocols` since this is terminal. This
+  matches `net/http` behavior.
+
 ## [3.1.0] - [2023-10-07]
 
 ### Fixed

--- a/src/code.cloudfoundry.org/vendor/github.com/urfave/negroni/v3/response_writer.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/urfave/negroni/v3/response_writer.go
@@ -102,7 +102,7 @@ func (rw *responseWriter) Size() int {
 }
 
 func (rw *responseWriter) Written() bool {
-	return rw.status >= http.StatusOK // don't treat 1xx responses as being written, as 100s are interim response codes and likely to send another response code
+	return rw.status >= http.StatusOK || rw.status == http.StatusSwitchingProtocols // treat all 1xx codes aside from SwitchingProtocols as non-terminal
 }
 
 func (rw *responseWriter) Before(before func(ResponseWriter)) {

--- a/src/code.cloudfoundry.org/vendor/modules.txt
+++ b/src/code.cloudfoundry.org/vendor/modules.txt
@@ -351,7 +351,7 @@ github.com/uber-go/atomic
 # github.com/uber-go/zap v1.27.0 => github.com/uber-go/zap v0.0.0-20161222040304-a5783ee4b216
 ## explicit
 github.com/uber-go/zap
-# github.com/urfave/negroni/v3 v3.1.1 => github.com/geofffranks/negroni/v3 v3.0.0-20240514190444-68130a0ac8eb
+# github.com/urfave/negroni/v3 v3.1.1
 ## explicit; go 1.17
 github.com/urfave/negroni/v3
 # github.com/vito/go-sse v1.0.0
@@ -608,4 +608,3 @@ gopkg.in/yaml.v3
 # github.com/uber-go/atomic => github.com/uber-go/atomic v1.1.0
 # github.com/codegangsta/cli => github.com/codegangsta/cli v1.6.0
 # github.com/cactus/go-statsd-client => github.com/cactus/go-statsd-client v2.0.2-0.20150911070441-6fa055a7b594+incompatible
-# github.com/urfave/negroni/v3 => github.com/geofffranks/negroni/v3 v3.0.0-20240514190444-68130a0ac8eb


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Reverts to using upstream negroni as a go dependency after https://github.com/urfave/negroni/pull/277 was merged.


Backward Compatibility
---------------
No.
