### PR TITLE
feat: Introduce switch for envelope v1 metrics

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -76,8 +76,11 @@ properties:
     description: "TLS Certificate used for the TLS listener of the LB healthcheck endpoint"
   router.status.tls.key:
     description: "Private Key used for the TLS listener of the LB healthcheck endpoint"
+  router.enable_envelope_v1_metrics:
+      description: "Enables support for metrics reported via Envelope."
+      default: true
   router.prometheus.port:
-    description: "Port for the prometheus endpoint."
+    description: "Port for the prometheus endpoint, automatically enables Prometheus support."
   router.prometheus.server_name:
     description: "The server name used in the certificate for the metrics endpoint."
   router.prometheus.ca_cert:

--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -93,13 +93,13 @@ properties:
     description: "TLS private key for prometheus server."
     default: ""
   router.prometheus.meters.route_lookup_time_histogram_buckets:
-    description: "Upper limits of the ranges in which the observed value of route lookup time is expected to fall"
+    description: "Upper limits in nanoseconds of the ranges in which the observed value of route lookup time is expected to fall"
     default: [10000, 20000, 30000, 40000, 50000, 60000, 70000, 80000, 90000, 100000]
   router.prometheus.meters.route_registration_latency_histogram_buckets:
-    description: "Upper limits of the ranges in which the observed value of route registration latency is expected to fall"
+    description: "Upper limits in milliseconds of the ranges in which the observed value of route registration latency is expected to fall"
     default: [0.1, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4]
   router.prometheus.meters.routing_response_latency_histogram_buckets:
-    description: "Upper limits of the ranges in which the observed value of route response latency is expected to fall"
+    description: "Upper limits in milliseconds of the ranges in which the observed value of route response latency is expected to fall"
     default: [1, 2, 4, 6, 8, 10, 20, 40, 50, 100, 500, 1000]
   router.requested_route_registration_interval_in_seconds:
     description: |

--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -80,7 +80,7 @@ properties:
       description: "Enables support for metrics reported via Envelope."
       default: true
   router.prometheus.port:
-    description: "Port for the prometheus endpoint, automatically enables Prometheus support."
+    description: "Port for the prometheus endpoint. Automatically enables Prometheus support."
   router.prometheus.server_name:
     description: "The server name used in the certificate for the metrics endpoint."
   router.prometheus.ca_cert:

--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -104,6 +104,9 @@ properties:
   router.prometheus.meters.routing_response_latency_histogram_buckets:
     description: "Upper limits in milliseconds of the ranges in which the observed value of route response latency is expected to fall"
     default: [1, 2, 4, 6, 8, 10, 20, 40, 50, 100, 500, 1000]
+  router.prometheus.meters.http_latency_histogram_buckets:
+    description: "Upper limits in seconds of the ranges in which the observed value of the latency of http requests from gorouter and back"
+    default: [0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6]
   router.requested_route_registration_interval_in_seconds:
     description: |
       On startup, the router will delay listening for requests by this duration to increase likelihood that it has a complete routing table before serving requests.

--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -92,6 +92,15 @@ properties:
   router.prometheus.key:
     description: "TLS private key for prometheus server."
     default: ""
+  router.prometheus.meters.route_lookup_time_histogram_buckets:
+    description: "Upper limits of the ranges in which the observed value of route lookup time is expected to fall"
+    default: [10000, 20000, 30000, 40000, 50000, 60000, 70000, 80000, 90000, 100000]
+  router.prometheus.meters.route_registration_latency_histogram_buckets:
+    description: "Upper limits of the ranges in which the observed value of route registration latency is expected to fall"
+    default: [0.1, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4]
+  router.prometheus.meters.routing_response_latency_histogram_buckets:
+    description: "Upper limits of the ranges in which the observed value of route response latency is expected to fall"
+    default: [1, 2, 4, 6, 8, 10, 20, 40, 50, 100, 500, 1000]
   router.requested_route_registration_interval_in_seconds:
     description: |
       On startup, the router will delay listening for requests by this duration to increase likelihood that it has a complete routing table before serving requests.

--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -81,6 +81,9 @@ properties:
       default: true
   router.prometheus.port:
     description: "Port for the prometheus endpoint. Automatically enables Prometheus support."
