### PR TITLE
Add drain_wait + lb_healthy_threshold properties for tcp_router

### DIFF
--- a/jobs/tcp_router/spec
+++ b/jobs/tcp_router/spec
@@ -13,9 +13,13 @@ templates:
   tcp_router_backend_client_cert_and_key.pem.erb: config/keys/tcp-router/backend/client_cert_and_key.pem
   tcp_router_backend_ca.crt.erb: config/certs/tcp-router/backend/ca.crt
   tcp_router_health_check_certificate.pem.erb: config/certs/health.pem
+  # config/haproxy.conf is used for initial haproxy config when starting up
   haproxy.conf.erb: config/haproxy.conf
-  haproxy.conf.template.erb: config/haproxy.conf.template
+  # config/haproxy.conf.template is rendered by tcp-router when routes are provided
+  haproxy.conf.template.erb: config/haproxy.conf.template 
   bpm.yml.erb: config/bpm.yml
+  drain.erb: bin/drain
+  post-start.erb: bin/post-start
 
 packages:
   - routing_utils
@@ -99,6 +103,19 @@ properties:
   tcp_router.fail_on_router_port_conflicts:
     description: "Fail the tcp router if routing_api.reserved_system_component_ports conflict with ports in existing router groups."
     default: "false"
+
+  tcp_router.drain_wait:
+    description: |
+      Delay in seconds after shut down is initiated before haproxy stops listening.
+      During this time haproxy will reject requests to the /health endpoint.
+      This accommodates requests forwarded by a load balancer until it considers the tcp_router unhealthy.
+    default: 20
+  tcp_router.load_balancer_healthy_threshold:
+    description: |
+      Time period in seconds to wait until declaring the tcp_router instance
+      started after starting the listener socket. This allows an external load
+      balancer time to register the instance as healthy."
+    default: 20
 
   uaa.token_endpoint:
     description: "UAA token endpoint host name. Do not include a scheme in this value; TCP Router will always use TLS to connect to UAA."

--- a/jobs/tcp_router/templates/drain.erb
+++ b/jobs/tcp_router/templates/drain.erb
@@ -1,0 +1,35 @@
+#!/bin/bash
+# vim: set ft=sh
+
+set -e
+
+pidfile=/var/vcap/sys/run/bpm/tcp_router/tcp_router.pid
+log_file=/var/vcap/sys/log/tcp_router/drain.log
+mkdir -p "$(dirname ${log_file})"
+
+log() {
+  log_string=$1
+
+  echo "$(date +%Y-%m-%dT%H:%M:%S.%NZ): ${log_string}" >> ${log_file}
+}
+
+if [[ ! -f ${pidfile} ]]; then
+  log "pidfile does not exist"
+  echo 0
+  exit 0
+fi
+
+pid="$(cat ${pidfile})"
+
+if kill -SIGUSR2 "${pid}"; then
+  # per https://bosh.io/docs/drain/
+  # echoing -5 here tells BOSH to sleep 5 mins and call the drain script again.
+  log "triggering drain"
+  echo -5
+else
+  # we get here when tcp-router has exited and there's no pid to signal, catches race condition
+  # when pulling pid from pidfile + actually signalling
+  log "tcp-router exited"
+  rm ${pidfile}
+  echo 0
+fi

--- a/jobs/tcp_router/templates/haproxy.conf.erb
+++ b/jobs/tcp_router/templates/haproxy.conf.erb
@@ -20,9 +20,11 @@ listen health_check_http_url
     mode http
     bind :<%= p("tcp_router.health_check_port") %>
     monitor-uri /health
+    monitor fail if { env(IS_DRAINING) -m str true }
 <% end %>
 
 listen health_check_https_url
     mode http
     bind :<%= p("tcp_router.tls_health_check_port") %> ssl crt /var/vcap/jobs/tcp_router/config/certs/health.pem
     monitor-uri /health
+    monitor fail if { env(IS_DRAINING) -m str true }

--- a/jobs/tcp_router/templates/haproxy.conf.template.erb
+++ b/jobs/tcp_router/templates/haproxy.conf.template.erb
@@ -20,9 +20,11 @@ listen health_check_http_url
     mode http
     bind :<%= p("tcp_router.health_check_port") %>
     monitor-uri /health
