### PR TITLE
clean: remove unused routing-info

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,3 @@
 	path = src/code.cloudfoundry.org/routing-api
 	url = https://github.com/cloudfoundry/routing-api
 	branch = main
-[submodule "src/code.cloudfoundry.org/routing-info"]
-	path = src/code.cloudfoundry.org/routing-info
-	url = https://github.com/cloudfoundry/routing-info
-	branch = main


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Routing-info is not used in routing-release, this removes it.


Backward Compatibility
---------------
Breaking Change? **No**