+  router.prometheus.enable_scraper:
+    description: "Activate the Prometheus scraper to collect metrics from the gorouter."
+    default: true
   router.prometheus.server_name:
     description: "The server name used in the certificate for the metrics endpoint."
   router.prometheus.ca_cert:

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -173,6 +173,7 @@ params = {
   'pid_file' => '/var/vcap/sys/run/gorouter/gorouter.pid',
   'ip_local_port_range' => p('router.ip_local_port_range'),
   'empty_pool_response_code_503' => p('for_backwards_compatibility_only.empty_pool_response_code_503'), # backwards compatibility only section
+  'enable_envelope_v1_metrics' => p('router.enable_envelope_v1_metrics'),
   'per_request_metrics_reporting' => p('router.per_request_metrics_reporting'),
   'per_app_prometheus_http_metrics_reporting' => p('router.per_app_prometheus_http_metrics_reporting'),
   'send_http_start_stop_server_event' => p('router.send_http_start_stop_server_event'),
@@ -182,6 +183,7 @@ params = {
 
 if_p('router.prometheus.port') do |port|
   params['prometheus'] = {
+    'enabled' => true,
     'port' => port,
     'cert_path' => '/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.crt',
     'key_path' => '/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.key',

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -182,14 +182,25 @@ params = {
 }
 
 if_p('router.prometheus.port') do |port|
-  params['prometheus'] = {
+   params['prometheus'] = {
     'enabled' => true,
     'port' => port,
-    'cert_path' => '/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.crt',
-    'key_path' => '/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.key',
-    'ca_path' => '/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus_ca.crt',
     'meters' => p('router.prometheus.meters')
-  }
+   }
+
+  cert_set = p('router.prometheus.cert') != ''
+  key_set = p('router.prometheus.key') != ''
+  ca_cert_set = p('router.prometheus.ca_cert') != ''
+
+  unless (cert_set && key_set && ca_cert_set) || (!cert_set && !key_set && !ca_cert_set)
+    raise 'either provide all of router.prometheus.cert, router.prometheus.key, and router.prometheus.ca_cert, or none of them'
+  end
+
+  if cert_set && key_set && ca_cert_set
+    params['prometheus']['cert_path'] = '/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.crt'
+    params['prometheus']['key_path'] = '/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.key'
+    params['prometheus']['ca_path'] = '/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus_ca.crt'
+  end
 end.else do
   if p('router.per_app_prometheus_http_metrics_reporting')
     raise 'per_app_prometheus_http_metrics_reporting should not be set without configuring prometheus'

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -187,7 +187,8 @@ if_p('router.prometheus.port') do |port|
     'port' => port,
     'cert_path' => '/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.crt',
     'key_path' => '/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.key',
-    'ca_path' => '/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus_ca.crt'
+    'ca_path' => '/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus_ca.crt',
+    'meters' => p('router.prometheus.meters')
   }
 end.else do
   if p('router.per_app_prometheus_http_metrics_reporting')

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -182,6 +182,10 @@ params = {
 }
 
 if_p('router.prometheus.port') do |port|
+   if port.to_i <= 0
+     raise 'router.prometheus.port must be a positive integer'
+   end
+   
    params['prometheus'] = {
     'enabled' => true,
     'port' => port,

--- a/jobs/gorouter/templates/prom_scraper_config.yml.erb
+++ b/jobs/gorouter/templates/prom_scraper_config.yml.erb
@@ -1,4 +1,4 @@
-<% if p('router.prometheus.port', 0) != 0 %>
+<% if p('router.prometheus.enable_scraper') &&  p('router.prometheus.port', 0) != 0 %>
 port: <%= p("router.prometheus.port") %>
 source_id: "gorouter"
 instance_id: <%= spec.id || spec.index.to_s %>

--- a/jobs/gorouter/templates/prom_scraper_config.yml.erb
+++ b/jobs/gorouter/templates/prom_scraper_config.yml.erb
@@ -2,6 +2,11 @@
 port: <%= p("router.prometheus.port") %>
 source_id: "gorouter"
 instance_id: <%= spec.id || spec.index.to_s %>
+<% if p('router.prometheus.cert') != '' && p('router.prometheus.key') != '' && p('router.prometheus.ca_cert') != '' %>
 scheme: https
 server_name: <%= p("router.prometheus.server_name") %>
+<% end %>
+labels:
+  metrics_version: "2.0"
+  origin: gorouter
 <% end %>

--- a/packages/gorouter/spec
+++ b/packages/gorouter/spec
@@ -42,6 +42,7 @@ files:
   - code.cloudfoundry.org/gorouter/metrics/*.go # gosub
   - code.cloudfoundry.org/gorouter/metrics/fakes/*.go # gosub
   - code.cloudfoundry.org/gorouter/metrics/monitor/*.go # gosub
+  - code.cloudfoundry.org/gorouter/metrics_prometheus/*.go # gosub
   - code.cloudfoundry.org/gorouter/proxy/*.go # gosub
   - code.cloudfoundry.org/gorouter/proxy/fails/*.go # gosub
   - code.cloudfoundry.org/gorouter/proxy/fails/fakes/*.go # gosub

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -693,17 +693,41 @@ describe 'gorouter' do
             deployment_manifest_fragment['router']['per_app_prometheus_http_metrics_reporting'] = true
             deployment_manifest_fragment['router']['prometheus'] = { 'port' => 9090 }
           end
-          it 'should set prometheus configuration' do
-            expect(parsed_yaml['per_app_prometheus_http_metrics_reporting']).to be true
-            expect(parsed_yaml['prometheus']['enabled']).to eq(true)
-            expect(parsed_yaml['prometheus']['port']).to eq(9090)
-            expect(parsed_yaml['prometheus']['cert_path']).to eq('/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.crt')
-            expect(parsed_yaml['prometheus']['key_path']).to eq('/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.key')
-            expect(parsed_yaml['prometheus']['ca_path']).to eq('/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus_ca.crt')
+          context 'without TLS' do
+            it 'should set prometheus configuration without certificates' do
+              expect(parsed_yaml['per_app_prometheus_http_metrics_reporting']).to be true
+              expect(parsed_yaml['prometheus']['enabled']).to eq(true)
+              expect(parsed_yaml['prometheus']['port']).to eq(9090)
+              expect(parsed_yaml['prometheus']['cert_path']).to be_nil
+              expect(parsed_yaml['prometheus']['key_path']).to be_nil
+              expect(parsed_yaml['prometheus']['ca_path']).to be_nil
+            end
+            it 'should enable envelope v1 per default' do
+              expect(parsed_yaml['enable_envelope_v1_metrics']).to be true
+            end
           end
-          it 'should enable envelope v1 per default' do
-            expect(parsed_yaml['enable_envelope_v1_metrics']).to be true
-            expect(parsed_yaml['prometheus']['enabled']).to eq(true)
+          context 'when certificates are configured' do
+            before do
+              deployment_manifest_fragment['router']['prometheus']['cert'] = TEST_CERT
+              deployment_manifest_fragment['router']['prometheus']['key'] = TEST_KEY
+              deployment_manifest_fragment['router']['prometheus']['ca_cert'] = TEST_CERT2
+            end
+            it 'should set prometheus configuration with certificates' do
+              expect(parsed_yaml['per_app_prometheus_http_metrics_reporting']).to be true
+              expect(parsed_yaml['prometheus']['enabled']).to eq(true)
+              expect(parsed_yaml['prometheus']['port']).to eq(9090)
+              expect(parsed_yaml['prometheus']['cert_path']).to eq('/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.crt')
+              expect(parsed_yaml['prometheus']['key_path']).to eq('/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.key')
+              expect(parsed_yaml['prometheus']['ca_path']).to eq('/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus_ca.crt')
+            end
+          end
+          context 'when certificates are configured incorrectly' do
+            before do
+              deployment_manifest_fragment['router']['prometheus']['cert'] = TEST_CERT
+            end
+            it 'should error when only one cert or key is configured' do
+              expect { raise parsed_yaml }.to raise_error(RuntimeError, 'either provide all of router.prometheus.cert, router.prometheus.key, and router.prometheus.ca_cert, or none of them')
+            end
           end
         end
         context 'when per app metrics is configured but prometheus port is not' do
@@ -725,9 +749,6 @@ describe 'gorouter' do
             expect(parsed_yaml['per_app_prometheus_http_metrics_reporting']).to be true
             expect(parsed_yaml['prometheus']['enabled']).to eq(true)
             expect(parsed_yaml['prometheus']['port']).to eq(9090)
-            expect(parsed_yaml['prometheus']['cert_path']).to eq('/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.crt')
-            expect(parsed_yaml['prometheus']['key_path']).to eq('/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus.key')
-            expect(parsed_yaml['prometheus']['ca_path']).to eq('/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus_ca.crt')
           end
         end
         context 'when prometheus meters are configured' do
@@ -1727,22 +1748,40 @@ describe 'gorouter' do
     end
 
     context 'when gorouter prometheus support is enabled' do
-      before do
-        deployment_manifest_fragment['router'] = {
-          'prometheus' => {
-            'port' => 9090,
-            'server_name' => 'example.org'
+      context 'with certificates' do
+        before do
+          deployment_manifest_fragment['router'] = {
+            'prometheus' => {
+              'port' => 9090,
+              'server_name' => 'example.org',
+              'cert' => TEST_CERT,
+              'key' => TEST_KEY,
+              'ca_cert' => TEST_CERT2,
+            }
           }
-        }
+        end
+        it 'configures the prom scraper to scrape the gorouter prometheus endpoint' do
+          expect(parsed_yaml['port']).to eq(9090)
+          expect(parsed_yaml['scheme']).to eq('https')
+          expect(parsed_yaml['server_name']).to eq('example.org')
+        end
+        it 'configures the prom scraper to emit events with source_id and instance_id tags' do
+          expect(parsed_yaml['source_id']).to eq('gorouter')
+          expect(parsed_yaml['instance_id']).to_not be_empty
+        end
       end
-      it 'configures the prom scraper to scrape the gorouter prometheus endpoint' do
-        expect(parsed_yaml['port']).to eq(9090)
-        expect(parsed_yaml['scheme']).to eq('https')
-        expect(parsed_yaml['server_name']).to eq('example.org')
-      end
-      it 'configures the prom scraper to emit events with source_id and instance_id tags' do
-        expect(parsed_yaml['source_id']).to eq('gorouter')
-        expect(parsed_yaml['instance_id']).to_not be_empty
+      context 'without certificates' do
+        before do
+          deployment_manifest_fragment['router'] = {
+            'prometheus' => {
+              'port' => 9090,
+            }
+          }
+        end
+        it 'configures the prom scraper to talk to prometheus without tls by default' do
+          expect(parsed_yaml['scheme']).to be_nil
+          expect(parsed_yaml['server_name']).to be_nil
+        end
       end
     end
   end

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -729,6 +729,14 @@ describe 'gorouter' do
               expect { raise parsed_yaml }.to raise_error(RuntimeError, 'either provide all of router.prometheus.cert, router.prometheus.key, and router.prometheus.ca_cert, or none of them')
             end
           end
+          context 'when port configure incorrectly' do
+            before do
+              deployment_manifest_fragment['router']['prometheus']['port'] = '0'
+            end
+            it 'should error' do
+              expect { raise parsed_yaml }.to raise_error(RuntimeError, 'router.prometheus.port must be a positive integer')
+            end
+          end
         end
         context 'when per app metrics is configured but prometheus port is not' do
           before do
@@ -1748,39 +1756,60 @@ describe 'gorouter' do
     end
 
     context 'when gorouter prometheus support is enabled' do
-      context 'with certificates' do
-        before do
-          deployment_manifest_fragment['router'] = {
-            'prometheus' => {
-              'port' => 9090,
-              'server_name' => 'example.org',
-              'cert' => TEST_CERT,
-              'key' => TEST_KEY,
-              'ca_cert' => TEST_CERT2,
-            }
+      before do
+        deployment_manifest_fragment['router'] = {
+          'prometheus' => {
+            'port' => 9090,
           }
+        }
+      end
+      it 'scraper enabled by default' do
+        expect(parsed_yaml).to_not be_nil
+      end
+
+      context 'with enable_scraper set to false' do
+        before do
+          deployment_manifest_fragment['router']['prometheus']['enable_scraper'] = false
         end
-        it 'configures the prom scraper to scrape the gorouter prometheus endpoint' do
-          expect(parsed_yaml['port']).to eq(9090)
-          expect(parsed_yaml['scheme']).to eq('https')
-          expect(parsed_yaml['server_name']).to eq('example.org')
-        end
-        it 'configures the prom scraper to emit events with source_id and instance_id tags' do
-          expect(parsed_yaml['source_id']).to eq('gorouter')
-          expect(parsed_yaml['instance_id']).to_not be_empty
+        it 'scraper disabled' do
+          expect(parsed_yaml).to be_nil
         end
       end
-      context 'without certificates' do
-        before do
-          deployment_manifest_fragment['router'] = {
-            'prometheus' => {
-              'port' => 9090,
+      context 'with default enable_scraper' do
+        context 'with certificates' do
+          before do
+            deployment_manifest_fragment['router'] = {
+              'prometheus' => {
+                'port' => 9090,
+                'server_name' => 'example.org',
+                'cert' => TEST_CERT,
+                'key' => TEST_KEY,
+                'ca_cert' => TEST_CERT2,
+              }
             }
-          }
+          end
+          it 'configures the prom scraper to scrape the gorouter prometheus endpoint' do
+            expect(parsed_yaml['port']).to eq(9090)
+            expect(parsed_yaml['scheme']).to eq('https')
+            expect(parsed_yaml['server_name']).to eq('example.org')
+          end
+          it 'configures the prom scraper to emit events with source_id and instance_id tags' do
+            expect(parsed_yaml['source_id']).to eq('gorouter')
+            expect(parsed_yaml['instance_id']).to_not be_empty
+          end
         end
-        it 'configures the prom scraper to talk to prometheus without tls by default' do
-          expect(parsed_yaml['scheme']).to be_nil
-          expect(parsed_yaml['server_name']).to be_nil
+        context 'without certificates' do
+          before do
+            deployment_manifest_fragment['router'] = {
+              'prometheus' => {
+                'port' => 9090,
+              }
+            }
+          end
+          it 'configures the prom scraper to talk to prometheus without tls by default' do
+            expect(parsed_yaml['scheme']).to be_nil
+            expect(parsed_yaml['server_name']).to be_nil
+          end
         end
       end
     end

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -730,6 +730,24 @@ describe 'gorouter' do
             expect(parsed_yaml['prometheus']['ca_path']).to eq('/var/vcap/jobs/gorouter/config/certs/prometheus/prometheus_ca.crt')
           end
         end
+        context 'when prometheus meters are configured' do
+          before do
+            deployment_manifest_fragment['router']['per_app_prometheus_http_metrics_reporting'] = true
+            deployment_manifest_fragment['router']['prometheus'] = {
+              'port' => 9090,
+              'meters' => {
+                'route_lookup_time_histogram_buckets' => [0, 100, 10000],
+                'route_registration_latency_histogram_buckets' => [-10, 0, 10],
+                'routing_response_latency_histogram_buckets' => [0.1, 0.5, 1]
+              }
+            }
+          end
+          it 'should set prometheus meters configuration' do
+            expect(parsed_yaml['prometheus']['meters']['route_lookup_time_histogram_buckets']).to eq([0, 100, 10000])
+            expect(parsed_yaml['prometheus']['meters']['route_registration_latency_histogram_buckets']).to eq([-10, 0, 10])
+            expect(parsed_yaml['prometheus']['meters']['routing_response_latency_histogram_buckets']).to eq([0.1, 0.5, 1])
+          end
+        end
       end
 
       describe 'route_services' do

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -767,7 +767,8 @@ describe 'gorouter' do
               'meters' => {
                 'route_lookup_time_histogram_buckets' => [0, 100, 10000],
                 'route_registration_latency_histogram_buckets' => [-10, 0, 10],
-                'routing_response_latency_histogram_buckets' => [0.1, 0.5, 1]
+                'routing_response_latency_histogram_buckets' => [0.1, 0.5, 1],
+                'http_latency_histogram_buckets' => [0.1, 0.2, 0.4, 0.8, 1],
               }
             }
           end
@@ -775,6 +776,7 @@ describe 'gorouter' do
             expect(parsed_yaml['prometheus']['meters']['route_lookup_time_histogram_buckets']).to eq([0, 100, 10000])
             expect(parsed_yaml['prometheus']['meters']['route_registration_latency_histogram_buckets']).to eq([-10, 0, 10])
             expect(parsed_yaml['prometheus']['meters']['routing_response_latency_histogram_buckets']).to eq([0.1, 0.5, 1])
+            expect(parsed_yaml['prometheus']['meters']['http_latency_histogram_buckets']).to eq([0.1, 0.2, 0.4, 0.8, 1])
           end
         end
       end


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
- Implement a switch to enable / disable metrics reported using Envelope V1
- Introduce a new gorouter prometheus property `enabled` which has been automatically set to true if prometheus.port is set. 
- Do not exclude metrics reporting by prometheus and using Envelope V1.
- Adapt `prom_scraper` configuration template to use https mode only if the certificates have been set. 
- Introduce a new flag to enable / disable `prom_scraper` for the use cases in which the metrics will be read by another consumers (e.g. telegraf). By default it should be enabled. 


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->

Complementing Gorouter PR: https://github.com/cloudfoundry/gorouter/pull/466
