### PR TITLE
Map reserved_system_component_ports to integer

### DIFF
--- a/jobs/tcp_router/templates/tcp_router.yml.erb
+++ b/jobs/tcp_router/templates/tcp_router.yml.erb
@@ -13,11 +13,11 @@ end
 
 def reserved_system_component_ports
   if_p('reserved_system_component_ports') do |prop|
-    return prop
+    return prop.map(&:to_i)
   end.else do
     if_link('routing_api') do |link|
       link.if_p('routing_api.reserved_system_component_ports') do |prop|
-        return prop
+        return prop.map(&:to_i)
       end
     end
   end


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This maps reserved_system_component_ports to integers. Previously, if passed as an array of strings, they would be ignored silently.


Backward Compatibility
---------------
Breaking Change? **Yes**

This change, while technically breaking, puts guard rails up to ensure functionality is transparent to the operator.