### PR TITLE
 fix: Rename least-connection load-balancing algorithm consistently

### DIFF
--- a/docs/03-how-to-add-new-route-option.md
+++ b/docs/03-how-to-add-new-route-option.md
@@ -19,7 +19,7 @@ applications:
       loadbalancing: round-robin
   - route: example2.com
     options:
-      loadbalancing: least-connections
+      loadbalancing: least-connection
 ```
 
 **NOTE**: In the implementation, the `options` property of a route represents per-route features.


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This is a fix for https://github.com/cloudfoundry/cloud_controller_ng/issues/4198.

Backward Compatibility
---------------
Breaking Change? **No** - this fixes a typo in the documentation. 

