### PR TITLE
close more conns for websocket apps

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/integration/route_services_test.go
+++ b/src/code.cloudfoundry.org/gorouter/integration/route_services_test.go
@@ -174,6 +174,7 @@ var _ = Describe("Route services", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(msgBuf[:num2])).To(Equal("WEBSOCKET OK"))
+				wsConn.Close()
 
 				Eventually(func() ([]byte, error) {
 					return os.ReadFile(testState.AccessLogFilePath())

--- a/src/code.cloudfoundry.org/gorouter/proxy/proxy_test.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/proxy_test.go
@@ -1781,6 +1781,7 @@ var _ = Describe("Proxy", func() {
 
 							g.Expect(err).NotTo(HaveOccurred())
 							g.Expect(string(msgBuf[:n])).To(Equal("WEBSOCKET OK"))
+							conn.Close()
 
 							g.Eventually(func() (int64, error) {
 								fi, err := f.Stat()

--- a/src/code.cloudfoundry.org/gorouter/test/websocket_app.go
+++ b/src/code.cloudfoundry.org/gorouter/test/websocket_app.go
@@ -26,6 +26,7 @@ func NewWebSocketApp(urls []route.Uri, rPort uint16, mbusClient *nats.Conn, dela
 
 		conn, _, err := w.(http.Hijacker).Hijack()
 		Expect(err).ToNot(HaveOccurred())
+		defer conn.Close()
 		x := test_util.NewHttpConn(conn)
 
 		resp := test_util.NewResponse(http.StatusSwitchingProtocols)
@@ -54,6 +55,7 @@ func NewFailingWebSocketApp(urls []route.Uri, rPort uint16, mbusClient *nats.Con
 
 		conn, _, err := w.(http.Hijacker).Hijack()
 		Expect(err).ToNot(HaveOccurred())
+		defer conn.Close()
 		x := test_util.NewHttpConn(conn)
 		err = x.Close()
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
for go 1.25

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
we need to close the connection on both ends.


Backward Compatibility
---------------
Breaking Change? No
