### PR TITLE
Keep Logs Enabled when Disabling Envelope Metrics 

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/cmd/gorouter/main.go
+++ b/src/code.cloudfoundry.org/gorouter/cmd/gorouter/main.go
@@ -276,20 +276,20 @@ func main() {
 	os.Exit(0)
 }
 
-// initializeDropsondeReporter setups metrics via dropsonse if enabled
+// initializeDropsondeReporter initializes logs. It also initializes envelope V1 metrics if enabled
 func initializeDropsondeReporter(prefix string, logger *slog.Logger, c *config.Config) *metrics.Metrics {
-	if !c.EnableEnvelopeV1Metrics {
-		return nil
-	}
 	err := dropsonde.Initialize(c.Logging.MetronAddress, c.Logging.JobName)
 	if err != nil {
 		grlog.Fatal(logger, "dropsonde-initialize-error", grlog.ErrAttr(err))
+	}
+	if !c.EnableEnvelopeV1Metrics {
+		return nil
 	}
 	dropsondeMetricSender := metric_sender.NewMetricSender(dropsonde.AutowiredEmitter())
 	return initializeMetrics(dropsondeMetricSender, c, grlog.CreateLoggerWithSource(prefix, "metricsreporter"))
 }
 
-// initializePrometheusReporter setups metrics via Prometheus if enabled
+// initializePrometheusReporter initializes metrics via Prometheus if enabled
 func initializePrometheusReporter(c *config.Config) *metrics_prometheus.Metrics {
 	if !c.Prometheus.Enabled {
 		return nil


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
With the implementation of Prometheus metrics and the switches to enable/disable Prometheus and Envelope metrics (`enable_envelope_v1_metrics`, `prometheus.enabled`), we are able to replace the Envelope metrics with Prometheus metrics. With the current implementation, the switch to disable Envelope metrics also disables access logs. With this change, access logs are kept even if the Envelope metrics switch is disabled.  

Backward Compatibility
---------------
Breaking Change? **No**
Setting `enable_envelope_v1_metrics: False` will enable access logs with this change. As the switch has been implemented recently, defaults to `True` and doesn't indicate log control, I consider this change as a fix, rather than a breaking change. 
