### PR TITLE
gh actions pr runs only on the develop branch

### DIFF
--- a/.github/gh-config-template/gh_template.yml
+++ b/.github/gh-config-template/gh_template.yml
@@ -4,7 +4,7 @@
 name: unit-integration-tests
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - develop
     types:
@@ -80,7 +80,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: repo-clone
     container:
-      image: cloudfoundry/tas-runtime-mysql-5.7
+      image: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-mysql-5.7
+      credentials:
+        username: _json_key
+        password: ${{ secrets.GCP_SERVICE_ACCOUNT_TAS_RUNTIME_BUILD_IMAGE_READER }}
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v4
@@ -106,7 +109,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: repo-clone
     container:
-      image: cloudfoundry/tas-runtime-build
+      image: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
+      credentials:
+        username: _json_key
+        password: ${{ secrets.GCP_SERVICE_ACCOUNT_TAS_RUNTIME_BUILD_IMAGE_READER }}
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v4
@@ -131,7 +137,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: repo-clone
     container:
-      image: cloudfoundry/tas-runtime-postgres
+      image: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-postgres
+      credentials:
+        username: _json_key
+        password: ${{ secrets.GCP_SERVICE_ACCOUNT_TAS_RUNTIME_BUILD_IMAGE_READER }}
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v4
@@ -156,7 +165,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: repo-clone
     container:
-      image: cloudfoundry/tas-runtime-mysql-8.0
+      image: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-mysql-8.0
+      credentials:
+        username: _json_key
+        password: ${{ secrets.GCP_SERVICE_ACCOUNT_TAS_RUNTIME_BUILD_IMAGE_READER }}
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v4

--- a/.github/gh-config-template/gh_template.yml
+++ b/.github/gh-config-template/gh_template.yml
@@ -4,10 +4,13 @@
 name: unit-integration-tests
 
 on:
-  push:
+  pull_request:
     branches:
       - develop
-  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 env:
   MAPPING: |

--- a/.github/gh-config-template/gh_template.yml
+++ b/.github/gh-config-template/gh_template.yml
@@ -1,6 +1,6 @@
 #@ load("@ytt:data", "data")
 #@ load("ytt-helpers.star", "helpers")
-
+# test commit
 name: unit-integration-tests
 
 on:

--- a/.github/gh-config-template/gh_template.yml
+++ b/.github/gh-config-template/gh_template.yml
@@ -5,8 +5,6 @@ name: unit-integration-tests
 
 on:
   pull_request_target:
-    branches:
-      - develop
     types:
       - opened
       - reopened

--- a/.github/gh-config-template/gh_template.yml
+++ b/.github/gh-config-template/gh_template.yml
@@ -4,10 +4,13 @@
 name: unit-integration-tests
 
 on:
-  push:
-    branches:
-      - develop
   pull_request:
+    branches:
+      - test-gh
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 env:
   MAPPING: |

--- a/.github/gh-config-template/gh_template.yml
+++ b/.github/gh-config-template/gh_template.yml
@@ -4,10 +4,14 @@
 name: unit-integration-tests
 
 on:
-  push:
-    branches:
-      - develop
-  pull_request:
+
+pull_request_target:
+        branches:
+            - develop
+        types:
+          - opened
+          - reopened
+          - synchronize
 
 env:
   MAPPING: |
@@ -39,8 +43,8 @@ jobs:
       - name: routing-release-repo
         uses: actions/checkout@v4
         with:
-          repository: cloudfoundry/routing-release.git
-          ref: github-action
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           submodules: recursive
           path: repo
       - name: Check out wg-appruntime code
@@ -63,7 +67,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: repo-clone
     container:
-      image: cloudfoundry/tas-runtime-mysql-5.7
+      image: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
+      credentials:
+        username: _json_key
+        password: ${{ secrets.GCP_SERVICE_ACCOUNT_TAS_RUNTIME_BUILD_IMAGE_READER }}
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v4
@@ -77,15 +84,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: repo-clone
     container:
-      image: cloudfoundry/tas-runtime-mysql-5.7
+      image: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-mysql-5.7
+      credentials:
+        username: _json_key
+        password: ${{ secrets.GCP_SERVICE_ACCOUNT_TAS_RUNTIME_BUILD_IMAGE_READER }}
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v4
       with:
           name: repo
     - run: |
-           tar -xzvf repo-artifact.tar.gz
-           tar -xzvf ci-artifact.tar.gz 
+          tar -xzvf repo-artifact.tar.gz
+          tar -xzvf ci-artifact.tar.gz 
     - name: build binaries
       run: |
         export DEFAULT_PARAMS="${GITHUB_WORKSPACE}/ci/routing-release/default-params/build-binaries/linux.yml"
@@ -103,7 +113,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: repo-clone
     container:
-      image: cloudfoundry/tas-runtime-build
+      image: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
+      credentials:
+        username: _json_key
+        password: ${{ secrets.GCP_SERVICE_ACCOUNT_TAS_RUNTIME_BUILD_IMAGE_READER }}
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v4
@@ -128,7 +141,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: repo-clone
     container:
-      image: cloudfoundry/tas-runtime-postgres
+      image: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-postgres
+      credentials:
+        username: _json_key
+        password: ${{ secrets.GCP_SERVICE_ACCOUNT_TAS_RUNTIME_BUILD_IMAGE_READER }}
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v4
@@ -153,7 +169,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: repo-clone
     container:
-      image: cloudfoundry/tas-runtime-mysql-8.0
+      image: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-mysql-8.0
+      credentials:
+        username: _json_key
+        password: ${{ secrets.GCP_SERVICE_ACCOUNT_TAS_RUNTIME_BUILD_IMAGE_READER }}
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/tests-workflow.yml
+++ b/.github/workflows/tests-workflow.yml
@@ -34,8 +34,8 @@ jobs:
     - name: routing-release-repo
       uses: actions/checkout@v4
       with:
-        repository: cloudfoundry/routing-release.git
-        ref: develop
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
         submodules: recursive
         path: repo
     - name: Check out wg-appruntime code

--- a/.github/workflows/tests-workflow.yml
+++ b/.github/workflows/tests-workflow.yml
@@ -2,9 +2,7 @@ name: unit-integration-tests
 on:
   pull_request_target:
     types:
-      - opened
-      - reopened
-      - synchronize
+      - labeled
 env:
   MAPPING: |
     build_nats_server=src/code.cloudfoundry.org/vendor/github.com/nats-io/nats-server/v2
@@ -29,6 +27,7 @@ env:
   FUNCTIONS: ci/routing-release/helpers/configure-binaries.bash
 jobs:
   repo-clone:
+    if: github.event.label.name == 'ready-to-run'
     runs-on: ubuntu-latest
     steps:
     - name: routing-release-repo

--- a/.github/workflows/tests-workflow.yml
+++ b/.github/workflows/tests-workflow.yml
@@ -1,10 +1,12 @@
 name: unit-integration-tests
 on:
-  push:
-    branches:
-      - develop
   pull_request:
-
+    branches:
+      - test-gh
+    types:
+      - opened
+      - reopened
+      - synchronize
 env:
   MAPPING: |
     build_nats_server=src/code.cloudfoundry.org/vendor/github.com/nats-io/nats-server/v2

--- a/.github/workflows/tests-workflow.yml
+++ b/.github/workflows/tests-workflow.yml
@@ -1,10 +1,12 @@
 name: unit-integration-tests
 on:
-  push:
+  pull_request_target:
     branches:
       - develop
-  pull_request:
-
+    types:
+      - opened
+      - reopened
+      - synchronize
 env:
   MAPPING: |
     build_nats_server=src/code.cloudfoundry.org/vendor/github.com/nats-io/nats-server/v2
@@ -34,8 +36,8 @@ jobs:
     - name: routing-release-repo
       uses: actions/checkout@v4
       with:
-        repository: cloudfoundry/routing-release.git
-        ref: develop
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
         submodules: recursive
         path: repo
     - name: Check out wg-appruntime code
