### PR TITLE
refactor: move timing info to extra access log fields logic

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -328,7 +328,7 @@ properties:
       this property and operators have to explicitly enable them. This is done to prevent breaking
       log parsing in existing setups by the introduction of new fields. Does not affect stdout /
       stderr logs.
-      Available fields are: local_address
+      Available fields are: backend_time, dial_time, dns_time, failed_attempts, failed_attempts_time, local_address, tls_time
     default: []
   router.logging.format.timestamp:
     description: |

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -391,11 +391,19 @@ if !['rfc3339', 'deprecated', 'unix-epoch'].include?(p('router.logging.format.ti
   raise "'#{p('router.logging.format.timestamp')}' is not a valid timestamp format for the property 'router.logging.format.timestamp'. Valid options are: 'rfc3339', 'deprecated', and 'unix-epoch'."
 end
 
+
+extra_access_log_fields = []
+# Support `enable_log_attempts_details` which was internally migrated to the new dynamic system.
+if p('router.enable_log_attempts_details')
+  extra_access_log_fields.concat(['failed_attempts', 'failed_attempts_time', 'dns_time', 'dial_time', 'tls_time', 'backend_time'])
+end
+
 if_p('router.logging.extra_access_log_fields') do |extra_fields|
-  valid_extra_log_fields=['local_address']
+  valid_extra_log_fields=['backend_time', 'dial_time', 'dns_time', 'failed_attempts', 'failed_attempts_time', 'local_address', 'tls_time']
   if !extra_fields.all? { |el| valid_extra_log_fields.include?(el) }
     raise "router.logging.extra_access_log_fields (#{extra_fields}) contains invalid values, valid are #{valid_extra_log_fields}"
   end
+  extra_access_log_fields.concat(extra_fields)
 end
 
 
@@ -410,13 +418,12 @@ params['logging'] = {
   'syslog_addr' => p('router.logging.syslog_addr'),
   'syslog_network' => p('router.logging.syslog_network'),
   'level' => p('router.logging_level'),
-  'extra_access_log_fields' => p('router.logging.extra_access_log_fields'),
+  'extra_access_log_fields' => extra_access_log_fields,
   'loggregator_enabled' => true,
   'metron_address' => "localhost:#{p('metron.port')}",
   'disable_log_forwarded_for' => p('router.disable_log_forwarded_for'),
   'disable_log_source_ip' => p('router.disable_log_source_ip'),
   'redact_query_params' => p('router.redact_query_parameters'),
-  'enable_attempts_details' => p('router.enable_log_attempts_details'),
   'format' => {
     'timestamp' => timestamp_format,
   },


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Now that we have to ability to add individual log fields I've migrated a set of log fields that was previously behind a special feature flag to use the same logic internally. The feature flag remains but gorouter is no longer aware of it.

The output is identical because the logic for the attempts logging and the dynamic logging is right next to each other. The template ensures that the order of the attempts logging fields is the same as it was previously in the gorouter code.


Backward Compatibility
---------------
Breaking Change? **No**