### PR TITLE
add additional unsafe params

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -132,9 +132,15 @@ properties:
         name (required, string): Human-readable reference for the healthcheck
         script_path (required, string): Path to script that will be run periodically to determine
           service health
+        unrestricted_volumes (optional, array of unrestricted_volumes): Additional directories to be mounted in the bpm config for the route_registrar job.
+        privileged: (optional, boolean): Sets bpm privileged flag. defaults to false
         timeout (optional, string): The healthcheck script must exit within this timeout, otherwise
           the script is terminated with `SIGKILL` and the route is unregistered. Value is a string (e.g. "10s") and must parse to a positive time duration i.e. "-5s" is not permitted. Must be less than the value of `registration_interval`.
           Default: Half of the value of `registration_interval`
+
+      unrestricted_volume object
+        path (required, string): the path to be mounted
+        writable (optional, boolean): sets the writable flag. defaults to false
 
       options object
         lb_algo (optional, string): Load balancing algorithm for routing incoming requests to the backend: 'round-robin' or 'least-connection'. In cases where this option is not specified, the algorithm defined in gorouter spec is applied.

--- a/jobs/route_registrar/templates/bpm.yml.erb
+++ b/jobs/route_registrar/templates/bpm.yml.erb
@@ -19,7 +19,9 @@ bpm = {
 }
 
 paths = []
+unrestricted_volumes = []
 routes = p('route_registrar.routes')
+unsafe_privileged = false
 routes.each do |route|
   if route['health_check']
     # valid path is /var/vcap/jobs/JOB
@@ -27,19 +29,43 @@ routes.each do |route|
     if matched
       paths << matched[1]
     end
+
+    if route['health_check']['privileged']
+      unsafe_privileged = route['health_check']['privileged']
+    end
+
+    if route['health_check']['unrestricted_volumes']
+      unrestricted_volumes.concat(route['health_check']['unrestricted_volumes'].map { |unrestricted_volume|
+        {
+          "path" => unrestricted_volume["path"],
+          "writable" => unrestricted_volume["writable"] || false,
+        }
+      })
+    end
   end
 end
 
 unless paths.empty?
   unsafe = {
     "unsafe" => {
-      "unrestricted_volumes" => []
+      "privileged" => unsafe_privileged,
+      "unrestricted_volumes" => unrestricted_volumes
     }
   }
 
-   paths.each do |path|
-     unsafe['unsafe']['unrestricted_volumes'] << {"path" =>  path, "allow_executions" => true}
-     unsafe['unsafe']['unrestricted_volumes'] << {"path" => path.sub('jobs', 'data')}
+  paths.each do |path|
+    merge_on_path = ->(hash) {
+      existing_path = unsafe['unsafe']['unrestricted_volumes'].find { |unrestricted_volume| unrestricted_volume['path'] == hash['path'] }
+      if existing_path
+        existing_path.merge!(hash)
+      else
+        unsafe['unsafe']['unrestricted_volumes'] << hash
+      end
+    }
+
+    merge_on_path.call( {"path" =>  path, "allow_executions" => true} )
+    merge_on_path.call( {"path" => path.sub('jobs', 'data')} )
+
   end
 
   bpm['processes'][0].merge!(unsafe)


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
this allows for more unsafe params to be set.

this is to allow postgres to invoke and access
data persistent disks which are necessary in order to query the database to determine if a node is
primary during an HA configuration.

allows for privlaged and additional volumes
to be mounted


Backward Compatibility
---------------
Breaking Change? **No**

