### PR TITLE
fix: properly order ginkgo arguments

### DIFF
--- a/scripts/docker/test.bash
+++ b/scripts/docker/test.bash
@@ -14,7 +14,7 @@ function test() {
 
   export GOFLAGS="-buildvcs=false"
   export DB="${DB}"
-  /ci/shared/tasks/run-bin-test/task.bash "${sub_package}" --nodes="${SAFE_CPU}"
+  /ci/shared/tasks/run-bin-test/task.bash --nodes="${SAFE_CPU}" "${sub_package}"
 }
 
 pushd /repo > /dev/null


### PR DESCRIPTION

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Packages needs to be specified last, with 60d74d0 we introduced the `--nodes` argument as the last one which works as long as you don't try to specify a sub-package.

This commit re-orders the arguments so that the package is last argument again.

Backward Compatibility
---------------
Breaking Change? **No**
