### PR TITLE
feat: support syslog message truncation

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -313,6 +313,9 @@ properties:
   router.logging.syslog_tag:
     description: "Tag to use when writing syslog messages"
     default: "vcap.gorouter"
+  router.logging.syslog_message_limit:
+    description: "Limit the number of bytes per access log written to syslog. A value of zero disables the limit."
+    default: 0
   router.logging.syslog_addr:
     description: "Address of a syslog server to send access logs"
     default: "localhost:514"

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -398,6 +398,7 @@ end
 
 params['logging'] = {
   'syslog' => p('router.logging.syslog_tag'),
+  'syslog_truncate' => p('router.logging.syslog_message_limit'),
   'syslog_addr' => p('router.logging.syslog_addr'),
   'syslog_network' => p('router.logging.syslog_network'),
   'level' => p('router.logging_level'),

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -1386,6 +1386,19 @@ describe 'gorouter' do
               expect(parsed_yaml['logging']['syslog_network']).to eq('tcp')
             end
           end
+          context 'when syslog message length is set' do
+            before do
+              deployment_manifest_fragment['router']['logging'] = { 'syslog_message_limit' => 4096 }
+            end
+            it 'it properly sets the value' do
+              expect(parsed_yaml['logging']['syslog_truncate']).to eq(4096)
+            end
+          end
+          context 'when syslog message length is not set' do
+            it 'it properly sets default values' do
+              expect(parsed_yaml['logging']['syslog_truncate']).to eq(0)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Allow the user to specify a limit at which messages sent via syslog are truncated.

Backward Compatibility
---------------
Breaking Change? **No**

See also: cloudfoundry/gorouter#411 