### PR TITLE
Update routing-api's bbr metadata to be overridable with a bosh property

### DIFF
--- a/jobs/routing-api/spec
+++ b/jobs/routing-api/spec
@@ -232,6 +232,13 @@ properties:
     description: "Local port to listen on with admin endpoint (used for backup/restore locking)"
     default: 15897
 
+  routing_api.bbr.metadata:
+    description: "BBR Metadata"
+    default: |
+      ---
+      restore_should_be_locked_before:
+      - job_name: uaa
+        release: uaa
 
   release_level_backup:
     default: false

--- a/jobs/routing-api/templates/bbr-metadata
+++ b/jobs/routing-api/templates/bbr-metadata
@@ -1,6 +1,2 @@
 #!/usr/bin/env bash
-
-echo "---
-restore_should_be_locked_before:
-- job_name: uaa
-  release: uaa"
+echo '<%= p("routing_api.bbr.metadata") %>'

--- a/spec/routing_api_templates_spec.rb
+++ b/spec/routing_api_templates_spec.rb
@@ -384,4 +384,41 @@ describe 'routing_api' do
       end
     end
   end
+
+  describe 'bbr metadata' do
+    let(:template) { job.template('bin/bbr/metadata') }
+    let(:links) { [] }
+
+    subject(:script_output) do
+      `#{template.render(merged_manifest_properties, consumes: links)}`
+    end
+
+    describe 'when the property is not defined' do
+      it 'has a sane default' do
+        expect(script_output).to eq('---
+restore_should_be_locked_before:
+- job_name: uaa
+  release: uaa
+
+')
+      end
+    end
+    describe 'when the property is provided' do
+      before do
+        merged_manifest_properties['routing_api']['bbr'] = {
+          'metadata'=> '---
+  test: yaml
+  corn: banana
+'
+        }
+      end
+      it 'overrides the output' do
+        expect(script_output).to eq('---
+  test: yaml
+  corn: banana
+
+')
+      end
+    end
+  end
 end


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Lets operators override bbr metadata entirely.

Backward Compatibility
---------------
Breaking Change? no