### PR TITLE
ci: make docker scripts podman-compatible

### DIFF
--- a/scripts/create-docker-container.bash
+++ b/scripts/create-docker-container.bash
@@ -16,13 +16,13 @@ fi
 
 CONTAINER_NAME="$REPO_NAME-$DB-docker-container"
 if [[ "${DB}" == "mysql" ]] || [[ "${DB}" == "mysql-8.0" ]]; then
-  IMAGE="cloudfoundry/tas-runtime-mysql-8.0"
+  IMAGE="docker.io/cloudfoundry/tas-runtime-mysql-8.0"
   DB="mysql"
 elif [[ "${DB}" == "mysql-5.7" ]]; then
-  IMAGE="cloudfoundry/tas-runtime-mysql-5.7"
+  IMAGE="docker.io/cloudfoundry/tas-runtime-mysql-5.7"
   DB="mysql"
 elif [[ "${DB}" == "postgres" ]]; then
-  IMAGE="cloudfoundry/tas-runtime-postgres"
+  IMAGE="docker.io/cloudfoundry/tas-runtime-postgres"
 else
   echo "Unsupported DB flavor"
   exit 1
@@ -35,7 +35,7 @@ else
 fi
 
 docker pull "${IMAGE}"
-docker rm -f $CONTAINER_NAME
+docker rm -f "${CONTAINER_NAME}" || true # needed for compatibility with podman
 docker run -it \
   --env "DB=${DB}" \
   --env "REPO_NAME=$REPO_NAME" \


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Podman is mostly compatible with the docker CLI except for a few small differences. This commit alignes the docker scripts so that it is compatible with both.

By default podman requires fully qualified image names and the `rm` command does not ignore errors when removing a containter that does not exist so we simply `|| true` after it.


Backward Compatibility
---------------
Breaking Change? **No**