### PR TITLE
Improve integration tests robustness

### DIFF
--- a/scripts/docker/test.bash
+++ b/scripts/docker/test.bash
@@ -14,7 +14,7 @@ function test() {
 
   export GOFLAGS="-buildvcs=false"
   export DB="${DB}"
-  /ci/shared/tasks/run-bin-test/task.bash "${sub_package}"
+  /ci/shared/tasks/run-bin-test/task.bash "${sub_package}" --nodes="${SAFE_CPU}"
 }
 
 pushd /repo > /dev/null
@@ -22,6 +22,9 @@ git_configure_safe_directory
 REPO_NAME=$(git_get_remote_name)
 export DEFAULT_PARAMS="/ci/$REPO_NAME/default-params/run-bin-test/linux.yml"
 popd > /dev/null
+
+SAFE_CPU=$(( $(getconf _NPROCESSORS_ONLN) - 1 ))   # Leave one thread unloaded for background tasks
+[[ $SAFE_CPU == 0 ]] && SAFE_CPU=1                 # Still do run on a single thread machine
 
 pushd / > /dev/null
 if [[ -n "${1:-}" ]]; then

--- a/scripts/test-in-docker.bash
+++ b/scripts/test-in-docker.bash
@@ -18,3 +18,6 @@ docker exec $CONTAINER_NAME '/repo/scripts/docker/build-binaries.bash'
 docker exec $CONTAINER_NAME '/repo/scripts/docker/tests-templates.bash'
 docker exec $CONTAINER_NAME '/repo/scripts/docker/test.bash' "$@"
 docker exec $CONTAINER_NAME '/repo/scripts/docker/lint.bash'
+
+# Cleanup if all tests succeed, otherwise -e prevents script from reaching this
+docker rm -f "${CONTAINER_NAME}" || true # needed for compatibility with podman


### PR DESCRIPTION
Summary
---------------

Improve robustness of integration suite. Tests hard-code use of 7 nodes for ginkgo parallel execution. On smaller VMs and computers with less than 8 threads, this exhausts CPU which then leads to various race conditions and other test errors (timeouts, late connection status updates etc.).

Update tests to use one less thread than available CPUs. This needs to be done via `--nodes` parameter, as that overrides earlier value of 7.

Cleanup test container if all the tests have succeeded. There is no need to keep it around for debug, when all tests passed.


Backward Compatibility
---------------
Breaking Change? No
