### PR TITLE
fix bash script to use env bash instead of system bash

### DIFF
--- a/scripts/create-docker-container.bash
+++ b/scripts/create-docker-container.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 set -o pipefail
@@ -14,15 +14,17 @@ if [[ ${DB:-empty} == "empty" ]]; then
   DB=mysql
 fi
 
+TAG=${TAG:-latest}
+
 CONTAINER_NAME="$REPO_NAME-$DB-docker-container"
 if [[ "${DB}" == "mysql" ]] || [[ "${DB}" == "mysql-8.0" ]]; then
-  IMAGE="docker.io/cloudfoundry/tas-runtime-mysql-8.0"
+  IMAGE="docker.io/cloudfoundry/tas-runtime-mysql-8.0:${TAG}"
   DB="mysql"
 elif [[ "${DB}" == "mysql-5.7" ]]; then
-  IMAGE="docker.io/cloudfoundry/tas-runtime-mysql-5.7"
+  IMAGE="docker.io/cloudfoundry/tas-runtime-mysql-5.7:${TAG}"
   DB="mysql"
 elif [[ "${DB}" == "postgres" ]]; then
-  IMAGE="docker.io/cloudfoundry/tas-runtime-postgres"
+  IMAGE="docker.io/cloudfoundry/tas-runtime-postgres:${TAG}"
 else
   echo "Unsupported DB flavor"
   exit 1
@@ -47,4 +49,3 @@ docker run -it \
   ${ARGS} \
   "${IMAGE}" \
   /bin/bash
-  


### PR DESCRIPTION
This allows the script to be run using bash 5.1+

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->

- This script errors out when using bash <5.1 :
```
❯ ./scripts/create-docker-container.bash
./scripts/create-docker-container.bash: line 31: *: unbound variable
```
Instead of upgrading the system bash, the environment bash could be upgraded (e.g., using brew). This fix will ensure that the environment bash is picked up and runs without any error.

- The TAG env variable is used to allow for users to specify a tag different than `latest`. For example, `go-1.24.6` is needed for the time being until the codebase is go-1.25+ compliant.


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
