### PR TITLE
Add tls/mtls support for TCP router via new bosh properties

### DIFF
--- a/jobs/tcp_router/spec
+++ b/jobs/tcp_router/spec
@@ -10,6 +10,8 @@ templates:
   routing_api_client_certificate.crt.erb: config/certs/routing-api/client.crt
   routing_api_client_private.key.erb: config/keys/routing-api/client.key
   routing_api_ca_certificate.crt.erb: config/certs/routing-api/ca_cert.crt
+  tcp_router_backend_client_cert_and_key.pem.erb: config/keys/tcp-router/backend/client_cert_and_key.pem
+  tcp_router_backend_ca.crt.erb: config/certs/tcp-router/backend/ca.crt
   tcp_router_health_check_certificate.pem.erb: config/certs/health.pem
   haproxy.conf.erb: config/haproxy.conf
   haproxy.conf.template.erb: config/haproxy.conf.template
@@ -46,6 +48,12 @@ properties:
     default: "1m"
   tcp_router.oauth_secret:
     description: "OAuth client secret used to obtain token for Routing API from UAA."
+  tcp_router.backend_tls.client_cert:
+    description: "TCP Router's TLS client cert used for mTLS with route backends"
+  tcp_router.backend_tls.client_key:
+    description: "TCP Router's TLS client private key used for mTLS with route backends"
+  tcp_router.backend_tls.ca_cert:
+    description: "TCP Router's TLS CA used with route backends"
 
   routing_api.uri:
     description: "URL where the routing API can be reached internally"

--- a/jobs/tcp_router/spec
+++ b/jobs/tcp_router/spec
@@ -48,6 +48,12 @@ properties:
     default: "1m"
   tcp_router.oauth_secret:
     description: "OAuth client secret used to obtain token for Routing API from UAA."
+  tcp_router.backend_tls.enabled:
+    description: |
+      Turns on support for TLS for TCP Router. Requires tcp_router.backend_tls.ca_cert to
+      be set. For mTLS also set tcp_router.backend_tls.client_cert and
+      tcp_router.backend_tls.client_key.
+    default: false
   tcp_router.backend_tls.client_cert:
     description: "TCP Router's TLS client cert used for mTLS with route backends"
   tcp_router.backend_tls.client_key:

--- a/jobs/tcp_router/templates/tcp_router.yml.erb
+++ b/jobs/tcp_router/templates/tcp_router.yml.erb
@@ -59,28 +59,32 @@ haproxy_pid_file: "/var/vcap/data/tcp_router/config/haproxy.pid"
 isolation_segments: <%= p("tcp_router.isolation_segments") %>
 reserved_system_component_ports: <%=  reserved_system_component_ports %>
 <%
-    ca_cert =     p('tcp_router.backend_tls.ca_cert', '').strip
-    client_cert = p('tcp_router.backend_tls.client_cert', '').strip
-    client_key =  p('tcp_router.backend_tls.client_key', '').strip
+    backend_tls_enabled = p('tcp_router.backend_tls.enabled')
 
-    if ca_cert == '' and client_cert != ''
-      raise 'tcp_router.backend_tls.client_cert was specified, but tcp_router.backend_tls.ca_cert was not provided'
-    end
-    if ca_cert == '' and client_key != ''
-      raise 'tcp_router.backend_tls.client_key was specified, but tcp_router.backend_tls.ca_cert was not provided'
-    end
-    if client_cert == '' and client_key != ''
-      raise 'tcp_router.backend_tls.client_key was specified, but tcp_router.backend_tls.client_cert was not provided'
-    end
-    if client_key == '' and client_cert != ''
-      raise 'tcp_router.backend_tls.client_cert was specified, but tcp_router.backend_tls.client_key was not provided'
-    end
+    if backend_tls_enabled
+      ca_cert =     p('tcp_router.backend_tls.ca_cert', '').strip
+      client_cert = p('tcp_router.backend_tls.client_cert', '').strip
+      client_key =  p('tcp_router.backend_tls.client_key', '').strip
 
