### PR TITLE
feat: add option to expose additional log fields

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -322,6 +322,14 @@ properties:
   router.logging.syslog_network:
     description: "Network protocol to use when connecting to the syslog server. Valid values are 'tcp', 'udp', <empty>. When choosing an empty string value, the local syslog daemon is used."
     default: "udp"
+  router.logging.extra_access_log_fields:
+    description: |
+      An array of additional access log fields to log. Any new log fields will only be exposed via
+      this property and operators have to explicitly enable them. This is done to prevent breaking
+      log parsing in existing setups by the introduction of new fields. Does not affect stdout /
+      stderr logs.
+      Available fields are: local_address
+    default: []
   router.logging.format.timestamp:
     description: |
       Format for timestamp in component logs. Valid values are 'rfc3339', 'deprecated', and 'unix-epoch'."

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -391,6 +391,14 @@ if !['rfc3339', 'deprecated', 'unix-epoch'].include?(p('router.logging.format.ti
   raise "'#{p('router.logging.format.timestamp')}' is not a valid timestamp format for the property 'router.logging.format.timestamp'. Valid options are: 'rfc3339', 'deprecated', and 'unix-epoch'."
 end
 
+if_p('router.logging.extra_access_log_fields') do |extra_fields|
+  valid_extra_log_fields=['local_address']
+  if !extra_fields.all? { |el| valid_extra_log_fields.include?(el) }
+    raise "router.logging.extra_access_log_fields (#{extra_fields}) contains invalid values, valid are #{valid_extra_log_fields}"
+  end
+end
+
+
 timestamp_format=p('router.logging.format.timestamp')
 if timestamp_format == 'deprecated'
   timestamp_format = 'unix-epoch'
@@ -402,6 +410,7 @@ params['logging'] = {
   'syslog_addr' => p('router.logging.syslog_addr'),
   'syslog_network' => p('router.logging.syslog_network'),
   'level' => p('router.logging_level'),
+  'extra_access_log_fields' => p('router.logging.extra_access_log_fields'),
   'loggregator_enabled' => true,
   'metron_address' => "localhost:#{p('metron.port')}",
   'disable_log_forwarded_for' => p('router.disable_log_forwarded_for'),

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -1348,6 +1348,38 @@ describe 'gorouter' do
           end
         end
 
+        context 'when extra_access_log_fields is set' do
+          context 'to ["local_address"]' do
+            before do
+              deployment_manifest_fragment['router']['logging'] = { 'extra_access_log_fields' => ['local_address'] }
+            end
+
+            it 'properly sets the config property' do
+              expect(parsed_yaml['logging']['extra_access_log_fields']).to include('local_address')
+            end
+          end
+
+          context 'to ["foobar"]' do
+            before do
+              deployment_manifest_fragment['router']['logging'] = { 'extra_access_log_fields' => ['foobar'] }
+            end
+
+            it 'raises an error' do
+              expect { parsed_yaml }.to raise_error(RuntimeError, 'router.logging.extra_access_log_fields (["foobar"]) contains invalid values, valid are ["local_address"]')
+            end
+          end
+
+          context 'to ["local_address", "foobar"]' do
+            before do
+              deployment_manifest_fragment['router']['logging'] = { 'extra_access_log_fields' => ['local_address', 'foobar'] }
+            end
+
+            it 'still raises an error' do
+              expect { parsed_yaml }.to raise_error(RuntimeError, 'router.logging.extra_access_log_fields (["local_address", "foobar"]) contains invalid values, valid are ["local_address"]')
+            end
+          end
+        end
+
         context 'when access log streaming via syslog is enabled' do
           before do
             deployment_manifest_fragment['router']['write_access_logs_locally'] = false


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
