### PR TITLE
fix: prevent race conditions in request tracing

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/integration/retry_test.go
+++ b/src/code.cloudfoundry.org/gorouter/integration/retry_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -54,7 +55,7 @@ var _ = Describe("Retries", func() {
 		})
 
 		It("does not prune the endpoint on context cancelled", func() {
-			conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", appURL, testState.cfg.Port))
+			conn, err := net.Dial("tcp", net.JoinHostPort(appURL, strconv.FormatInt(int64(testState.cfg.Port), 10)))
 			Expect(err).ToNot(HaveOccurred())
 
 			_, err = conn.Write([]byte(fmt.Sprintf("GET / HTTP/1.1\r\nHost: %s\r\n\r\n", appURL)))

--- a/src/code.cloudfoundry.org/gorouter/proxy/round_tripper/proxy_round_tripper.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/round_tripper/proxy_round_tripper.go
@@ -102,9 +102,8 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 	var res *http.Response
 	var endpoint *route.Endpoint
 
-	request := originalRequest.Clone(originalRequest.Context())
-	request, trace := traceRequest(request)
-
+	originalCtx := originalRequest.Context()
+	request := originalRequest.Clone(originalCtx)
 	if request.Body != nil {
 		// Temporarily disable closing of the body while in the RoundTrip function, since
 		// the underlying Transport will close the client request body.
@@ -143,11 +142,22 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 	}
 	triedEndpoints := map[string]bool{}
 
+	// It is safe to use trace inside the loop unconditionally as we set it as
+	// the first thing, but code outside the for loop should check if it's nil
+	// to be on the safe side.
+	var trace *requestTracer
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		logger := rt.logger
 
-		// Reset the trace to prepare for new times and prevent old data from polluting our results.
-		trace.Reset()
+		// We have to set the tracing for each round-trip as we otherwise risk
+		// having some asynchronous callback modifying the previous trace even
+		// after we have reset it as the handling of connections and requests
+		// in net/http is performing most of its task concurrently. If we re-use
+		// the previous context and set the trace again this causes us to
+		// accumulate callbacks as new traces are called in addition to the
+		// existing ones which could cause issues if a request is retried a lot.
+		request := request.Clone(originalCtx)
+		request, trace = traceRequest(request)
 
 		if reqInfo.RouteServiceURL == nil {
 			// Because this for-loop is 1-indexed, we substract one from the attempt value passed to selectEndpoint,
@@ -337,14 +347,17 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 		rt.combinedReporter.CaptureWebSocketUpdate()
 	}
 
-	// Record the times from the last attempt, but only if it succeeded.
-	reqInfo.DnsStartedAt = trace.DnsStart()
-	reqInfo.DnsFinishedAt = trace.DnsDone()
-	reqInfo.DialStartedAt = trace.DialStart()
-	reqInfo.DialFinishedAt = trace.DialDone()
-	reqInfo.TlsHandshakeStartedAt = trace.TlsStart()
-	reqInfo.TlsHandshakeFinishedAt = trace.TlsDone()
-	reqInfo.LocalAddress = trace.LocalAddr()
+	if trace != nil {
+		// Record the times from the last attempt, but only on success and if we
+		// have a trace.
+		reqInfo.DnsStartedAt = trace.DnsStart()
+		reqInfo.DnsFinishedAt = trace.DnsDone()
+		reqInfo.DialStartedAt = trace.DialStart()
+		reqInfo.DialFinishedAt = trace.DialDone()
+		reqInfo.TlsHandshakeStartedAt = trace.TlsStart()
+		reqInfo.TlsHandshakeFinishedAt = trace.TlsDone()
+		reqInfo.LocalAddress = trace.LocalAddr()
+	}
 
 	if res != nil && endpoint.PrivateInstanceId != "" && !requestSentToRouteService(request) {
 		setupStickySession(

--- a/src/code.cloudfoundry.org/gorouter/proxy/round_tripper/trace.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/round_tripper/trace.go
@@ -24,20 +24,6 @@ type requestTracer struct {
 	tlsDone   atomic.Int64
 }
 
-// Reset the trace data. Helpful when performing the same request again.
-func (t *requestTracer) Reset() {
-	t.gotConn.Store(false)
-	t.connReused.Store(false)
-	t.wroteHeaders.Store(false)
-	t.localAddr.Store(nil)
-	t.dnsStart.Store(0)
-	t.dnsDone.Store(0)
-	t.dialStart.Store(0)
-	t.dialDone.Store(0)
-	t.tlsStart.Store(0)
-	t.tlsDone.Store(0)
-}
-
 // GotConn returns true if a connection (TCP + TLS) to the backend was established on the traced request.
 func (t *requestTracer) GotConn() bool {
 	return t.gotConn.Load()

--- a/src/code.cloudfoundry.org/gorouter/router/router_test.go
+++ b/src/code.cloudfoundry.org/gorouter/router/router_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"os"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -721,7 +722,7 @@ var _ = Describe("Router", func() {
 			return appRegistered(registry, app)
 		}).Should(BeTrue())
 
-		conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", config.Ip, config.Port))
+		conn, err := net.Dial("tcp", net.JoinHostPort(config.Ip, strconv.FormatInt(int64(config.Port), 10)))
 		Expect(err).NotTo(HaveOccurred())
 		defer conn.Close()
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

The documentation of net/http/httptrace.ClientTrace clearly states the following:

> Functions may be called concurrently from different goroutines and some
> may be called after the request has completed or failed.

The implementation neglegted this detail and assumed that after RoundTrip returns we can simply reset the timings and only the new timings will be recorded from that point on.

This commit adjusts the round-tripper to clone the request for each try as this is the only way to set the context for a request which carries the trace and its callbacks. For cloning the original context (without the previous trace) is used and a new trace is then attached to the request. It also removes the reset function as it is no longer used.

~I still have to figure out the testing setup as I have failures on my machine both for develop and my branch, keeping this as a draft until I figure this out.~ Was mostly related to running with go1.25, setting it to go1.24 (the version the release is also built with) and running on amd64 natively resolved the issues, the suite passes.

Backward Compatibility
---------------
Breaking Change? **No**