### PR TITLE
fix: bump minimum go version to 1.23 for partitioned cookies

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org
 
-go 1.22.0
+go 1.23.0
 
 toolchain go1.22.3
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->

Bump minimum go version to 1.23 since support for partitioned cookies was only introduced with go1.23.


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
