### PR TITLE
Make TCP Router's backend TLS cert files render repeatably when no certs are passed in to avoid unnecessary updates of the tcp-router VMs

### DIFF
--- a/jobs/tcp_router/templates/tcp_router_backend_ca.crt.erb
+++ b/jobs/tcp_router/templates/tcp_router_backend_ca.crt.erb
@@ -1,9 +1,1 @@
-<%=
-  def server_ca_cert
-    if_p('tcp_router.backend_tls.ca_cert') do |prop|
-      return prop
-    end
-  end
-
-  server_ca_cert
--%>
+<%= p('tcp_router.backend_tls.ca_cert', "") -%>

--- a/jobs/tcp_router/templates/tcp_router_backend_client_cert_and_key.pem.erb
+++ b/jobs/tcp_router/templates/tcp_router_backend_client_cert_and_key.pem.erb
@@ -1,18 +1,2 @@
-<%=
-  def cert
-    if_p('tcp_router.backend_tls.client_cert') do |prop|
-      return prop
-    end
-  end
-
-  cert
-%>
-<%=
-  def private_key
-    if_p('tcp_router.backend_tls.client_key') do |prop|
-      return prop
-    end
-  end
-
-  private_key
--%>
+<%= p('tcp_router.backend_tls.client_cert', "") %>
+<%= p('tcp_router.backend_tls.client_key', "") -%>


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
if_p was rendering into a stringification of Bosh::Template::EvaluationContext::ActiveElseBlock when no certs were provided, which changes every time it's rendered. Now it just returns an empty string if no cert is provided for repeatability.

Backward Compatibility
---------------
Breaking Change? no