### PR TITLE
tcp_router: fix cert directory permissions

### DIFF
--- a/jobs/tcp_router/templates/pre-start.erb
+++ b/jobs/tcp_router/templates/pre-start.erb
@@ -1,5 +1,4 @@
 #!/bin/bash -e
 
-<% if spec.bootstrap == true %>
+# certs need to be written to the filesystem on all VMs
 /var/vcap/packages/tcp_router/bin/config-validator -config /var/vcap/jobs/tcp_router/config/tcp_router.yml -enable-cert-creation true
-<% end %>

--- a/jobs/tcp_router/templates/pre-start.erb
+++ b/jobs/tcp_router/templates/pre-start.erb
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
-# certs need to be written to the filesystem on all VMs
+# This pre-start script runs (1) config validation and (2) creates frontend certs on the VM (if any)
 /var/vcap/packages/tcp_router/bin/config-validator -config /var/vcap/jobs/tcp_router/config/tcp_router.yml -enable-cert-creation true

--- a/src/code.cloudfoundry.org/cf-tcp-router/config/config.go
+++ b/src/code.cloudfoundry.org/cf-tcp-router/config/config.go
@@ -102,6 +102,12 @@ func resolveGroupID(primary, fallback string) (int, error) {
 	return gid, nil
 }
 