+    monitor fail if { env(IS_DRAINING) -m str true }
 <% end %>
 
 listen health_check_https_url
     mode http
     bind :<%= p("tcp_router.tls_health_check_port") %> ssl crt /var/vcap/jobs/tcp_router/config/certs/health.pem
     monitor-uri /health
+    monitor fail if { env(IS_DRAINING) -m str true }

--- a/jobs/tcp_router/templates/haproxy_reloader
+++ b/jobs/tcp_router/templates/haproxy_reloader
@@ -2,10 +2,15 @@
 
 set -e
 
+# ignore the SIGUSR2 signal in case we were reconfiguring haproxy while a SIGUSR2 event came in,
+# we don't want to abort this process
+trap "echo Ignoring SIGUSR2" SIGUSR2
+
+
 LOGFILE="/var/vcap/sys/log/tcp_router/haproxy_reloader.log"
 
 PATH="/var/vcap/packages/tcp_router/bin:/var/vcap/packages/haproxy/bin:$PATH"
-DAEMON="$(which haproxy)"
+DAEMON="/var/vcap/packages/haproxy/bin/haproxy"
 CONFIG=/var/vcap/data/tcp_router/config/haproxy.conf
 HAPROXY_PID_FILE=/var/vcap/data/tcp_router/config/haproxy.pid
 HAPROXY_SOCKET_FILE=/var/vcap/data/tcp_router/config/haproxy.sock

--- a/jobs/tcp_router/templates/post-start.erb
+++ b/jobs/tcp_router/templates/post-start.erb
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+LOG_DIR=/var/vcap/sys/log/tcp_router
+source /var/vcap/packages/routing_utils/syslog_utils.sh
+<% lb_delay = p("tcp_router.load_balancer_healthy_threshold") %>
+
+tee_output_to_sys_log "${LOG_DIR}" "post-start" rfc3339
+
+echo "Waiting <%= lb_delay %> seconds to allow load balancer to consider tcp_router healthy..."
+sleep <%= lb_delay %>
+echo "tcp_tcp_router is ready."

--- a/jobs/tcp_router/templates/tcp_router.yml.erb
+++ b/jobs/tcp_router/templates/tcp_router.yml.erb
@@ -58,6 +58,9 @@ routing_api:
 haproxy_pid_file: "/var/vcap/data/tcp_router/config/haproxy.pid"
 isolation_segments: <%= p("tcp_router.isolation_segments") %>
 reserved_system_component_ports: <%=  reserved_system_component_ports %>
+
+drain_wait: <%= p('tcp_router.drain_wait') %>s
+
 <%
     backend_tls_enabled = p('tcp_router.backend_tls.enabled')
 

--- a/spec/tcp_router_templates_spec.rb
+++ b/spec/tcp_router_templates_spec.rb
@@ -304,6 +304,7 @@ describe 'tcp_router' do
                                       'port' => 1000,
                                       'skip_ssl_validation' => false
                                     },
+                                    'drain_wait' => '20s',
                                     'backend_tls' => { 'enabled' => false },
                                     'reserved_system_component_ports' => [8080, 8081],
                                     'routing_api' => {
@@ -314,6 +315,16 @@ describe 'tcp_router' do
                                       'ca_cert_path' => '/var/vcap/jobs/tcp_router/config/certs/routing-api/ca_cert.crt',
                                       'client_private_key_path' => '/var/vcap/jobs/tcp_router/config/keys/routing-api/client.key'
                                     })
+    end
+
+    describe 'when overriding the default drain_wait' do
+      before do
+        merged_manifest_properties['tcp_router']['drain_wait'] = 30
+      end
+
+      it 'propagates to the yml' do
+        expect(rendered_config['drain_wait']).to eq('30s')
+      end
     end
 
     describe 'tcp_router.backend_tls' do


### PR DESCRIPTION

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Plumbs drain_wait into tcp_router, and reconfigures the haproxy health monitor to support conditionally failing (when in drain mode) so that load balancers will remove it from service.

Adds a post-start script based on gorouter's that will wait until load balancers have had time to re-add nodes to the pool before moving onto the next instance, to ensure there's always at least one healthy tcp router in the load balancing pool during deploys.


Backward Compatibility
---------------
Breaking Change? No. The new properties have sane defaults. The drain + post-start scripts require no operator intervention. Deploy times will be slightly longer, but availability will be much higher for tcp-routes during deploys.