### PR TITLE
test: fix acceptance tests on Apple Silicon Macs

### DIFF
--- a/scripts/create-docker-container.bash
+++ b/scripts/create-docker-container.bash
@@ -34,12 +34,20 @@ else
   ARGS="${*}"
 fi
 
+# disable asyncpreempt on MacOS ARM64 (Apple Silicon) as it may cause sporadic errors in emulation
+# see: https://github.com/golang/go/issues/42774
+DISABLE_ASYNC_PREEMPT=
+if [ "$(uname -sm)" == "Darwin arm64" ]; then
+    DISABLE_ASYNC_PREEMPT='--env GODEBUG=asyncpreemptoff=1'
+fi
+
 docker pull "${IMAGE}"
 docker rm -f $CONTAINER_NAME
 docker run -it \
   --env "DB=${DB}" \
   --env "REPO_NAME=$REPO_NAME" \
   --env "REPO_PATH=/repo" \
+  $DISABLE_ASYNC_PREEMPT \
   --rm \
   --name "$CONTAINER_NAME" \
   -v "${REPO_PATH}:/repo" \
@@ -47,4 +55,3 @@ docker run -it \
   ${ARGS} \
   "${IMAGE}" \
   /bin/bash
-  


### PR DESCRIPTION
We observed sporadic compilation or bytecode issues
on Apple Silicon Macs.

According to https://github.com/golang/go/issues/42774,
the env variable `GODEBUG=asyncpreemptoff=1` works around
the issue by disabling asynchronous preemption of
goroutines.

This might impact garbage collection performance, but restores
the same level of reliability to locally running tests as
when run in Docker on an Intel based Mac.

The `GODEBUG=asyncpreemptoff=1` variable is set when creating
the Docker container for running tests locally, and applies
to all Go code, including `go vet`, for which we also observed
sporadic issues.
