### PR TITLE
Let route_registrar consume client creds from routing_api's link if provided

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -77,10 +77,9 @@ properties:
     description: (optional, string) The OAuth server's URL. This is required to register any TCP routes.
     default: https://uaa.service.cf.internal:8443
   route_registrar.routing_api.client_id:
-    description: (optional, string) An OAuth client ID for a client that is permitted to add new TCP routes. This is required to register any TCP routes.
-    default: routing_api_client
+    description: (optional, string) An OAuth client ID for a client that is permitted to add new TCP routes. This is required to register any TCP routes. If set, overrides values provided via routing_api's link. If not provided via link or property, defaults to 'routing_api_client'.
   route_registrar.routing_api.client_secret:
-    description: (optional, string) The OAuth client secret for the above client. This is required to register any TCP routes.
+    description: (optional, string) The OAuth client secret for the above client. This is required to register any TCP routes. If set, overrides values provided via routing_api's link. If not provided via link, this must be set when registering TCP routes.
   route_registrar.routing_api.ca_certs:
     description: (optional, array of strings) The certificate authority certificates for any APIs that the route registrar is communicating with over HTTPS, e.g., the OAuth server. This is required to register any TCP routes.
   route_registrar.routing_api.skip_ssl_validation:

--- a/jobs/route_registrar/templates/registrar_settings.json.erb
+++ b/jobs/route_registrar/templates/registrar_settings.json.erb
@@ -117,10 +117,18 @@ TEXT
     client_private_key_path: '/var/vcap/jobs/route_registrar/config/routing_api/keys/client_private.key',
     server_ca_cert_path: '/var/vcap/jobs/route_registrar/config/routing_api/certs/server_ca.crt',
     max_ttl: '120s',
+    client_id: 'routing_api_client',
   }
   if_link('routing_api') do |link|
     link.if_p('routing_api.max_ttl') do |prop|
       routing_api[:max_ttl] = prop
+    end
+
+
+    link.if_p('routing_api.clients') do |clients|
+      client_id = clients.keys.sort.first
+      routing_api[:client_id] = client_id
+      routing_api[:client_secret] = clients[client_id]['secret']
     end
   end
 
@@ -137,10 +145,10 @@ TEXT
     routing_api['oauth_url'] = prop
   end
   if_p('route_registrar.routing_api.client_id') do |prop|
-    routing_api['client_id'] = prop
+    routing_api[:client_id] = prop
   end
   if_p('route_registrar.routing_api.client_secret') do |prop|
-    routing_api['client_secret'] = prop
+    routing_api[:client_secret] = prop
   end
 
   routing_api['skip_ssl_validation'] = p('route_registrar.routing_api.skip_ssl_validation')


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Without this, the `clients` property in routing_api's link are ignored completely in route_registrar.


Backward Compatibility
---------------
Breaking Change? no