### PR TITLE
gh action - pr only for develop branch

### DIFF
--- a/.github/gh-config-template/gh_template.yml
+++ b/.github/gh-config-template/gh_template.yml
@@ -1,13 +1,11 @@
 #@ load("@ytt:data", "data")
 #@ load("ytt-helpers.star", "helpers")
-
 name: unit-integration-tests
 
 on:
-  push:
-    branches:
-      - develop
-  pull_request:
+  pull_request_target:
+    types:
+      - labeled
 
 env:
   MAPPING: |
@@ -34,13 +32,14 @@ env:
 
 jobs:
   repo-clone:
+    if: github.event.label.name == 'ready-to-run'
     runs-on: ubuntu-latest
     steps:
       - name: routing-release-repo
         uses: actions/checkout@v4
         with:
-          repository: cloudfoundry/routing-release.git
-          ref: github-action
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           submodules: recursive
           path: repo
       - name: Check out wg-appruntime code
@@ -63,7 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: repo-clone
     container:
-      image: cloudfoundry/tas-runtime-mysql-5.7
+      image: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
+      credentials:
+        username: _json_key
+        password: ${{ secrets.GCP_SERVICE_ACCOUNT_TAS_RUNTIME_BUILD_IMAGE_READER }}
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v4
@@ -77,15 +79,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: repo-clone
     container:
-      image: cloudfoundry/tas-runtime-mysql-5.7
+      image: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-mysql-5.7
+      credentials:
+        username: _json_key
+        password: ${{ secrets.GCP_SERVICE_ACCOUNT_TAS_RUNTIME_BUILD_IMAGE_READER }}
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v4
       with:
           name: repo
     - run: |
-           tar -xzvf repo-artifact.tar.gz
-           tar -xzvf ci-artifact.tar.gz 
+          tar -xzvf repo-artifact.tar.gz
+          tar -xzvf ci-artifact.tar.gz 
     - name: build binaries
       run: |
         export DEFAULT_PARAMS="${GITHUB_WORKSPACE}/ci/routing-release/default-params/build-binaries/linux.yml"
@@ -103,7 +108,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: repo-clone
     container:
-      image: cloudfoundry/tas-runtime-build
+      image: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
+      credentials:
+        username: _json_key
+        password: ${{ secrets.GCP_SERVICE_ACCOUNT_TAS_RUNTIME_BUILD_IMAGE_READER }}
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v4
@@ -128,7 +136,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: repo-clone
     container:
-      image: cloudfoundry/tas-runtime-postgres
+      image: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-postgres
+      credentials:
+        username: _json_key
+        password: ${{ secrets.GCP_SERVICE_ACCOUNT_TAS_RUNTIME_BUILD_IMAGE_READER }}
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v4
@@ -153,7 +164,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: repo-clone
     container:
-      image: cloudfoundry/tas-runtime-mysql-8.0
+      image: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-mysql-8.0
+      credentials:
+        username: _json_key
+        password: ${{ secrets.GCP_SERVICE_ACCOUNT_TAS_RUNTIME_BUILD_IMAGE_READER }}
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/tests-workflow.yml
+++ b/.github/workflows/tests-workflow.yml
@@ -1,10 +1,8 @@
 name: unit-integration-tests
 on:
-  push:
-    branches:
-      - develop
-  pull_request:
-
+  pull_request_target:
+    types:
+      - labeled
 env:
   MAPPING: |
     build_nats_server=src/code.cloudfoundry.org/vendor/github.com/nats-io/nats-server/v2
@@ -29,13 +27,14 @@ env:
   FUNCTIONS: ci/routing-release/helpers/configure-binaries.bash
 jobs:
   repo-clone:
+    if: github.event.label.name == 'ready-to-run'
     runs-on: ubuntu-latest
     steps:
     - name: routing-release-repo
       uses: actions/checkout@v4
       with:
-        repository: cloudfoundry/routing-release.git
-        ref: develop
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
         submodules: recursive
         path: repo
     - name: Check out wg-appruntime code
@@ -67,7 +66,9 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: repo
-    - run: "tar -xzvf repo-artifact.tar.gz\ntar -xzvf ci-artifact.tar.gz\n"
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
     - name: template-tests
       run: |
         "${GITHUB_WORKSPACE}"/ci/shared/tasks/run-tests-templates/task.bash
@@ -84,7 +85,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: repo
-    - run: "tar -xzvf repo-artifact.tar.gz\ntar -xzvf ci-artifact.tar.gz\n"
+    - run: "tar -xzvf repo-artifact.tar.gz\ntar -xzvf ci-artifact.tar.gz \n"
     - name: build binaries
       run: |
         export DEFAULT_PARAMS="${GITHUB_WORKSPACE}/ci/routing-release/default-params/build-binaries/linux.yml"
@@ -94,18 +95,21 @@ jobs:
         DIR: src/code.cloudfoundry.org/gorouter
         DB: mysql
       run: |
+        "${GITHUB_WORKSPACE}"/ci/routing-release/helpers/configure-binaries.bash
         "${GITHUB_WORKSPACE}"/ci/shared/tasks/run-bin-test/task.bash --keep-going --trace -r --fail-on-pending --randomize-all --nodes=7 --race --timeout 30m --flake-attempts 2
     - name: cf-tcp-router-mysql
       env:
         DIR: src/code.cloudfoundry.org/cf-tcp-router
         DB: mysql
       run: |
+        "${GITHUB_WORKSPACE}"/ci/routing-release/helpers/configure-binaries.bash
         "${GITHUB_WORKSPACE}"/ci/shared/tasks/run-bin-test/task.bash --keep-going --trace -r --fail-on-pending --randomize-all --nodes=7 --race --timeout 30m --flake-attempts 2
     - name: routing-api-mysql
       env:
         DIR: src/code.cloudfoundry.org/routing-api
         DB: mysql
       run: |
+        "${GITHUB_WORKSPACE}"/ci/routing-release/helpers/configure-binaries.bash
         "${GITHUB_WORKSPACE}"/ci/shared/tasks/run-bin-test/task.bash --keep-going --trace -r --fail-on-pending --randomize-all --nodes=7 --race --timeout 30m --flake-attempts 2
   test-repos-withoutdb:
     runs-on: ubuntu-latest
@@ -120,7 +124,9 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: repo
-    - run: "tar -xzvf repo-artifact.tar.gz\ntar -xzvf ci-artifact.tar.gz\n"
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
     - name: build binaries
       run: |
         export DEFAULT_PARAMS="${GITHUB_WORKSPACE}/ci/routing-release/default-params/build-binaries/linux.yml"
@@ -156,7 +162,9 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: repo
-    - run: "tar -xzvf repo-artifact.tar.gz\ntar -xzvf ci-artifact.tar.gz\n"
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
     - name: build binaries
       run: |
         export DEFAULT_PARAMS="${GITHUB_WORKSPACE}/ci/routing-release/default-params/build-binaries/linux.yml"
@@ -192,7 +200,9 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: repo
-    - run: "tar -xzvf repo-artifact.tar.gz\ntar -xzvf ci-artifact.tar.gz\n"
+    - run: |
+        tar -xzvf repo-artifact.tar.gz
+        tar -xzvf ci-artifact.tar.gz
     - name: build binaries
       run: |
         export DEFAULT_PARAMS="${GITHUB_WORKSPACE}/ci/routing-release/default-params/build-binaries/linux.yml"


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
1. Control the workflow action by adding a label as `ready-to-run`. prevents ddos attacks on available github action runners.
2. few updates to gh template file.
3. Tested similar one here. https://github.com/kart2bc/routing-release/pull/8

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