@@ -67,7 +69,9 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: repo
-    - run: "tar -xzvf repo-artifact.tar.gz\ntar -xzvf ci-artifact.tar.gz\n"
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
     - name: template-tests
       run: |
         "${GITHUB_WORKSPACE}"/ci/shared/tasks/run-tests-templates/task.bash
@@ -84,7 +88,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: repo
-    - run: "tar -xzvf repo-artifact.tar.gz\ntar -xzvf ci-artifact.tar.gz\n"
+    - run: "tar -xzvf repo-artifact.tar.gz\ntar -xzvf ci-artifact.tar.gz \n"
     - name: build binaries
       run: |
         export DEFAULT_PARAMS="${GITHUB_WORKSPACE}/ci/routing-release/default-params/build-binaries/linux.yml"
@@ -94,18 +98,21 @@ jobs:
         DIR: src/code.cloudfoundry.org/gorouter
         DB: mysql
       run: |
+        "${GITHUB_WORKSPACE}"/ci/routing-release/helpers/configure-binaries.bash
         "${GITHUB_WORKSPACE}"/ci/shared/tasks/run-bin-test/task.bash --keep-going --trace -r --fail-on-pending --randomize-all --nodes=7 --race --timeout 30m --flake-attempts 2
     - name: cf-tcp-router-mysql
       env:
         DIR: src/code.cloudfoundry.org/cf-tcp-router
         DB: mysql
       run: |
+        "${GITHUB_WORKSPACE}"/ci/routing-release/helpers/configure-binaries.bash
         "${GITHUB_WORKSPACE}"/ci/shared/tasks/run-bin-test/task.bash --keep-going --trace -r --fail-on-pending --randomize-all --nodes=7 --race --timeout 30m --flake-attempts 2
     - name: routing-api-mysql
       env:
         DIR: src/code.cloudfoundry.org/routing-api
         DB: mysql
       run: |
+        "${GITHUB_WORKSPACE}"/ci/routing-release/helpers/configure-binaries.bash
         "${GITHUB_WORKSPACE}"/ci/shared/tasks/run-bin-test/task.bash --keep-going --trace -r --fail-on-pending --randomize-all --nodes=7 --race --timeout 30m --flake-attempts 2
   test-repos-withoutdb:
     runs-on: ubuntu-latest
@@ -120,7 +127,9 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: repo
-    - run: "tar -xzvf repo-artifact.tar.gz\ntar -xzvf ci-artifact.tar.gz\n"
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
     - name: build binaries
       run: |
         export DEFAULT_PARAMS="${GITHUB_WORKSPACE}/ci/routing-release/default-params/build-binaries/linux.yml"
@@ -156,7 +165,9 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: repo
-    - run: "tar -xzvf repo-artifact.tar.gz\ntar -xzvf ci-artifact.tar.gz\n"
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
     - name: build binaries
       run: |
         export DEFAULT_PARAMS="${GITHUB_WORKSPACE}/ci/routing-release/default-params/build-binaries/linux.yml"
@@ -192,7 +203,9 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: repo
-    - run: "tar -xzvf repo-artifact.tar.gz\ntar -xzvf ci-artifact.tar.gz\n"
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
     - name: build binaries
       run: |
         export DEFAULT_PARAMS="${GITHUB_WORKSPACE}/ci/routing-release/default-params/build-binaries/linux.yml"

--- a/.github/workflows/tests-workflow.yml
+++ b/.github/workflows/tests-workflow.yml
@@ -2,7 +2,7 @@ name: unit-integration-tests
 on:
   pull_request:
     branches:
-      - test-gh
+      - develop
     types:
       - opened
       - reopened

--- a/.github/workflows/tests-workflow.yml
+++ b/.github/workflows/tests-workflow.yml
@@ -1,8 +1,6 @@
 name: unit-integration-tests
 on:
   pull_request_target:
-    branches:
-      - develop
     types:
       - opened
       - reopened

--- a/.github/workflows/tests-workflow.yml
+++ b/.github/workflows/tests-workflow.yml
@@ -1,6 +1,6 @@
 name: unit-integration-tests
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - develop
     types:


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Run gh actions on PR only targeting on the develop branch. 


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
