### PR TITLE
feat: allow sni_routable_sni to be configured when type is san and terminate_frontend_tls is enabled

### DIFF
--- a/docs/01-route-registrar-usage.md
+++ b/docs/01-route-registrar-usage.md
@@ -84,6 +84,8 @@ The route-registrar expects a configuration json file like the one below:
   - `route_service_url` is optional. When provided, Gorouter will proxy
     requests received for the `uris` above to this address.
   - `health_check` is optional and explained in more detail below.
+  - `sni_routable_san` is the SAN used to route the request to the appropriate
+    backend. Required when `type` is `sni` and `terminate_frontend_tls` is enabled.
   - `terminate_frontend_tls` is optional. When true, the router will terminate 
     TLS before forwarding the requests to the backend servers. Default: false
   - `enable_backend_tls` is optional. When true, the router will initiate a 

--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -130,6 +130,8 @@ properties:
         options (optional, object, for http routes): Custom per-route options
         terminate_frontend_tls (optional, boolean): When true, the router will terminate TLS before forwarding requests to the backend. Default: false
         alpns (optional, array): Application Layer Protocol Negotiation strings.
+        sni_routable_san(optional, string): is the SAN used to route the request to the appropriate backend. 
+          Required when `type` is `sni` and `terminate_frontend_tls` is enabled.
 
       health_check object
         name (required, string): Human-readable reference for the healthcheck

--- a/jobs/route_registrar/templates/registrar_settings.json.erb
+++ b/jobs/route_registrar/templates/registrar_settings.json.erb
@@ -54,7 +54,7 @@ TEXT
   end
 
   message_bus_servers = nil
-  if nats_user and nats_password
+  if nats_user && nats_password
     message_bus_servers = nats_machines.map do |host|
       {
         host: "#{host}:#{nats_port}",
@@ -91,7 +91,17 @@ TEXT
       route['uris'].map! { |uri| "#{spec.index}-#{uri}" }
     end
 
-    if route['type'] == 'sni'
+    if route['type'] == 'sni' && route['terminate_frontend_tls']
+      if route['sni_routable_san'] == nil || route['sni_routable_san'] == ''
+        raise "route_registrar.routes[#{index}].route.sni_routable_san must be provided when type is sni and terminate_frontend_tls is enabled"
+      end
+    end
+
+    if route['type'] == 'sni' && !route['terminate_frontend_tls']
+      if route['sni_routable_san'] != nil
+        raise "route_registrar.routes[#{index}].route.sni_routable_san cannot be provided when type is sni and terminate_frontend_tls is disabled"
+      end
+
       route['sni_routable_san'] = spec.address
 
       if route.key?('server_cert_domain_name_modifier')
@@ -142,7 +152,7 @@ TEXT
     end
 
     link.if_p('routing_api.enabled_api_endpoints') do |endpoints|
-      if endpoints == 'both' or endpoints == 'mtls'
+      if endpoints == 'both' || endpoints == 'mtls'
         api_scheme = 'https'
         api_port = link.p('routing_api.tls_port', api_port)
       end
@@ -156,7 +166,7 @@ TEXT
 
   if_p('route_registrar.routing_api.api_url') do |prop|
     if_link('routing_api') do |link|
-      if link.p('routing_api.enabled_api_endpoints') == "mtls" and not prop.start_with?('https')
+      if link.p('routing_api.enabled_api_endpoints') == "mtls" && !prop.start_with?('https')
           raise 'expected route_registrar.routing_api.api_url to be https when routing_api.enabled_api_endpoints is mtls only'
       end
     end

--- a/spec/route_registar_templates_spec.rb
+++ b/spec/route_registar_templates_spec.rb
@@ -41,6 +41,18 @@ describe 'route_registrar' do
     }
   end
 
+  let(:sni_route) { {
+    "name" => "svc-name",
+    "registration_interval" => "20s",
+    "router_group" => "svc-router-group",
+    "external_port" => 1024,
+    "type" => "sni",
+    "sni_port" => 5671,
+    "sni_routable_san" => "svc-1.foobar.com",
+    "terminate_frontend_tls" => true,
+    "enable_backend_tls" => true
+  } }
+
   describe 'config/routing_api/certs/client.crt' do
     let(:template) { job.template('config/routing_api/certs/client.crt') }
     let(:links) do
