### PR TITLE
Fixes integration tests when run outside of CI (or GCP envs).

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/integration/main_test.go
+++ b/src/code.cloudfoundry.org/gorouter/integration/main_test.go
@@ -858,22 +858,24 @@ var _ = Describe("Router Integration", func() {
 
 		Context("when the route service is not hosted on the platform (external)", func() {
 			BeforeEach(func() {
+				routeServiceHost := fmt.Sprintf("external-route-service.%s", test_util.LocalhostDNS)
 				routeServiceSrv = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusTeapot)
 				}))
 
-				rsKey, rsCert := test_util.CreateKeyPair("test.routeservice.com")
+				rsKey, rsCert := test_util.CreateKeyPair(routeServiceHost)
 				cfg.CACerts = []string{string(rsCert)}
 				rsTLSCert, err := tls.X509KeyPair(rsCert, rsKey)
 				Expect(err).ToNot(HaveOccurred())
 
 				routeServiceSrv.TLS = &tls.Config{
 					Certificates: []tls.Certificate{rsTLSCert},
-					ServerName:   "test.routeservice.com",
+					ServerName:   routeServiceHost,
 				}
 				routeServiceSrv.StartTLS()
 
-				routeServiceURL = routeServiceSrv.URL
+				port := strings.Split(routeServiceSrv.Listener.Addr().String(), ":")[1]
+				routeServiceURL = fmt.Sprintf("https://%s:%s/", routeServiceHost, port)
 			})
 
 			AfterEach(func() {

--- a/src/code.cloudfoundry.org/gorouter/integration/test_utils_test.go
+++ b/src/code.cloudfoundry.org/gorouter/integration/test_utils_test.go
@@ -49,7 +49,7 @@ func configDrainSetup(cfg *config.Config, pruneInterval, pruneThreshold time.Dur
 	cfg.DropletStaleThreshold = pruneThreshold
 	cfg.StartResponseDelayInterval = 1 * time.Second
 	cfg.EndpointTimeout = 5 * time.Second
-	cfg.EndpointDialTimeout = 10 * time.Millisecond
+	cfg.EndpointDialTimeout = 500 * time.Millisecond
 	cfg.DrainTimeout = 200 * time.Millisecond
 	cfg.DrainWait = time.Duration(drainWait) * time.Second
 }


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
EndpointDialTimeout was set too low to let the DNS resolution succeed. Also updates the name + URL used in the external route service tests so that they also get DNS resolution instead of going by IP and confusing everyone since they didn't hit the DNS timeout.


Backward Compatibility
---------------
Breaking Change? no