### PR TITLE
Remove old property: router.max_header_kb

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -287,20 +287,13 @@ properties:
   router.route_services_strict_signature_validation:
       description: "Enforce strict validation of a route service signature"
       default: false
-  router.max_header_kb:
-    description: |
-        Deprecated, use router.max_request_header_kb instead which is equivalent to this option.
-    default: 1024 # 1Mb
   router.max_request_header_kb:
     description: |
         This value controls the maximum number of bytes (in KB) the gorouter will read
         parsing the request header's keys and values, including the request
         line. It does not limit the size of the request body. Requests with
         larger headers will result in a 431 status code. Must be between 1 and 1024kb.
-        Note: This value takes precedence over router.max_header_kb but has no default to not break
-        existing setups. If you previously configured router.max_header_kb it is recommended to
-        switch to this property instead.
-    example: 1024 # 1Mb
+    default: 1024 # 1Mb
   router.max_response_header_kb:
     description: |
         This value controls the maximum number of bytes (in KB) the gorouter will read

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -76,14 +76,9 @@ def status_tls
 end
 
 def max_request_header_bytes
-  # See property description for details.
-  if_p("router.max_request_header_kb") do |kb|
-    return kb * 1024
-  end
-
-  kb = p("router.max_header_kb")
+  kb = p("router.max_request_header_kb")
   if kb < 1 or kb > 1024
-    raise "Invalid router.max_header_kb value. Must be between 1 and 1,024 kb"
+    raise "Invalid router.max_request_header_kb value. Must be between 1 and 1,024 kb"
   end
 
   return kb * 1024

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -210,7 +210,6 @@ describe 'gorouter' do
           'route_services_secret_decrypt_only' => 'secret',
           'route_services_recommend_https' => false,
           'extra_headers_to_log' => 'test-header',
-          'max_header_kb' => 1_024,
           'enable_proxy' => false,
           'force_forwarded_proto_https' => false,
           'sanitize_forwarded_proto' => false,
@@ -344,29 +343,19 @@ describe 'gorouter' do
         end
       end
 
-      describe 'max_(request_)header_kb' do
+      describe 'max_request_header_kb' do
         context 'as a default' do
           it 'should set max_request_header_bytes' do
             expect(parsed_yaml['max_request_header_bytes']).to eq(1_048_576)
           end
         end
 
-        context 'when only max_header_kb is set' do
+        context 'when only max_request_header_kb is set' do
           before do
-            deployment_manifest_fragment['router']['max_header_kb'] = 10
+            deployment_manifest_fragment['router']['max_request_header_kb'] = 10
           end
           it 'should set max_request_header_bytes according to it' do
             expect(parsed_yaml['max_request_header_bytes']).to eq(10_240)
-          end
-        end
-
-        context 'when max_header_kb and max_request_header_kb are set' do
-          before do
-            deployment_manifest_fragment['router']['max_header_kb'] = 10
-            deployment_manifest_fragment['router']['max_request_header_kb'] = 20
-          end
-          it 'should set max_request_header_bytes according to max_request_header_kb' do
-            expect(parsed_yaml['max_request_header_bytes']).to eq(20_480)
           end
         end
       end
@@ -1702,22 +1691,22 @@ describe 'gorouter' do
         end
       end
 
-      context 'max_header_kb' do
+      context 'max_request_header_kb' do
         context 'less than 1' do
           before do
-            deployment_manifest_fragment['router']['max_header_kb'] = 0
+            deployment_manifest_fragment['router']['max_request_header_kb'] = 0
           end
           it 'throws an error' do
-            expect { parsed_yaml }.to raise_error(/Invalid router.max_header_kb/)
+            expect { parsed_yaml }.to raise_error(/Invalid router.max_request_header_kb/)
           end
         end
 
         context 'greater than 1mb' do
           before do
-            deployment_manifest_fragment['router']['max_header_kb'] = 1024 + 1
+            deployment_manifest_fragment['router']['max_request_header_kb'] = 1024 + 1
           end
           it 'throws an error' do
-            expect { parsed_yaml }.to raise_error(/Invalid router.max_header_kb/)
+            expect { parsed_yaml }.to raise_error(/Invalid router.max_request_header_kb/)
           end
         end
       end


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Remove old property: router.max_header_kb


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
