### PR TITLE
Make ReadHeaderTimeout configurable in release

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -364,6 +364,9 @@ properties:
       Generally, this timeout must be greater than that of the load balancer. As examples, GCP HTTP(S) load balancer has a default timeout of 600 seconds so a value greater than 600 is recommended and AWS ELB has a default timeout of 60 seconds so a value greater than 60 is recommended.
       However, depending on the IaaS, this timeout may need to be shorter than the load balancer's timeout, e.g., Azure's load balancer times out at 240 seconds (by default) and GCP TCP load balancer times out at 600 seconds without sending a TCP RST to clients, so a value lower than this is recommended in order to force it to send the TCP RST.
     default: 900
+  router.read_header_timeout:
+    description: "The amount of time allowed to read request headers."
+    default: 0
   router.backends.max_conns:
     description: "Maximum concurrent TCP connections per backend. When set to 0 there is no limit"
     default: 500

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -119,6 +119,7 @@ params = {
   'suspend_pruning_if_nats_unavailable' => p("router.suspend_pruning_if_nats_unavailable"),
   'route_latency_metric_muzzle_duration' => '30s',
   'frontend_idle_timeout' => "#{p('router.frontend_idle_timeout')}s",
+  'read_header_timeout' => "#{p('router.read_header_timeout')}s",
   'drain_wait' => "#{p('router.drain_wait')}s",
   'drain_timeout' => "#{p('router.drain_timeout')}s",
   'healthcheck_user_agent' => p('router.healthcheck_user_agent'),


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Keeping to 0 by default for backwards compatibility.

Backward Compatibility
---------------
Breaking Change? **No**
