### PR TITLE
refactor: rename lb_algo to loadbalancing

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -144,7 +144,7 @@ properties:
         writable (optional, boolean): sets the writable flag. defaults to false
 
       options object
-        lb_algo (optional, string): Load balancing algorithm for routing incoming requests to the backend: 'round-robin' or 'least-connection'. In cases where this option is not specified, the algorithm defined in gorouter spec is applied.
+        loadbalancing (optional, string): Load balancing algorithm for routing incoming requests to the backend: 'round-robin' or 'least-connection'. In cases where this option is not specified, the algorithm defined in gorouter spec is applied.
 
     example: |
       - name: my-service
@@ -162,7 +162,7 @@ properties:
           timeout: 5s
         route_service_url: https://my-oauth-proxy-route-service.example.com
         options:
-          lb_algo: least-connection
+          loadbalancing: least-connection
       - name: my-tls-endpoint
         tls_port: 12346
         server_cert_domain_san: "my-tls-endpoint.internal.com"

--- a/jobs/route_registrar/templates/registrar_settings.json.erb
+++ b/jobs/route_registrar/templates/registrar_settings.json.erb
@@ -82,8 +82,8 @@ TEXT
     end
 
     if route['options'] != nil
-      if (route['options']['lb_algo'] != nil && route['options']['lb_algo'] != 'least-connection' && route['options']['lb_algo'] != 'round-robin')
-        raise "expected route_registrar.routes[#{index}].route.options.lb_algo to be least-connection or round-robin when provided"
+      if (route['options']['loadbalancing'] != nil && route['options']['loadbalancing'] != 'least-connection' && route['options']['loadbalancing'] != 'round-robin')
+        raise "expected route_registrar.routes[#{index}].route.options.loadbalancing to be least-connection or round-robin when provided"
       end
     end
 

--- a/spec/route_registar_templates_spec.rb
+++ b/spec/route_registar_templates_spec.rb
@@ -722,24 +722,24 @@ describe 'route_registrar' do
         merged_manifest_properties['route_registrar']['routes'][0]['options'] = {}
       end
 
-      it 'uses configured round-robin lb_algo' do
-        merged_manifest_properties['route_registrar']['routes'][0]['options']['lb_algo'] = 'round-robin'
+      it 'uses configured round-robin loadbalancing' do
+        merged_manifest_properties['route_registrar']['routes'][0]['options']['loadbalancing'] = 'round-robin'
         rendered_hash = JSON.parse(template.render(merged_manifest_properties, consumes: links))
-        expect(rendered_hash['routes'][0]['options']['lb_algo']).to eq('round-robin')
+        expect(rendered_hash['routes'][0]['options']['loadbalancing']).to eq('round-robin')
       end
-      it 'uses configured least-connection lb_algo' do
-        merged_manifest_properties['route_registrar']['routes'][0]['options']['lb_algo'] = 'least-connection'
+      it 'uses configured least-connection loadbalancing' do
+        merged_manifest_properties['route_registrar']['routes'][0]['options']['loadbalancing'] = 'least-connection'
         rendered_hash = JSON.parse(template.render(merged_manifest_properties, consumes: links))
-        expect(rendered_hash['routes'][0]['options']['lb_algo']).to eq('least-connection')
+        expect(rendered_hash['routes'][0]['options']['loadbalancing']).to eq('least-connection')
       end
-      it 'without lb_algo' do
+      it 'without loadbalancing' do
         rendered_hash = JSON.parse(template.render(merged_manifest_properties, consumes: links))
-        expect(rendered_hash['routes'][0]['options']['lb_algo']).to be nil
+        expect(rendered_hash['routes'][0]['options']['loadbalancing']).to be nil
       end
-      it 'raises error for unknown lb_algo' do
-        merged_manifest_properties['route_registrar']['routes'][0]['options']['lb_algo'] = 'unknown'
+      it 'raises error for unknown loadbalancing' do
+        merged_manifest_properties['route_registrar']['routes'][0]['options']['loadbalancing'] = 'unknown'
         expect { template.render(merged_manifest_properties, consumes: links) }.to raise_error(
-          RuntimeError, 'expected route_registrar.routes[0].route.options.lb_algo to be least-connection or round-robin when provided'
+          RuntimeError, 'expected route_registrar.routes[0].route.options.loadbalancing to be least-connection or round-robin when provided'
         )
       end
     end


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Renaming the `lb_algo` property to `loadbalancing` to align with cloud controller.
The per-route options feature ([RFC 0027](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0027-generic-per-route-features.md)) is not live yet, so this is not a breaking change.
See https://github.com/cloudfoundry/community/pull/1039 for an overview of all related PRs


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