+      if ca_cert == ''
+        raise 'tcp_router.backend_tls.enabled was set to true, but tcp_router.backend_tls.ca_cert was not provided'
+      end
+
+      if client_cert == '' and client_key != ''
+        raise 'tcp_router.backend_tls.enabled was set to true, tcp_router.backend_tls.client_key was set, but tcp_router.backend_tls.client_cert was not provided'
+      end
+
+      if client_key == '' and client_cert != ''
+        raise 'tcp_router.backend_tls.enabled was set to true, tcp_router.backend_tls.client_cert was set, but tcp_router.backend_tls.client_key was not provided'
+      end
+    end
 -%>
-<% if ca_cert != '' -%>
+
 backend_tls:
+  enabled: <%= backend_tls_enabled %>
+<% if backend_tls_enabled %>
   ca_cert_path: "/var/vcap/jobs/tcp_router/config/certs/tcp-router/backend/ca.crt"
-<% if client_cert != '' -%>
+<% if client_cert != '' and client_key != '' %>
   client_cert_and_key_path: "/var/vcap/jobs/tcp_router/config/keys/tcp-router/backend/client_cert_and_key.pem"
-<% end -%>
+<% end %>
 <% end -%>

--- a/jobs/tcp_router/templates/tcp_router.yml.erb
+++ b/jobs/tcp_router/templates/tcp_router.yml.erb
@@ -59,9 +59,9 @@ haproxy_pid_file: "/var/vcap/data/tcp_router/config/haproxy.pid"
 isolation_segments: <%= p("tcp_router.isolation_segments") %>
 reserved_system_component_ports: <%=  reserved_system_component_ports %>
 <%
-    ca_cert =     p('tcp_router.backend_tls.ca_cert', '')
-    client_cert = p('tcp_router.backend_tls.client_cert', '')
-    client_key =  p('tcp_router.backend_tls.client_key', '')
+    ca_cert =     p('tcp_router.backend_tls.ca_cert', '').strip
+    client_cert = p('tcp_router.backend_tls.client_cert', '').strip
+    client_key =  p('tcp_router.backend_tls.client_key', '').strip
 
     if ca_cert == '' and client_cert != ''
       raise 'tcp_router.backend_tls.client_cert was specified, but tcp_router.backend_tls.ca_cert was not provided'

--- a/jobs/tcp_router/templates/tcp_router.yml.erb
+++ b/jobs/tcp_router/templates/tcp_router.yml.erb
@@ -58,3 +58,29 @@ routing_api:
 haproxy_pid_file: "/var/vcap/data/tcp_router/config/haproxy.pid"
 isolation_segments: <%= p("tcp_router.isolation_segments") %>
 reserved_system_component_ports: <%=  reserved_system_component_ports %>
+<%
+    ca_cert =     p('tcp_router.backend_tls.ca_cert', '')
+    client_cert = p('tcp_router.backend_tls.client_cert', '')
+    client_key =  p('tcp_router.backend_tls.client_key', '')
+
+    if ca_cert == '' and client_cert != ''
+      raise 'tcp_router.backend_tls.client_cert was specified, but tcp_router.backend_tls.ca_cert was not provided'
+    end
+    if ca_cert == '' and client_key != ''
+      raise 'tcp_router.backend_tls.client_key was specified, but tcp_router.backend_tls.ca_cert was not provided'
+    end
+    if client_cert == '' and client_key != ''
+      raise 'tcp_router.backend_tls.client_key was specified, but tcp_router.backend_tls.client_cert was not provided'
+    end
+    if client_key == '' and client_cert != ''
+      raise 'tcp_router.backend_tls.client_cert was specified, but tcp_router.backend_tls.client_key was not provided'
+    end
+
+-%>
+<% if ca_cert != '' -%>
+backend_tls:
+  ca_cert_path: "/var/vcap/jobs/tcp_router/config/certs/tcp-router/backend/ca.crt"
+<% if client_cert != '' -%>
+  client_cert_and_key_path: "/var/vcap/jobs/tcp_router/config/keys/tcp-router/backend/client_cert_and_key.pem"
+<% end -%>
+<% end -%>

