### PR TITLE
Log redundant route/endpoint unregistration on Debug level

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/registry/registry.go
+++ b/src/code.cloudfoundry.org/gorouter/registry/registry.go
@@ -184,22 +184,21 @@ func (r *RouteRegistry) Unregister(uri route.Uri, endpoint *route.Endpoint) {
 
 	r.reporter.CaptureUnregistryMessage(endpoint)
 
-	var logMsg string
 	if endpointRemoved {
-		logMsg = "endpoint-unregistered"
+		r.logger.Info("endpoint-unregistered", buildSlogAttrs(uri, endpoint)...)
 	} else {
-		logMsg = "endpoint-not-unregistered"
-	}
-
-	if r.logger.Enabled(context.Background(), slog.LevelInfo) {
-		r.logger.Info(logMsg, buildSlogAttrs(uri, endpoint)...)
+		if r.logger.Enabled(context.Background(), slog.LevelDebug) {
+			r.logger.Debug("endpoint-not-unregistered", buildSlogAttrs(uri, endpoint)...)
+		}
 	}
 
 	if routePoolRemoved {
 		r.logger.Info("route-unregistered", slog.Any("uri", uri))
 		r.reporter.CaptureRoutesUnregistered()
 	} else {
-		r.logger.Info("route-not-unregistered", slog.Any("uri", uri))
+		if r.logger.Enabled(context.Background(), slog.LevelDebug) {
+			r.logger.Debug("route-not-unregistered", slog.Any("uri", uri))
+		}
 	}
 }
 

--- a/src/code.cloudfoundry.org/gorouter/registry/registry_test.go
+++ b/src/code.cloudfoundry.org/gorouter/registry/registry_test.go
@@ -845,6 +845,14 @@ var _ = Describe("RouteRegistry", func() {
 				Eventually(logger).Should(gbytes.Say(`"log_level":1.*route-unregistered.*a\.route`))
 			})
 
+			It("logs the redundant route and endpoint unregistration at debug level", func() {
+				r.Unregister("a.route", fooEndpoint)
+				Eventually(logger).Should(gbytes.Say(`"log_level":1.*endpoint-unregistered.*a\.route.*192\.168\.1\.1`))
+				Eventually(logger).Should(gbytes.Say(`"log_level":1.*route-unregistered.*a\.route`))
+				Eventually(logger).Should(gbytes.Say(`"log_level":0.*endpoint-not-unregistered.*a\.route.*192\.168\.1\.1`))
+				Eventually(logger).Should(gbytes.Say(`"log_level":0.*route-not-unregistered.*a\.route`))
+			})
+
 			It("only logs unregistration for existing routes", func() {
 				r.Unregister("non-existent-route", fooEndpoint)
 				Expect(logger).NotTo(gbytes.Say(`unregister.*.*a\.non-existent-route`))


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
When unregistering an endpoint, e.g. when scaling down the number of instance, simply rescheduling an application on another cell, or when app instances are stopped, crashed, or removed, route-emitter repeatedly sends unregistration messages via NATS towards gorouter. The number of repeats for sending unregistration messages is [configurable](https://github.com/cloudfoundry/route-emitter/blob/26f4ea327c50ff95828162de3f6db8f14f25f49c/cmd/route-emitter/config/config.go#L64). This ensures reliable route cleanup even if Gorouter misses earlier messages. It also prevents stale routes 
from remaining registered.

Gorouter logs each of these messages on `Info` level, even the redundant messages, when the endpoint and/or route has already been unregistered. This leads to a huge amount of redundant log messages. This change proposes to keep the logging level at `Info` for the actual unregistration, but change it to `Debug` for subsequent redundant messages.  

Backward Compatibility
---------------
Breaking Change? **Questionable**
While changing the log level may be considered a breaking change, the affected log messages are redundant and do not provide any value.