### PR TITLE
Update routing-api + route-registrar for tcp routes

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -71,16 +71,13 @@ properties:
     description: "Log level for route_registrar"
     default: "info"
   route_registrar.routing_api.api_url:
-    description: (optional, string) The routing API's URL. This is required to register any TCP routes.
-    default: https://routing-api.service.cf.internal:3001
+    description: (optional, string) The routing API's URL. This is required to register any TCP routes. If not provided here or via link, this defaults to 'https://routing-api.service.cf.internal:3001'
   route_registrar.routing_api.oauth_url:
-    description: (optional, string) The OAuth server's URL. This is required to register any TCP routes.
-    default: https://uaa.service.cf.internal:8443
+    description: (optional, string) The OAuth server's URL. This is required to register any TCP routes. If not provided here or via link, this defaults to 'https://uaa.service.cf.internal:8443'
   route_registrar.routing_api.client_id:
-    description: (optional, string) An OAuth client ID for a client that is permitted to add new TCP routes. This is required to register any TCP routes.
-    default: routing_api_client
+    description: (optional, string) An OAuth client ID for a client that is permitted to add new TCP routes. This is required to register any TCP routes. If set, overrides values provided via routing_api's link. If not provided via link or property, defaults to 'routing_api_client'.
   route_registrar.routing_api.client_secret:
-    description: (optional, string) The OAuth client secret for the above client. This is required to register any TCP routes.
+    description: (optional, string) The OAuth client secret for the above client. This is required to register any TCP routes. If set, overrides values provided via routing_api's link. If not provided via link, this must be set when registering TCP routes.
   route_registrar.routing_api.ca_certs:
     description: (optional, array of strings) The certificate authority certificates for any APIs that the route registrar is communicating with over HTTPS, e.g., the OAuth server. This is required to register any TCP routes.
   route_registrar.routing_api.skip_ssl_validation:

--- a/jobs/route_registrar/templates/ca.crt.erb
+++ b/jobs/route_registrar/templates/ca.crt.erb
@@ -1,3 +1,15 @@
-<% if_p('route_registrar.routing_api.ca_certs') do |value| %>
-<%= value.join("\n") %>
-<% end %>
+<%=
+  def ca_certs
+    if_p('route_registrar.routing_api.ca_certs') do |value|
+      return value.join("\n")
+    end.else do
+      if_link('routing_api') do |link|
+        return link.p('uaa.ca_cert')
+      end
+    end
+
+    return ''
+  end
+
+  ca_certs
+-%>

--- a/jobs/route_registrar/templates/registrar_settings.json.erb
+++ b/jobs/route_registrar/templates/registrar_settings.json.erb
@@ -117,10 +117,40 @@ TEXT
     client_private_key_path: '/var/vcap/jobs/route_registrar/config/routing_api/keys/client_private.key',
     server_ca_cert_path: '/var/vcap/jobs/route_registrar/config/routing_api/certs/server_ca.crt',
     max_ttl: '120s',
+    client_id: 'routing_api_client',
   }
+  oauth_endpoint = 'uaa.service.cf.internal'
+  oauth_port = '8443'
+
+  api_scheme = 'https'
+  api_endpoint = 'routing-api.service.cf.internal'
+  api_port = '3001'
+
   if_link('routing_api') do |link|
     link.if_p('routing_api.max_ttl') do |prop|
       routing_api[:max_ttl] = prop
+    end
+
+    link.if_p('routing_api.clients') do |clients|
+      client_id = clients.keys.sort.first
+      routing_api[:client_id] = client_id
+      routing_api[:client_secret] = clients[client_id]['secret']
+    end
+
+    link.if_p('uaa.token_endpoint') do |endpoint|
+      oauth_endpoint = endpoint
+    end
+
+    link.if_p('routing_api.enabled_api_endpoints') do |endpoints|
+      if endpoints == 'both' or endpoints == 'mtls'
+        api_scheme = 'https'
+        api_port = link.p('routing_api.tls_port', api_port)
+      end
+    end
+
+
+    link.if_p('uaa.tls_port') do |port|
+      oauth_port = port
     end
   end
 
@@ -131,17 +161,22 @@ TEXT
       end
     end
 
-    routing_api['api_url'] = prop
+    routing_api[:api_url] = prop
+  end.else do
+    routing_api[:api_url] = "#{api_scheme}://#{api_endpoint}:#{api_port}"
   end
-  if_p('route_registrar.routing_api.oauth_url') do |prop|
-    routing_api['oauth_url'] = prop
+  if_p('route_registrar.routing_api.oauth_url') do |endpoint|
+    routing_api[:oauth_url] = endpoint
+  end.else do
+    routing_api[:oauth_url] = "https://#{oauth_endpoint}:#{oauth_port}"
   end
   if_p('route_registrar.routing_api.client_id') do |prop|
-    routing_api['client_id'] = prop
+    routing_api[:client_id] = prop
   end
   if_p('route_registrar.routing_api.client_secret') do |prop|
-    routing_api['client_secret'] = prop
+    routing_api[:client_secret] = prop
   end
+
 
   routing_api['skip_ssl_validation'] = p('route_registrar.routing_api.skip_ssl_validation')
 

--- a/jobs/routing-api/spec
+++ b/jobs/routing-api/spec
@@ -47,6 +47,8 @@ provides:
   - routing_api.reserved_system_component_ports
   - routing_api.enabled_api_endpoints
   - routing_api.max_ttl
+  - uaa.token_endpoint
+  - uaa.tls_port
   - uaa.ca_cert
   - skip_ssl_validation
 - name: routing_api_db


### PR DESCRIPTION


- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The routing-api link needed some additional data exposed, and route-registrar needed to consume routing-api link data so for that + for other properties, so that it gets everything it needs to register TCP Routes.

- uaa.token_endpoint + uaa.tls_port -> routing_api.oauth_url
- routing_api.tls_port -> routing_api.api_url
- uaa.ca_cert -> routing_api.ca_certs
- routing_api.clients -> routing_api.client_id + routing_api.client_secret


Backward Compatibility
---------------
Breaking Change? no