+// initConfigFromFile initializes the config and write the certs to the filesystem when enableCertCreation is true.
+//
+// enableCertCreation is set to true during pre-start on all VMs. During pre-start initConfigFromFile is run
+// to (1) validate the config provided and (2) create the FrontendTLSJob certs on the filesystem if provided.
+//
+// enableCertCreation is set to false when bosh starts the tcp-router job.
 func (c *Config) initConfigFromFile(path string, enableCertCreation bool) error {
 	b, err := os.ReadFile(path)
 	if err != nil {
@@ -121,70 +127,56 @@ func (c *Config) initConfigFromFile(path string, enableCertCreation bool) error 
 	}
 
 	if enableCertCreation && len(c.FrontendTLSJob) > 0 {
-		owner, err := user.Lookup("root")
-		if err != nil {
-			return err
+		// remove existing directory which will clean out old certs if necessary
+		if err := os.RemoveAll(c.FrontendTLSJobBasePath()); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("directory could not be removed: %w", err)
 		}
 
-		uid, err := strconv.Atoi(owner.Uid)
-		if err != nil {
-			return err
+		if err := c.createDir(c.FrontendTLSJobBasePath()); err != nil {
+			return fmt.Errorf("could not create directory: %w", err)
+		}
+	}
+
+	for i, cert := range c.FrontendTLSJob {
+		// validations
+		name := strings.TrimSpace(cert.Name)
+		if name == "" {
+			return fmt.Errorf("frontend_tls[%d]: empty name", i)
 		}
 
-		gid, err := resolveGroupID("vcap", "root")
-		if err != nil {
-			return err
-		}
-		var outputs []FrontendTLSConfig
-		basePath := c.FrontendTLSJobBasePath()
-		for i, cert := range c.FrontendTLSJob {
-
-			name := strings.TrimSpace(cert.Name)
-			certChain := strings.TrimSpace(cert.CertChain)
-			privateKey := strings.TrimSpace(cert.PrivateKey)
-
-			if name == "" || certChain == "" || privateKey == "" {
-				return fmt.Errorf("frontend_tls[%d] must include name, cert_chain, and private_key", i)
-			}
-
-			block, _ := pem.Decode([]byte(certChain))
-			if block == nil {
-				return errors.New("failed to parse PEM block")
-			}
-			cert, err := x509.ParseCertificate(block.Bytes)
-			if err != nil {
-				return err
-			}
-
-			hasSAN := certHasSAN(cert)
-			if !hasSAN {
-				return fmt.Errorf("frontend_tls[%d].cert_chain must include a subjectAltName extension", i)
-			}
-
-			dirPath := filepath.Join(basePath, name)
-			if err := os.MkdirAll(dirPath, 0750); err != nil {
-				return err
-			}
-
-			certFilePath := filepath.Join(dirPath, fmt.Sprintf("%s.pem", name))
-			keyFilePath := filepath.Join(dirPath, fmt.Sprintf("%s.pem.key", name))
-
-			if err := writeFile(certFilePath, []byte(certChain), 0750, uid, gid); err != nil {
-				return err
-			}
-
-			if err := writeFile(keyFilePath, []byte(privateKey), 0750, uid, gid); err != nil {
-				return err
-			}
-
-			outputs = append(outputs, FrontendTLSConfig{
-				Enabled:        true,
-				CertificateDir: dirPath,
-			})
+		certChain := strings.TrimSpace(cert.CertChain)
+		if certChain == "" {
+			return fmt.Errorf("frontend_tls[%d]: empty cert_chain", i)
 		}
 
-		c.FrontendTLS = outputs
+		privateKey := strings.TrimSpace(cert.PrivateKey)
+		if privateKey == "" {
+			return fmt.Errorf("frontend_tls[%d]: empty private_key", i)
+		}
 
+		// check if san is present and that the cert chain is valid
+		if err := certHasSAN(cert.CertChain); err != nil {
+			return fmt.Errorf("frontend_tls[%d]: %w", i, err)
+		}
+
+		dirPath := filepath.Join(c.FrontendTLSJobBasePath(), name)
+
+		// write certs to the disk
+		if enableCertCreation {
+			if err := c.createDir(dirPath); err != nil {
+				return fmt.Errorf("frontend_tls[%d]: %w", i, err)
+			}
+
+			if err := c.writeCertsToDisk(dirPath, name, cert, privateKey); err != nil {
+				return fmt.Errorf("frontend_tls[%d]: %w", i, err)
+			}
+		}
+
+		// update the config
+		c.FrontendTLS = append(c.FrontendTLS, FrontendTLSConfig{
+			Enabled:        true,
+			CertificateDir: dirPath,
+		})
 	}
 
 	if c.BackendTLS.Enabled {
@@ -262,18 +254,80 @@ func (c *Config) initConfigFromFile(path string, enableCertCreation bool) error 
 	return nil
 }
 
-func certHasSAN(cert *x509.Certificate) bool {
-	hasSANExtension := false
-	for _, ext := range cert.Extensions {
-		if ext.Id.String() == "2.5.29.17" {
-			hasSANExtension = true
-			break
-		}
+func (c *Config) createDir(dirPath string) error {
+	// ensure directory exists
+	if err := os.MkdirAll(dirPath, 0750); err != nil {
+		return err
 	}
 
-	hasDNSEntries := len(cert.DNSNames) > 0
+	targetUID, targetGID, err := c.getUIDGID()
+	if err != nil {
+		return err
+	}
 
-	return hasSANExtension || hasDNSEntries
+	// Change ownership
+	err = os.Chown(dirPath, targetUID, targetGID)
+	if err != nil {
+		return fmt.Errorf("Error changing ownership: %s", err)
+	}
+
+	return nil
+}
+
+func (c *Config) writeCertsToDisk(dirPath string, name string, cert FrontendTLSJob, privateKey string) error {
+	uid, gid, err := c.getUIDGID()
+	if err != nil {
+		return err
+	}
+
+	certFilePath := filepath.Join(dirPath, fmt.Sprintf("%s.pem", name))
+	keyFilePath := filepath.Join(dirPath, fmt.Sprintf("%s.pem.key", name))
+
+	if err := writeFile(certFilePath, []byte(cert.CertChain), 0750, uid, gid); err != nil {
+		return err
+	}
+
+	if err := writeFile(keyFilePath, []byte(privateKey), 0750, uid, gid); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Config) getUIDGID() (int, int, error) {
+	owner, err := user.Lookup("root")
+	if err != nil {
+		return 0, 0, err
+	}
+
+	uid, err := strconv.Atoi(owner.Uid)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	gid, err := resolveGroupID("vcap", "root")
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return uid, gid, nil
+}
+
+func certHasSAN(certChain string) error {
+	block, _ := pem.Decode([]byte(certChain))
+	if block == nil {
+		return errors.New("failed to parse PEM block")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("could not parse certificate: %w", err)
+	}
+
+	if len(cert.DNSNames) > 0 {
+		return nil
+	}
+
+	return fmt.Errorf("cert_chain must include either a subjectAltName extension or DNSNames")
 }
 
 func writeFile(path string, data []byte, mode os.FileMode, uid, gid int) error {
@@ -281,9 +335,5 @@ func writeFile(path string, data []byte, mode os.FileMode, uid, gid int) error {
 		return err
 	}
 
-	if err := os.Chown(path, uid, gid); err != nil {
-		return err
-	}
-
-	return nil
+	return os.Chown(path, uid, gid)
 }

--- a/src/code.cloudfoundry.org/cf-tcp-router/config/config_test.go
+++ b/src/code.cloudfoundry.org/cf-tcp-router/config/config_test.go
@@ -2,7 +2,9 @@ package config_test
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"os"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -221,7 +223,7 @@ var _ = Describe("Config", Serial, func() {
 		)
 
 		BeforeEach(func() {
-			tmpDir = GinkgoT().TempDir()
+			tmpDir = path.Join(GinkgoT().TempDir(), fmt.Sprintf("frontend-%d", rand.IntN(100)))
 			os.Setenv("FRONTEND_TLS_BASE_PATH", tmpDir)
 		})
 
@@ -229,7 +231,7 @@ var _ = Describe("Config", Serial, func() {
 			os.Unsetenv("FRONTEND_TLS_BASE_PATH")
 		})
 
-		Context("with valid cert and key", func() {
+		Context("with valid cert and key and enableCertCreation set to true", func() {
 			BeforeEach(func() {
 				cfg, err = config.New("fixtures/valid_frontend_cert.yml", true)
 			})
@@ -238,7 +240,7 @@ var _ = Describe("Config", Serial, func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("adds the certs and keys to the expected directories", func() {
+			It("updates the config with the expected directories", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cfg.FrontendTLS).To(HaveLen(2))
 
@@ -253,64 +255,17 @@ var _ = Describe("Config", Serial, func() {
 				}))
 			})
 
-			It("writes the correct cert and key files", func() {
+			It("writes the cert and key files", func() {
+				Expect(tmpDir).To(BeADirectory())
+
 				for i, name := range []string{"prod", "dev"} {
 					certPath := filepath.Join(tmpDir, name, name+".pem")
 					keyPath := filepath.Join(tmpDir, name, name+".pem.key")
 
-					Expect(certPath).To(BeAnExistingFile())
-					Expect(keyPath).To(BeAnExistingFile())
-
-					certData, certErr := os.ReadFile(certPath)
-					Expect(certErr).NotTo(HaveOccurred())
-					Expect(string(certData)).To(Equal(cfg.FrontendTLSJob[i].CertChain))
-
-					keyData, keyErr := os.ReadFile(keyPath)
-					Expect(keyErr).NotTo(HaveOccurred())
-					Expect(string(keyData)).To(Equal(cfg.FrontendTLSJob[i].PrivateKey))
-				}
-			})
-		})
-
-		Context("with invalid cert and key", func() {
-			BeforeEach(func() {
-				cfg, err = config.New("fixtures/valid_frontend_cert.yml", true)
-			})
-
-			It("loads config without error", func() {
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("adds the certs and keys to the expected directories", func() {
-				Expect(err).NotTo(HaveOccurred())
-				Expect(cfg.FrontendTLS).To(HaveLen(2))
-
-				Expect(cfg.FrontendTLS[0]).To(Equal(config.FrontendTLSConfig{
-					Enabled:        true,
-					CertificateDir: filepath.Join(tmpDir, "prod"),
-				}))
-
-				Expect(cfg.FrontendTLS[1]).To(Equal(config.FrontendTLSConfig{
-					Enabled:        true,
-					CertificateDir: filepath.Join(tmpDir, "dev"),
-				}))
-			})
-
-			It("writes the correct cert and key files with correct permissions", func() {
-				for i, name := range []string{"prod", "dev"} {
-					certPath := filepath.Join(tmpDir, name, name+".pem")
-					keyPath := filepath.Join(tmpDir, name, name+".pem.key")
+					Expect(path.Join(tmpDir, name)).To(BeADirectory())
 
 					Expect(certPath).To(BeAnExistingFile())
 					Expect(keyPath).To(BeAnExistingFile())
-
-					certData, certErr := os.ReadFile(certPath)
-					Expect(certErr).NotTo(HaveOccurred())
-					Expect(string(certData)).To(Equal(cfg.FrontendTLSJob[i].CertChain))
-
-					keyData, keyErr := os.ReadFile(keyPath)
-					Expect(keyErr).NotTo(HaveOccurred())
-					Expect(string(keyData)).To(Equal(cfg.FrontendTLSJob[i].PrivateKey))
 
 					certInfo, err := os.Stat(certPath)
 					Expect(err).NotTo(HaveOccurred())
@@ -319,28 +274,89 @@ var _ = Describe("Config", Serial, func() {
 					keyInfo, err := os.Stat(keyPath)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(os.FileMode(0750)).To(Equal(keyInfo.Mode().Perm()))
+
+					certData, certErr := os.ReadFile(certPath)
+					Expect(certErr).NotTo(HaveOccurred())
+					Expect(string(certData)).To(Equal(cfg.FrontendTLSJob[i].CertChain))
+
+					keyData, keyErr := os.ReadFile(keyPath)
+					Expect(keyErr).NotTo(HaveOccurred())
+					Expect(string(keyData)).To(Equal(cfg.FrontendTLSJob[i].PrivateKey))
+				}
+			})
+		})
+
+		Context("with valid cert (having san and dnsnames) and key and enableCertCreation set to false", func() {
+			BeforeEach(func() {
+				cfg, err = config.New("fixtures/valid_frontend_cert.yml", false)
+			})
+
+			It("loads config without error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("updates the config with the expected directories", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg.FrontendTLS).To(HaveLen(2))
+
+				Expect(cfg.FrontendTLS[0]).To(Equal(config.FrontendTLSConfig{
+					Enabled:        true,
+					CertificateDir: filepath.Join(tmpDir, "prod"),
+				}))
+
+				Expect(cfg.FrontendTLS[1]).To(Equal(config.FrontendTLSConfig{
+					Enabled:        true,
+					CertificateDir: filepath.Join(tmpDir, "dev"),
+				}))
+			})
+
+			It("does not write the cert and key files as enableCertCreation is false", func() {
+				for _, name := range []string{"prod", "dev"} {
+					certPath := filepath.Join(tmpDir, name, name+".pem")
+					keyPath := filepath.Join(tmpDir, name, name+".pem.key")
+
+					Expect(certPath).ToNot(BeAnExistingFile())
+					Expect(keyPath).ToNot(BeAnExistingFile())
 				}
 			})
 		})
 
 		Context("with invalid frontend_tls config", func() {
-			It("should fail if cert_chain is missing SAN information", func() {
-				_, err := config.New("fixtures/frontend_cert_without_san.yml", true)
+			It("should fail if cert is empty", func() {
+				_, err := config.New("fixtures/no_frontend_certs.yml", false)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("frontend_tls[0].cert_chain must include a subjectAltName extension"))
-			})
-			It("should fail if certs or keys are empty", func() {
-				_, err := config.New("fixtures/no_frontend_certs.yml", true)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("frontend_tls[0] must include name, cert_chain, and private_key"))
-			})
-			It("should fail if cert is invalid", func() {
-				_, err := config.New("fixtures/invalid_frontend_certs.yml", true)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("failed to parse PEM block"))
+				Expect(err.Error()).To(Equal("frontend_tls[0]: empty cert_chain"))
 			})
 
+			It("should fail if key is missing", func() {
+				_, err := config.New("fixtures/invalid_frontend_key.yml", false)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("frontend_tls[0]: empty private_key"))
+			})
+
+			It("should fail if name is missing", func() {
+				_, err := config.New("fixtures/invalid_frontend_name.yml", false)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("frontend_tls[0]: empty name"))
+			})
+
+			It("should fail if cert is invalid", func() {
+				_, err := config.New("fixtures/invalid_frontend_certs.yml", false)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("frontend_tls[0]: failed to parse PEM block"))
+			})
+
+			It("should fail if cert_chain is missing SAN information and DNSnames", func() {
+				_, err := config.New("fixtures/frontend_cert_without_san.yml", false)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("frontend_tls[0]: cert_chain must include either a subjectAltName extension or DNSNames"))
+			})
+
+			It("should fail if cert_chain is invalid", func() {
+				_, err := config.New("fixtures/invalid_frontend_cert_certchain.yml", false)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("frontend_tls[0]: could not parse certificate: x509: malformed certificate"))
+			})
 		})
 	})
-
 })

--- a/src/code.cloudfoundry.org/cf-tcp-router/config/fixtures/invalid_frontend_cert_certchain.yml
+++ b/src/code.cloudfoundry.org/cf-tcp-router/config/fixtures/invalid_frontend_cert_certchain.yml
@@ -17,10 +17,10 @@ routing_api:
 haproxy_pid_file: /path/to/pid/file
 isolation_segments: ["foo-iso-seg"]
 reserved_system_component_ports: [8080, 8081]
-backend_tls:
-  enabled: false
-  ca_cert_path: fixtures/ca.pem
-  client_cert_and_key_path: fixtures/cert_and_key.pem
 frontend_tls:
-  enabled: true
-  cert_dir: /tmp
+  - name: "prod"
+    cert_chain: |-
+      -----BEGIN CERTIFICATE-----
+      Zm9vYmFyCg==
+      -----END CERTIFICATE-----
+    private_key: "some key"

--- a/src/code.cloudfoundry.org/cf-tcp-router/config/fixtures/invalid_frontend_key.yml
+++ b/src/code.cloudfoundry.org/cf-tcp-router/config/fixtures/invalid_frontend_key.yml
@@ -1,0 +1,47 @@
+oauth:
+  token_endpoint: "uaa.service.cf.internal"
+  client_name: "someclient"
+  client_secret: "somesecret"
+  port: 8443
+  skip_ssl_validation: true
+  ca_certs: "some-ca-cert"
+
+routing_api:
+  uri: http://routing-api.service.cf.internal
+  port: 3000
+  auth_disabled: false
+  client_cert_path: /a/client_cert
+  client_private_key_path: /b/private_key
+  ca_cert_path: /c/ca_cert
+
+haproxy_pid_file: /path/to/pid/file
+isolation_segments: ["foo-iso-seg"]
+reserved_system_component_ports: [8080, 8081]
+frontend_tls:
+  - name: "prod"
+    cert_chain: |-
+      -----BEGIN CERTIFICATE-----
+      MIIESzCCAjOgAwIBAgIQDnaPUSkJl2T+TaMLHUlWqzANBgkqhkiG9w0BAQsFADAS
+      MRAwDgYDVQQDEwd0ZXN0LWNhMB4XDTIxMTAyMTIwMDIzMloXDTIzMDQyMTE2Mjkw
+      NVowHTEbMBkGA1UEAxMSdGVzdDItd2l0aC1zYW4uY29tMIIBIjANBgkqhkiG9w0B
+      AQEFAAOCAQ8AMIIBCgKCAQEAwc8fvFNfGF1SqVs7UOTwYbQCv18wF+EfJYT4tq3P
+      1MLBuW7eURKnJ4ZAslsogX4WXmksYHnjRbIsQw6mtgAkMtkC+C5tuRO5uaEBSFxP
+      vA9z7b9uM9MGA2YSJVP1+U00y/HCrwI5LEc/SGij3bvKOcs+CUAEmHhr3sG95BTF
+      atVE5vbG+XHLw2DwaWzDFrtPG3o9zBtDb7/yqTNJCb+i7iyp9Yh0N2ZHgKjNI8Ru
+      6rEkQz8nYk44NjCwV5l0fKV3eKLXTRyfEb+Gr1RHfTtG7wRvfDcDanS5XTZQWAAr
+      a61V38xfR+bYniYsSLmH/VZ1CAhqY8t45N9Sc47cH6gOHQIDAQABo4GRMIGOMA4G
+      A1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHQYD
+      VR0OBBYEFMl9dHRf9wJoWyuWNg93QldFc5IKMB8GA1UdIwQYMBaAFBIf8JzVENnJ
+      GH272x8d5Ld5ZjNMMB0GA1UdEQQWMBSCEnRlc3QyLXdpdGgtc2FuLmNvbTANBgkq
+      hkiG9w0BAQsFAAOCAgEADQFp7nPDLMRPbwWo1fRj7jF6XC85qJF5F9hMRyuioxu9
+      ZHnlejEpi8o41/NRCV0lPLIAXe9/0owppZF3WhqF7eYUFa1YxFr+BkQg3r4nAq9g
+      UKkT2qB/AmJA72HYGGYbb1OdxccRxbgh1+nWzEkxFzB7HbiIrY7OqmDFLr7JRAeF
+      kaH27wLnZ2TJ2MCDQZNM8n12+3szwytZDl8uz6Dl5W7L4HcK6KIROhvjA6s3lAvA
+      3E2VJ07bkAvMcXGX0jobcTVDB/+WVvVoZym0TfmMUVQ0JD6vFe8sNdsJysWCsUe9
+      DbE9ZRA+3GaURVlpZ89n4sURVIopP+N51Vs6aZAIZdOuOvFwu+7N82LjI4i8800c
+      P90vC+M77jSGmu7Cuehu62Q0aUIx+X98TXQXpb4KLQ5Ot5RIPV0E3ksmKuqIrwuO
+      m5tSO2hX/BIkj160bikWbi3oqU8+91+jeW9fQnRLApkPwLWXSViF1Q7K8c6+/H/p
+      oyX7VxkqnU43+nzL+Egc9ibYRF22XMkCBICZFrPu3rZbz8zHTw43ldqHezvx+O/J
+      R5DG1U9dcbt9urELWUBEWlrDudlyC1p6ZvMYQIHP2e27pUaU6wFy7xnIrTxYbDM6
+      HTngE/Gz+qIUe7OkPXPPkFeoSfR1poQ3yNz4bim9Vx+w50l6m+h6SZOYJTxEUds=
+      -----END CERTIFICATE-----

--- a/src/code.cloudfoundry.org/cf-tcp-router/config/fixtures/invalid_frontend_name.yml
+++ b/src/code.cloudfoundry.org/cf-tcp-router/config/fixtures/invalid_frontend_name.yml
@@ -1,0 +1,47 @@
+oauth:
+  token_endpoint: "uaa.service.cf.internal"
+  client_name: "someclient"
+  client_secret: "somesecret"
+  port: 8443
+  skip_ssl_validation: true
+  ca_certs: "some-ca-cert"
+
+routing_api:
+  uri: http://routing-api.service.cf.internal
+  port: 3000
+  auth_disabled: false
+  client_cert_path: /a/client_cert
+  client_private_key_path: /b/private_key
+  ca_cert_path: /c/ca_cert
+
+haproxy_pid_file: /path/to/pid/file
+isolation_segments: ["foo-iso-seg"]
+reserved_system_component_ports: [8080, 8081]
+frontend_tls:
+  - cert_chain: |-
+      -----BEGIN CERTIFICATE-----
+      MIIESzCCAjOgAwIBAgIQDnaPUSkJl2T+TaMLHUlWqzANBgkqhkiG9w0BAQsFADAS
+      MRAwDgYDVQQDEwd0ZXN0LWNhMB4XDTIxMTAyMTIwMDIzMloXDTIzMDQyMTE2Mjkw
+      NVowHTEbMBkGA1UEAxMSdGVzdDItd2l0aC1zYW4uY29tMIIBIjANBgkqhkiG9w0B
+      AQEFAAOCAQ8AMIIBCgKCAQEAwc8fvFNfGF1SqVs7UOTwYbQCv18wF+EfJYT4tq3P
+      1MLBuW7eURKnJ4ZAslsogX4WXmksYHnjRbIsQw6mtgAkMtkC+C5tuRO5uaEBSFxP
+      vA9z7b9uM9MGA2YSJVP1+U00y/HCrwI5LEc/SGij3bvKOcs+CUAEmHhr3sG95BTF
+      atVE5vbG+XHLw2DwaWzDFrtPG3o9zBtDb7/yqTNJCb+i7iyp9Yh0N2ZHgKjNI8Ru
+      6rEkQz8nYk44NjCwV5l0fKV3eKLXTRyfEb+Gr1RHfTtG7wRvfDcDanS5XTZQWAAr
+      a61V38xfR+bYniYsSLmH/VZ1CAhqY8t45N9Sc47cH6gOHQIDAQABo4GRMIGOMA4G
+      A1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHQYD
+      VR0OBBYEFMl9dHRf9wJoWyuWNg93QldFc5IKMB8GA1UdIwQYMBaAFBIf8JzVENnJ
+      GH272x8d5Ld5ZjNMMB0GA1UdEQQWMBSCEnRlc3QyLXdpdGgtc2FuLmNvbTANBgkq
+      hkiG9w0BAQsFAAOCAgEADQFp7nPDLMRPbwWo1fRj7jF6XC85qJF5F9hMRyuioxu9
+      ZHnlejEpi8o41/NRCV0lPLIAXe9/0owppZF3WhqF7eYUFa1YxFr+BkQg3r4nAq9g
+      UKkT2qB/AmJA72HYGGYbb1OdxccRxbgh1+nWzEkxFzB7HbiIrY7OqmDFLr7JRAeF
+      kaH27wLnZ2TJ2MCDQZNM8n12+3szwytZDl8uz6Dl5W7L4HcK6KIROhvjA6s3lAvA
+      3E2VJ07bkAvMcXGX0jobcTVDB/+WVvVoZym0TfmMUVQ0JD6vFe8sNdsJysWCsUe9
+      DbE9ZRA+3GaURVlpZ89n4sURVIopP+N51Vs6aZAIZdOuOvFwu+7N82LjI4i8800c
+      P90vC+M77jSGmu7Cuehu62Q0aUIx+X98TXQXpb4KLQ5Ot5RIPV0E3ksmKuqIrwuO
+      m5tSO2hX/BIkj160bikWbi3oqU8+91+jeW9fQnRLApkPwLWXSViF1Q7K8c6+/H/p
+      oyX7VxkqnU43+nzL+Egc9ibYRF22XMkCBICZFrPu3rZbz8zHTw43ldqHezvx+O/J
+      R5DG1U9dcbt9urELWUBEWlrDudlyC1p6ZvMYQIHP2e27pUaU6wFy7xnIrTxYbDM6
+      HTngE/Gz+qIUe7OkPXPPkFeoSfR1poQ3yNz4bim9Vx+w50l6m+h6SZOYJTxEUds=
+      -----END CERTIFICATE-----
+    private_key: "some key"


### PR DESCRIPTION
- [ x ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
- ensure the tcp-router configuration also has the derived frontend_tls_config
- ensure the directory permissions are root:vcap


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