--- a/jobs/tcp_router/templates/tcp_router_backend_ca.crt.erb
+++ b/jobs/tcp_router/templates/tcp_router_backend_ca.crt.erb
@@ -1,0 +1,9 @@
+<%=
+  def server_ca_cert
+    if_p('tcp_router.backend_tls.ca_cert') do |prop|
+      return prop
+    end
+  end
+
+  server_ca_cert
+-%>

--- a/jobs/tcp_router/templates/tcp_router_backend_client_cert_and_key.pem.erb
+++ b/jobs/tcp_router/templates/tcp_router_backend_client_cert_and_key.pem.erb
@@ -1,0 +1,18 @@
+<%=
+  def cert
+    if_p('tcp_router.backend_tls.client_cert') do |prop|
+      return prop
+    end
+  end
+
+  cert
+%>
+<%=
+  def private_key
+    if_p('tcp_router.backend_tls.client_key') do |prop|
+      return prop
+    end
+  end
+
+  private_key
+-%>

--- a/scripts/docker/test.bash
+++ b/scripts/docker/test.bash
@@ -27,7 +27,7 @@ pushd / > /dev/null
 if [[ -n "${1:-}" ]]; then
   test "src/code.cloudfoundry.org/${1}" "${2:-}"
 else
-  internal_repos=$(yq -r '.internal_repos|.[].name' "/ci/$REPO_NAME/index.yml")
+  internal_repos=$(yq -r '.internal_repos[] | select(.acceptance != true) | .name' "/ci/$REPO_NAME/index.yml")
   for component in $internal_repos; do
     test "src/code.cloudfoundry.org/${component}"
   done

--- a/spec/tcp_router_templates_spec.rb
+++ b/spec/tcp_router_templates_spec.rb
@@ -304,6 +304,7 @@ describe 'tcp_router' do
                                       'port' => 1000,
                                       'skip_ssl_validation' => false
                                     },
