### PR TITLE
Add dynamic_config_globs property to route_registrar

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -94,6 +94,10 @@ properties:
   route_registrar.routing_api.server_ca_cert:
     description: "Routing API Certificate Authority"
 
+  route_registrar.dynamic_config_globs:
+    description: "Files matching the globs contain routes configuration that will be loaded dynamically. Parent directory must exist for bpm to mount it."
+    default: [/var/vcap/jobs/*/config/route_registrar/config.yml]
+
   route_registrar.routes:
     description: |
       (required, array of objects): Routes that will be registered

--- a/jobs/route_registrar/templates/bpm.yml.erb
+++ b/jobs/route_registrar/templates/bpm.yml.erb
@@ -22,12 +22,14 @@ paths = []
 unrestricted_volumes = []
 routes = p('route_registrar.routes')
 unsafe_privileged = false
+
 routes.each do |route|
   if route['health_check']
     # valid path is /var/vcap/jobs/JOB
     matched = /(^\/var\/vcap\/jobs\/[^\/]*)\/.*/.match(route['health_check']['script_path'])
     if matched
-      paths << matched[1]
+      paths.append({ "path" => matched[1], "allow_executions" => true })
+      paths.append({ "path" => matched[1].sub('jobs', 'data') })
     end
 
     if route['health_check']['privileged']
@@ -39,34 +41,35 @@ routes.each do |route|
         {
           "path" => unrestricted_volume["path"],
           "writable" => unrestricted_volume["writable"] || false,
+          "allow_executions" => unrestricted_volume["allow_executions"] || false,
         }
       })
     end
   end
 end
 
+if_p('route_registrar.dynamic_config_globs') do |globs|
+   globs.each do |glob|
+     paths.append({ "path" => File.dirname(glob), "mount_only" => true })
+   end
+ end
+
 unless paths.empty?
+  paths.each do |path|
+    existing_path = unrestricted_volumes.find { |unrestricted_volume| unrestricted_volume['path'] == path['path'] }
+    if existing_path
+      existing_path.merge!(path)
+    else
+      unrestricted_volumes << path
+    end
+  end
+
   unsafe = {
     "unsafe" => {
       "privileged" => unsafe_privileged,
       "unrestricted_volumes" => unrestricted_volumes
     }
   }
-
-  paths.each do |path|
-    merge_on_path = ->(hash) {
-      existing_path = unsafe['unsafe']['unrestricted_volumes'].find { |unrestricted_volume| unrestricted_volume['path'] == hash['path'] }
-      if existing_path
-        existing_path.merge!(hash)
-      else
-        unsafe['unsafe']['unrestricted_volumes'] << hash
-      end
-    }
-
-    merge_on_path.call( {"path" =>  path, "allow_executions" => true} )
-    merge_on_path.call( {"path" => path.sub('jobs', 'data')} )
-
-  end
 
   bpm['processes'][0].merge!(unsafe)
 end

--- a/jobs/route_registrar/templates/registrar_settings.json.erb
+++ b/jobs/route_registrar/templates/registrar_settings.json.erb
@@ -157,6 +157,7 @@ TEXT
     nats_mtls_config: nats_mtls_config,
     host: host,
     routes: routes,
+    dynamic_config_globs: p('route_registrar.dynamic_config_globs'),
     routing_api: routing_api,
     availability_zone: spec.az,
   }

--- a/packages/route_registrar/spec
+++ b/packages/route_registrar/spec
@@ -66,3 +66,4 @@ files:
   - code.cloudfoundry.org/vendor/golang.org/x/oauth2/internal/*.go # gosub
   - code.cloudfoundry.org/vendor/golang.org/x/sys/cpu/*.go # gosub
   - code.cloudfoundry.org/vendor/golang.org/x/sys/cpu/*.s # gosub
+  - code.cloudfoundry.org/vendor/gopkg.in/yaml.v3/*.go # gosub


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Add new property `dynamic_config_globs` to route-registrar job that specifies list of globs route-registrar will be scanning periodically to register routes dynamically.
Also, simplify bpm template, remove lambda from unrestricted volumes.

Backward Compatibility
---------------
Breaking Change? **No**
