### PR TITLE
fix: align package spec

### DIFF
--- a/packages/gorouter/spec
+++ b/packages/gorouter/spec
@@ -16,7 +16,6 @@ files:
   - code.cloudfoundry.org/gorouter/accesslog/schema/*.go # gosub
   - code.cloudfoundry.org/gorouter/accesslog/schema/fakes/*.go # gosub
   - code.cloudfoundry.org/gorouter/accesslog/syslog/*.go # gosub
-  - code.cloudfoundry.org/gorouter/cmd/gorouter/*.go # gosub
   - code.cloudfoundry.org/gorouter/common/*.go # gosub
   - code.cloudfoundry.org/gorouter/common/health/*.go # gosub
   - code.cloudfoundry.org/gorouter/common/http/*.go # gosub


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Follow-up to #475 and #476. The path I removed never existing in gorouter, not sure how it got added in.


Backward Compatibility
---------------
Breaking Change? **No**