@@ -492,7 +504,7 @@ describe 'route_registrar' do
       context 'when uaa.tls_port is provided in the link' do
         let(:uaa_link_properties) do
           {
-             'tls_port' => 9443, 
+             'tls_port' => 9443,
           }
         end
         it 'uses the link value' do
@@ -511,7 +523,7 @@ describe 'route_registrar' do
       context 'when uaa.token_endpoint is provided in the link' do
         let(:uaa_link_properties) do
           {
-            'token_endpoint' => 'link-uaa.service.cf.internal', 
+            'token_endpoint' => 'link-uaa.service.cf.internal',
           }
         end
         it 'uses the link value' do
@@ -678,6 +690,56 @@ describe 'route_registrar' do
         expect { template.render(merged_manifest_properties, consumes: links) }.to raise_error(
           RuntimeError, 'expected route_registrar.routes[0].route.server_cert_domain_san when tls_port is provided'
         )
+      end
+    end
+
+    describe 'when type is sni and frontend_tls is enabled and sni_routable_san is provided' do
+      before do
+        merged_manifest_properties['route_registrar']['routes'][0] = sni_route
+        merged_manifest_properties['nats'] = { 'fail_if_using_nats_without_tls' => false }
+      end
+
+      it 'should use the provided sni_routable_san' do
+        rendered_hash = JSON.parse(template.render(merged_manifest_properties, consumes: links))
+        expect(rendered_hash['routes'][0]).to eq({
+                                                   "name" => "svc-name",
+                                                   "registration_interval" => "20s",
+                                                   "router_group" => "svc-router-group",
+                                                   "external_port" => 1024,
+                                                   "type" => "sni",
+                                                   "sni_port" => 5671,
+                                                   "sni_routable_san" => "svc-1.foobar.com",
+                                                   "terminate_frontend_tls" => true,
+                                                   "enable_backend_tls" => true
+                                                 })
+      end
+    end
+
+    describe 'when type is sni and frontend_tls is disabled and sni_routable_san is provided' do
+      before do
+        merged_manifest_properties['route_registrar']['routes'][0] = sni_route
+        merged_manifest_properties['route_registrar']['routes'][0]['terminate_frontend_tls'] = false
+        merged_manifest_properties['nats'] = { 'fail_if_using_nats_without_tls' => false }
+      end
+
+      it 'raises an error for invalid sni_routable_san' do
+        expect { template.render(merged_manifest_properties, consumes: links) }.to raise_error(
+          RuntimeError, 'route_registrar.routes[0].route.sni_routable_san cannot be provided when type is sni and terminate_frontend_tls is disabled'
+       )
+      end
+    end
+
+    describe 'when type is sni and frontend_tls is enabled and sni_routable_san is NOT provided' do
+      before do
+        merged_manifest_properties['route_registrar']['routes'][0] = sni_route
+        merged_manifest_properties['route_registrar']['routes'][0]['sni_routable_san'] = ''
+        merged_manifest_properties['nats'] = { 'fail_if_using_nats_without_tls' => false }
+      end
+
+      it 'raises an error for invalid sni_routable_san' do
+        expect { template.render(merged_manifest_properties, consumes: links) }.to raise_error(
+         RuntimeError, 'route_registrar.routes[0].route.sni_routable_san must be provided when type is sni and terminate_frontend_tls is enabled'
+       )
       end
     end
 


### PR DESCRIPTION
- [x ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->
Allow sni_routable_sni to be configured when type is san and terminate_frontend_tls is enabled

- Add SNI routing documentation and example configuration
- Implement validation rules for SNI routing:
  - Require sni_routable_san when terminate_frontend_tls is enabled
  - Use spec.address as default SAN when terminate_frontend_tls is disabled
  - Support server_cert_domain_name_modifier for SAN customization
- Add comprehensive tests for SNI configuration scenarios

This is a request from Broadcom Engineering team to fix it and is recorded under TNZ-55925

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