+                                    'backend_tls' => { 'enabled' => false },
                                     'reserved_system_component_ports' => [8080, 8081],
                                     'routing_api' => {
                                       'uri' => 'https://routing-api.service.cf.internal',
@@ -316,57 +317,176 @@ describe 'tcp_router' do
     end
 
     describe 'tcp_router.backend_tls' do
-      describe 'when a CA is provided' do
-          let :backend_tls do
-            {
-              'ca_cert' => 'ca cert',
-            }
-          end
-
-        it 'renders the backend_tls properties' do
-          expect(rendered_config['backend_tls']).to eq({
-            'ca_cert_path' => '/var/vcap/jobs/tcp_router/config/certs/tcp-router/backend/ca.crt',
-          })
+      describe 'when disabled' do
+        let :backend_tls do
+          {
+            'enabled' => false,
+            'ca_cert' => 'meowca',
+            'client_cert' => 'meowcert',
+            'client_key' => 'meowkey',
+          }
         end
 
-        describe 'when client cert/keys are provided' do
+        it 'does not set the CA path or client cert/key path' do
+            expect(rendered_config['backend_tls']).to eq({
+              'enabled' => false,
+            })
+        end
+      end
+      describe 'when enabled' do
+        describe 'when CA is a whitespace-only string' do
           let :backend_tls do
             {
+              'enabled' => true,
+              'ca_cert' => ' ',
+            }
+          end
+          it 'throws an error' do
+              expect { rendered_config }.to raise_error(
+                RuntimeError,
+                'tcp_router.backend_tls.enabled was set to true, but tcp_router.backend_tls.ca_cert was not provided',
+              )
+          end
+        end
+        describe 'when CA is not provided' do
+          let :backend_tls do
+            {
+              'enabled' => true,
+            }
+          end
+          it 'throws an error' do
+              expect { rendered_config }.to raise_error(
+                RuntimeError,
+                'tcp_router.backend_tls.enabled was set to true, but tcp_router.backend_tls.ca_cert was not provided',
+              )
+          end
+        end
+
+
+        describe 'when a CA is provided' do
+          let :backend_tls do
+            {
+              'enabled' => true,
               'ca_cert' => 'ca cert',
-              'client_cert' => 'client cert',
-              'client_key' =>'client key',
             }
           end
 
           it 'renders the backend_tls properties' do
             expect(rendered_config['backend_tls']).to eq({
+              'enabled' => true,
               'ca_cert_path' => '/var/vcap/jobs/tcp_router/config/certs/tcp-router/backend/ca.crt',
-              'client_cert_and_key_path' => '/var/vcap/jobs/tcp_router/config/keys/tcp-router/backend/client_cert_and_key.pem',
             })
           end
 
-        end
+          describe 'when client cert/keys are provided' do
+            let :backend_tls do
+              {
+                'enabled' => true,
+                'ca_cert' => 'ca cert',
+                'client_cert' => 'client cert',
+                'client_key' =>'client key',
+              }
+            end
 
-        describe 'when a client cert is provided but not a key' do
-          let :backend_tls do
-            {
-              'ca_cert' => 'ca cert',
-              'client_cert' => 'client cert',
-            }
+            it 'renders the backend_tls properties' do
+              expect(rendered_config['backend_tls']).to eq({
+                'enabled' => true,
+                'ca_cert_path' => '/var/vcap/jobs/tcp_router/config/certs/tcp-router/backend/ca.crt',
+                'client_cert_and_key_path' => '/var/vcap/jobs/tcp_router/config/keys/tcp-router/backend/client_cert_and_key.pem',
+              })
+            end
           end
 
-          it 'throws an error' do
-            expect { rendered_config }.to raise_error(
-              RuntimeError,
-              'tcp_router.backend_tls.client_cert was specified, but tcp_router.backend_tls.client_key was not provided',
-            )
+          describe 'when a client cert is provided but not a key' do
+            let :backend_tls do
+              {
+                'enabled' => true,
+                'ca_cert' => 'ca cert',
+                'client_cert' => 'client cert',
+              }
+            end
+
+            it 'throws an error' do
+              expect { rendered_config }.to raise_error(
+                RuntimeError,
+                'tcp_router.backend_tls.enabled was set to true, tcp_router.backend_tls.client_cert was set, but tcp_router.backend_tls.client_key was not provided',
+              )
+            end
+          end
+
+          describe 'when client cert is provided but key is a whitespace-only string' do
+            let :backend_tls do
+              {
+                'enabled' => true,
+                'ca_cert' => 'ca cert',
+                'client_cert' => 'client cert',
+                'client_key' => ' ',
+              }
+            end
+
+            it 'throws an error' do
+              expect { rendered_config }.to raise_error(
+                RuntimeError,
+                'tcp_router.backend_tls.enabled was set to true, tcp_router.backend_tls.client_cert was set, but tcp_router.backend_tls.client_key was not provided',
+              )
+            end
+          end
+
+          describe 'when a client key is provided but not a cert' do
+            let :backend_tls do
+              {
+                'enabled' => true,
+                'ca_cert' => 'ca cert',
+                'client_key' =>'client key',
+              }
+            end
+
+            it 'throws an error' do
+              expect { rendered_config }.to raise_error(
+                RuntimeError,
+                'tcp_router.backend_tls.enabled was set to true, tcp_router.backend_tls.client_key was set, but tcp_router.backend_tls.client_cert was not provided',
+              )
+            end
+          end
+
+          describe 'when client key is provided but cert is a whitespace-only string' do
+            let :backend_tls do
+              {
+                'enabled' => true,
+                'ca_cert' => 'ca cert',
+                'client_cert' => ' ',
+                'client_key' =>'client key',
+              }
+            end
+
+            it 'throws an error' do
+              expect { rendered_config }.to raise_error(
+                RuntimeError,
+                'tcp_router.backend_tls.enabled was set to true, tcp_router.backend_tls.client_key was set, but tcp_router.backend_tls.client_cert was not provided',
+              )
+            end
           end
         end
 
-        describe 'when a client key is provided but not a cert' do
+        describe 'when a client cert is provided but not the CA' do
+            let :backend_tls do
+              {
+                'enabled' => true,
+                'client_cert' => 'client cert',
+              }
+            end
+
+            it 'throws an error' do
+              expect { rendered_config }.to raise_error(
+                RuntimeError,
+                'tcp_router.backend_tls.enabled was set to true, but tcp_router.backend_tls.ca_cert was not provided',
+              )
+            end
+        end
+        describe 'when a client key is provided but not the CA' do
           let :backend_tls do
             {
-              'ca_cert' => 'ca cert',
+              'enabled' => true,
               'client_key' =>'client key',
             }
           end
@@ -374,39 +494,26 @@ describe 'tcp_router' do
           it 'throws an error' do
             expect { rendered_config }.to raise_error(
               RuntimeError,
-              'tcp_router.backend_tls.client_key was specified, but tcp_router.backend_tls.client_cert was not provided',
+              'tcp_router.backend_tls.enabled was set to true, but tcp_router.backend_tls.ca_cert was not provided',
             )
           end
         end
-      end
-
-      describe 'when a client cert is provided but not the CA' do
+        describe 'when a client key is provided but the CA is whitespace-only ' do
           let :backend_tls do
             {
-              'client_cert' => 'client cert',
-            }
-          end
-
-          it 'throws an error' do
-            expect { rendered_config }.to raise_error(
-              RuntimeError,
-              'tcp_router.backend_tls.client_cert was specified, but tcp_router.backend_tls.ca_cert was not provided',
-            )
-          end
-      end
-      describe 'when a client key is provided but not the CA' do
-          let :backend_tls do
-            {
+              'enabled' => true,
               'client_key' =>'client key',
+              'ca_cert' => ' ',
             }
           end
 
           it 'throws an error' do
             expect { rendered_config }.to raise_error(
               RuntimeError,
-              'tcp_router.backend_tls.client_key was specified, but tcp_router.backend_tls.ca_cert was not provided',
+              'tcp_router.backend_tls.enabled was set to true, but tcp_router.backend_tls.ca_cert was not provided',
             )
           end
+        end
       end
     end
 

--- a/spec/tcp_router_templates_spec.rb
+++ b/spec/tcp_router_templates_spec.rb
@@ -9,11 +9,13 @@ describe 'tcp_router' do
   let(:release_path) { File.join(File.dirname(__FILE__), '..') }
   let(:release) { Bosh::Template::Test::ReleaseDir.new(release_path) }
   let(:job) { release.job('tcp_router') }
+  let(:backend_tls) { {} }
 
   let(:merged_manifest_properties) do
     {
       'tcp_router' => {
-        'oauth_secret' => ''
+        'oauth_secret' => '',
+        'backend_tls' => backend_tls,
       },
       'uaa' => {
         'tls_port' => 1000
@@ -243,6 +245,26 @@ describe 'tcp_router' do
     end
   end
 
+  describe 'config/keys/tcp-router/client_cert_and_key.pem' do
+    let(:template) { job.template('config/keys/tcp-router/backend/client_cert_and_key.pem') }
+
+    it 'renders the client cert + key in a single PEM file' do
+      merged_manifest_properties['tcp_router']['backend_tls']['client_cert'] = "the backend client cert"
+      merged_manifest_properties['tcp_router']['backend_tls']['client_key'] = "the backend client key"
+      client_pem = template.render(merged_manifest_properties)
+      expect(client_pem).to eq("the backend client cert\nthe backend client key")
+    end
+  end
+
+  describe 'config/certs/tcp-router/ca.crt' do
+    let(:template) { job.template('config/certs/tcp-router/backend/ca.crt') }
+
+    it 'renders the ca.crt' do
+      merged_manifest_properties['tcp_router']['backend_tls']['ca_cert'] = "the backend ca cert"
+      expect(template.render(merged_manifest_properties)).to eq('the backend ca cert')
+    end
+  end
+
   describe 'tcp_router.yml' do
     let(:template) { job.template('config/tcp_router.yml') }
     let(:links) do
@@ -291,6 +313,101 @@ describe 'tcp_router' do
                                       'ca_cert_path' => '/var/vcap/jobs/tcp_router/config/certs/routing-api/ca_cert.crt',
                                       'client_private_key_path' => '/var/vcap/jobs/tcp_router/config/keys/routing-api/client.key'
                                     })
+    end
+
+    describe 'tcp_router.backend_tls' do
+      describe 'when a CA is provided' do
+          let :backend_tls do
+            {
+              'ca_cert' => 'ca cert',
+            }
+          end
+
+        it 'renders the backend_tls properties' do
+          expect(rendered_config['backend_tls']).to eq({
+            'ca_cert_path' => '/var/vcap/jobs/tcp_router/config/certs/tcp-router/backend/ca.crt',
+          })
+        end
+
+        describe 'when client cert/keys are provided' do
+          let :backend_tls do
+            {
+              'ca_cert' => 'ca cert',
+              'client_cert' => 'client cert',
+              'client_key' =>'client key',
+            }
+          end
+
+          it 'renders the backend_tls properties' do
+            expect(rendered_config['backend_tls']).to eq({
+              'ca_cert_path' => '/var/vcap/jobs/tcp_router/config/certs/tcp-router/backend/ca.crt',
+              'client_cert_and_key_path' => '/var/vcap/jobs/tcp_router/config/keys/tcp-router/backend/client_cert_and_key.pem',
+            })
+          end
+
+        end
+
+        describe 'when a client cert is provided but not a key' do
+          let :backend_tls do
+            {
+              'ca_cert' => 'ca cert',
+              'client_cert' => 'client cert',
+            }
+          end
+
+          it 'throws an error' do
+            expect { rendered_config }.to raise_error(
+              RuntimeError,
+              'tcp_router.backend_tls.client_cert was specified, but tcp_router.backend_tls.client_key was not provided',
+            )
+          end
+        end
+
+        describe 'when a client key is provided but not a cert' do
+          let :backend_tls do
+            {
+              'ca_cert' => 'ca cert',
+              'client_key' =>'client key',
+            }
+          end
+
+          it 'throws an error' do
+            expect { rendered_config }.to raise_error(
+              RuntimeError,
+              'tcp_router.backend_tls.client_key was specified, but tcp_router.backend_tls.client_cert was not provided',
+            )
+          end
+        end
+      end
+
+      describe 'when a client cert is provided but not the CA' do
+          let :backend_tls do
+            {
+              'client_cert' => 'client cert',
+            }
+          end
+
+          it 'throws an error' do
+            expect { rendered_config }.to raise_error(
+              RuntimeError,
+              'tcp_router.backend_tls.client_cert was specified, but tcp_router.backend_tls.ca_cert was not provided',
+            )
+          end
+      end
+      describe 'when a client key is provided but not the CA' do
+          let :backend_tls do
+            {
+              'client_key' =>'client key',
+            }
+          end
+
+          it 'throws an error' do
+            expect { rendered_config }.to raise_error(
+              RuntimeError,
+              'tcp_router.backend_tls.client_key was specified, but tcp_router.backend_tls.ca_cert was not provided',
+            )
+          end
+      end
     end
 
     describe 'routing_api.reserved_system_component_ports' do


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Adds TLS/mTLS support to TCP Router.

Supercedes #422. 


Backward Compatibility
---------------
Breaking Change? Nope
