### PR TITLE
Gorouter Metrics: switch to Gauge /GaugeVec types instead of Histogram/HistogramVec

### DIFF
--- a/docs/04-gorouter-observability.md
+++ b/docs/04-gorouter-observability.md
@@ -268,67 +268,10 @@ bad_gateways 0
 # TYPE empty_content_length_header counter
 empty_content_length_header 0
 # HELP latency routing response latency in ms
-# TYPE latency histogram
-latency_bucket{component="",le="1"} 2
-latency_bucket{component="",le="2"} 8705
-latency_bucket{component="",le="4"} 55939
-latency_bucket{component="",le="6"} 73786
-latency_bucket{component="",le="8"} 79800
-latency_bucket{component="",le="10"} 81911
-latency_bucket{component="",le="20"} 86670
-latency_bucket{component="",le="40"} 95701
-latency_bucket{component="",le="50"} 100139
-latency_bucket{component="",le="100"} 102135
-latency_bucket{component="",le="500"} 104114
-latency_bucket{component="",le="1000"} 104518
-latency_bucket{component="",le="+Inf"} 104519
-latency_sum{component=""} 1.5821502875950185e+06
-latency_count{component=""} 104519
-latency_bucket{component="CloudController",le="1"} 0
-latency_bucket{component="CloudController",le="2"} 0
-latency_bucket{component="CloudController",le="4"} 7
-latency_bucket{component="CloudController",le="6"} 3928
-latency_bucket{component="CloudController",le="8"} 5142
-latency_bucket{component="CloudController",le="10"} 5606
-latency_bucket{component="CloudController",le="20"} 22662
-latency_bucket{component="CloudController",le="40"} 75564
-latency_bucket{component="CloudController",le="50"} 82497
-latency_bucket{component="CloudController",le="100"} 87240
-latency_bucket{component="CloudController",le="500"} 91080
-latency_bucket{component="CloudController",le="1000"} 91566
-latency_bucket{component="CloudController",le="+Inf"} 91579
-latency_sum{component="CloudController"} 3.744289433603952e+06
-latency_count{component="CloudController"} 91579
-latency_bucket{component="route-emitter",le="1"} 0
-latency_bucket{component="route-emitter",le="2"} 337
-latency_bucket{component="route-emitter",le="4"} 448
-latency_bucket{component="route-emitter",le="6"} 462
-latency_bucket{component="route-emitter",le="8"} 1241
-latency_bucket{component="route-emitter",le="10"} 31250
-latency_bucket{component="route-emitter",le="20"} 75412
-latency_bucket{component="route-emitter",le="40"} 75695
-latency_bucket{component="route-emitter",le="50"} 75711
-latency_bucket{component="route-emitter",le="100"} 75717
-latency_bucket{component="route-emitter",le="500"} 75799
-latency_bucket{component="route-emitter",le="1000"} 75800
-latency_bucket{component="route-emitter",le="+Inf"} 75802
-latency_sum{component="route-emitter"} 808316.2385179874
-latency_count{component="route-emitter"} 75802
-latency_bucket{component="uaa",le="1"} 0
-latency_bucket{component="uaa",le="2"} 1
-latency_bucket{component="uaa",le="4"} 5951
-latency_bucket{component="uaa",le="6"} 64736
-latency_bucket{component="uaa",le="8"} 83650
-latency_bucket{component="uaa",le="10"} 90136
-latency_bucket{component="uaa",le="20"} 101690
-latency_bucket{component="uaa",le="40"} 102816
-latency_bucket{component="uaa",le="50"} 102868
-latency_bucket{component="uaa",le="100"} 106615
-latency_bucket{component="uaa",le="500"} 119313
-latency_bucket{component="uaa",le="1000"} 119325
-latency_bucket{component="uaa",le="+Inf"} 119328
-latency_sum{component="uaa"} 2.5461252577970154e+06
-latency_count{component="uaa"} 119328
+# TYPE latency gaugeVec
+latency{component="CloudController"} 91579
+latency{component="route-emitter"} 337
+latency{component="uaa"} 1
 # HELP ms_since_last_registry_update time since last registry update in ms
 # TYPE ms_since_last_registry_update gauge
 ms_since_last_registry_update 3942
@@ -355,34 +298,11 @@ responses{status_group="2xx"} 312778
 responses{status_group="3xx"} 29409
 responses{status_group="4xx"} 49041
 # HELP route_lookup_time route lookup time per request in ns
-# TYPE route_lookup_time histogram
-route_lookup_time_bucket{le="10000"} 377295
-route_lookup_time_bucket{le="20000"} 389278
-route_lookup_time_bucket{le="30000"} 390445
-route_lookup_time_bucket{le="40000"} 391008
-route_lookup_time_bucket{le="50000"} 391261
-route_lookup_time_bucket{le="60000"} 391337
-route_lookup_time_bucket{le="70000"} 391378
-route_lookup_time_bucket{le="80000"} 391397
-route_lookup_time_bucket{le="90000"} 391417
-route_lookup_time_bucket{le="100000"} 391432
-route_lookup_time_bucket{le="+Inf"} 391525
-route_lookup_time_sum 1.584830859e+09
-route_lookup_time_count 391525
+# TYPE route_lookup_time gauge
+route_lookup_time 377295
 # HELP route_registration_latency route registration latency in ms
-# TYPE route_registration_latency histogram
-route_registration_latency_bucket{le="0.1"} 0
-route_registration_latency_bucket{le="0.5"} 0
-route_registration_latency_bucket{le="1"} 0
-route_registration_latency_bucket{le="1.5"} 0
-route_registration_latency_bucket{le="2"} 2
-route_registration_latency_bucket{le="2.5"} 15
-route_registration_latency_bucket{le="3"} 152
-route_registration_latency_bucket{le="3.5"} 625
-route_registration_latency_bucket{le="4"} 1372
-route_registration_latency_bucket{le="+Inf"} 2012
-route_registration_latency_sum 7695.366220000008
-route_registration_latency_count 2012
+# TYPE route_registration_latency gauge
+route_registration_latency 15
 # HELP routes_pruned number of pruned routes
 # TYPE routes_pruned counter
 routes_pruned 0

--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -95,18 +95,6 @@ properties:
   router.prometheus.key:
     description: "TLS private key for prometheus server."
     default: ""
-  router.prometheus.meters.route_lookup_time_histogram_buckets:
-    description: "Upper limits in nanoseconds of the ranges in which the observed value of route lookup time is expected to fall"
-    default: [10000, 20000, 30000, 40000, 50000, 60000, 70000, 80000, 90000, 100000]
-  router.prometheus.meters.route_registration_latency_histogram_buckets:
-    description: "Upper limits in milliseconds of the ranges in which the observed value of route registration latency is expected to fall"
-    default: [0.1, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4]
-  router.prometheus.meters.routing_response_latency_histogram_buckets:
-    description: "Upper limits in milliseconds of the ranges in which the observed value of route response latency is expected to fall"
-    default: [1, 2, 4, 6, 8, 10, 20, 40, 50, 100, 500, 1000]
-  router.prometheus.meters.http_latency_histogram_buckets:
-    description: "Upper limits in seconds of the ranges in which the observed value of the latency of http requests from gorouter and back"
-    default: [0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6]
   router.requested_route_registration_interval_in_seconds:
     description: |
       On startup, the router will delay listening for requests by this duration to increase likelihood that it has a complete routing table before serving requests.

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -185,8 +185,7 @@ if_p('router.prometheus.port') do |port|
    
    params['prometheus'] = {
     'enabled' => true,
-    'port' => port,
-    'meters' => p('router.prometheus.meters')
+    'port' => port
    }
 
   cert_set = p('router.prometheus.cert') != ''

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -820,26 +820,6 @@ describe 'gorouter' do
             expect(parsed_yaml['prometheus']['port']).to eq(9090)
           end
         end
-        context 'when prometheus meters are configured' do
-          before do
-            deployment_manifest_fragment['router']['per_app_prometheus_http_metrics_reporting'] = true
-            deployment_manifest_fragment['router']['prometheus'] = {
-              'port' => 9090,
-              'meters' => {
-                'route_lookup_time_histogram_buckets' => [0, 100, 10000],
-                'route_registration_latency_histogram_buckets' => [-10, 0, 10],
-                'routing_response_latency_histogram_buckets' => [0.1, 0.5, 1],
-                'http_latency_histogram_buckets' => [0.1, 0.2, 0.4, 0.8, 1],
-              }
-            }
-          end
-          it 'should set prometheus meters configuration' do
-            expect(parsed_yaml['prometheus']['meters']['route_lookup_time_histogram_buckets']).to eq([0, 100, 10000])
-            expect(parsed_yaml['prometheus']['meters']['route_registration_latency_histogram_buckets']).to eq([-10, 0, 10])
-            expect(parsed_yaml['prometheus']['meters']['routing_response_latency_histogram_buckets']).to eq([0.1, 0.5, 1])
-            expect(parsed_yaml['prometheus']['meters']['http_latency_histogram_buckets']).to eq([0.1, 0.2, 0.4, 0.8, 1])
-          end
-        end
       end
 
       describe 'route_services' do

--- a/src/code.cloudfoundry.org/gorouter/cmd/gorouter/main.go
+++ b/src/code.cloudfoundry.org/gorouter/cmd/gorouter/main.go
@@ -295,7 +295,7 @@ func initializePrometheusReporter(c *config.Config) *metrics_prometheus.Metrics 
 		return nil
 	}
 	promRegistry := metrics_prometheus.NewMetricsRegistry(c.Prometheus)
-	return metrics_prometheus.NewMetrics(promRegistry, c.PerRequestMetricsReporting, c.Prometheus.Meters)
+	return metrics_prometheus.NewMetrics(promRegistry, c.PerRequestMetricsReporting)
 }
 
 func initializeFDMonitor(reporter metrics.MetricReporter, logger *slog.Logger) *monitor.FileDescriptor {

--- a/src/code.cloudfoundry.org/gorouter/config/config.go
+++ b/src/code.cloudfoundry.org/gorouter/config/config.go
@@ -115,32 +115,11 @@ var defaultStatusConfig = StatusConfig{
 }
 
 type PrometheusConfig struct {
-	Enabled  bool         `yaml:"enabled,omitempty"`
-	Port     uint16       `yaml:"port"`
-	CertPath string       `yaml:"cert_path"`
-	KeyPath  string       `yaml:"key_path"`
-	CAPath   string       `yaml:"ca_path"`
-	Meters   MetersConfig `yaml:"meters,omitempty"`
-}
-
-var defaultPrometheusConfig = PrometheusConfig{
-	Meters: defaultMetersConfig,
-}
-
-type MetersConfig struct {
-	RouteLookupTimeHistogramBuckets          []float64 `yaml:"route_lookup_time_histogram_buckets,omitempty"`
-	GorouterTimeHistogramBuckets             []float64 `yaml:"gorouter_time_histogram_buckets,omitempty"`
-	RouteRegistrationLatencyHistogramBuckets []float64 `yaml:"route_registration_latency_histogram_buckets,omitempty"`
-	RoutingResponseLatencyHistogramBuckets   []float64 `yaml:"routing_response_latency_histogram_buckets,omitempty"`
-	HTTPLatencyHistogramBuckets              []float64 `yaml:"http_latency_histogram_buckets,omitempty"`
-}
-
-var defaultMetersConfig = MetersConfig{
-	RouteLookupTimeHistogramBuckets:          []float64{10_000, 20_000, 30_000, 40_000, 50_000, 60_000, 70_000, 80_000, 90_000, 100_000},
-	GorouterTimeHistogramBuckets:             []float64{1, 2, 4, 6, 8, 10, 20, 40, 50, 100, 500, 1000},
-	RouteRegistrationLatencyHistogramBuckets: []float64{0.1, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4},
-	RoutingResponseLatencyHistogramBuckets:   []float64{1, 2, 4, 6, 8, 10, 20, 40, 50, 100, 500, 1000},
-	HTTPLatencyHistogramBuckets:              []float64{0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6},
+	Enabled  bool   `yaml:"enabled,omitempty"`
+	Port     uint16 `yaml:"port"`
+	CertPath string `yaml:"cert_path"`
+	KeyPath  string `yaml:"key_path"`
+	CAPath   string `yaml:"ca_path"`
 }
 
 type NatsConfig struct {
@@ -526,7 +505,6 @@ var defaultConfig = Config{
 	Nats:                           defaultNatsConfig,
 	Logging:                        defaultLoggingConfig,
 	Port:                           8081,
-	Prometheus:                     defaultPrometheusConfig,
 	Index:                          0,
 	GoMaxProcs:                     -1,
 	EnablePROXY:                    false,

--- a/src/code.cloudfoundry.org/gorouter/config/config_test.go
+++ b/src/code.cloudfoundry.org/gorouter/config/config_test.go
@@ -251,7 +251,7 @@ max_request_header_bytes: 10
 		})
 
 		It("sets prometheus endpoint config", func() {
-			cfg, err := DefaultConfig()
+			_, err := DefaultConfig()
 			Expect(err).ToNot(HaveOccurred())
 
 			var b = []byte(`
@@ -271,26 +271,6 @@ prometheus:
 			Expect(config.Prometheus.CertPath).To(Equal("/some-cert-path"))
 			Expect(config.Prometheus.KeyPath).To(Equal("/some-key-path"))
 			Expect(config.Prometheus.CAPath).To(Equal("/some-ca-path"))
-			Expect(config.Prometheus.Meters).To(Equal(cfg.Prometheus.Meters))
-		})
-
-		It("sets prometheus histogram buckets config", func() {
-			var b = []byte(`
-prometheus:
-  meters:
-    route_lookup_time_histogram_buckets: [0, 100, 10000]
-    route_registration_latency_histogram_buckets: [-10, 0, 10]
-    gorouter_time_histogram_buckets: [1,2,4]
-    routing_response_latency_histogram_buckets: [0.1, 0.5, 1]
-`)
-
-			err := config.Initialize(b)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(config.Prometheus.Meters.RouteLookupTimeHistogramBuckets).To(Equal([]float64{0, 100, 10000}))
-			Expect(config.Prometheus.Meters.RouteRegistrationLatencyHistogramBuckets).To(Equal([]float64{-10, 0, 10}))
-			Expect(config.Prometheus.Meters.GorouterTimeHistogramBuckets).To(Equal([]float64{1, 2, 4}))
-			Expect(config.Prometheus.Meters.RoutingResponseLatencyHistogramBuckets).To(Equal([]float64{0.1, 0.5, 1}))
 		})
 
 		It("defaults frontend idle timeout to 900", func() {

--- a/src/code.cloudfoundry.org/gorouter/metrics_prometheus/metrics.go
+++ b/src/code.cloudfoundry.org/gorouter/metrics_prometheus/metrics.go
@@ -22,9 +22,9 @@ type Metrics struct {
 	RoutesUnregistered          mr.Counter
 	TotalRoutes                 mr.Gauge
 	TimeSinceLastRegistryUpdate mr.Gauge
-	RouteLookupTime             mr.Histogram
-	GorouterTime                mr.Histogram
-	RouteRegistrationLatency    mr.Histogram
+	RouteLookupTime             mr.Gauge
+	GorouterTime                mr.Gauge
+	RouteRegistrationLatency    mr.Gauge
 	RoutingRequest              mr.CounterVec
 	BadRequest                  mr.Counter
 	BadGateway                  mr.Counter
@@ -37,11 +37,11 @@ type Metrics struct {
 	WebsocketFailures           mr.Counter
 	Responses                   mr.CounterVec
 	RouteServicesResponses      mr.CounterVec
-	RoutingResponseLatency      mr.HistogramVec
+	RoutingResponseLatency      mr.GaugeVec
 	FoundFileDescriptors        mr.Gauge
 	NATSBufferedMessages        mr.Gauge
 	NATSDroppedMessages         mr.Gauge
-	HTTPLatency                 mr.HistogramVec
+	HTTPLatency                 mr.GaugeVec
 	perRequestMetricsReporting  bool
 }
 
@@ -61,7 +61,7 @@ func NewMetricsRegistry(config config.PrometheusConfig) *mr.Registry {
 
 var _ metrics.MetricReporter = &Metrics{}
 
-func NewMetrics(registry *mr.Registry, perRequestMetricsReporting bool, meterConfig config.MetersConfig) *Metrics {
+func NewMetrics(registry *mr.Registry, perRequestMetricsReporting bool) *Metrics {
 	return &Metrics{
 		RouteRegistration:           registry.NewCounterVec("registry_message", "number of route registration messages", []string{"component", "action"}),
 		RouteUnregistration:         registry.NewCounterVec("unregistry_message", "number of unregister messages", []string{"component"}),
@@ -70,9 +70,9 @@ func NewMetrics(registry *mr.Registry, perRequestMetricsReporting bool, meterCon
 		RoutesUnregistered:          registry.NewCounter("routes_unregistered", "number of unregistered routes"),
 		TotalRoutes:                 registry.NewGauge("total_routes", "number of total routes"),
 		TimeSinceLastRegistryUpdate: registry.NewGauge("ms_since_last_registry_update", "time since last registry update in ms"),
-		RouteLookupTime:             registry.NewHistogram("route_lookup_time", "route lookup time per request in ns", meterConfig.RouteLookupTimeHistogramBuckets),
-		GorouterTime:                registry.NewHistogram("gorouter_time", "gorouter time per request in seconds", meterConfig.GorouterTimeHistogramBuckets),
-		RouteRegistrationLatency:    registry.NewHistogram("route_registration_latency", "route registration latency in ms", meterConfig.RouteRegistrationLatencyHistogramBuckets),
+		RouteLookupTime:             registry.NewGauge("route_lookup_time", "route lookup time per request in ns"),
+		GorouterTime:                registry.NewGauge("gorouter_time", "gorouter time per request in seconds"),
+		RouteRegistrationLatency:    registry.NewGauge("route_registration_latency", "route registration latency in ms"),
 		RoutingRequest:              registry.NewCounterVec("total_requests", "number of routing requests", []string{"component"}),
 		BadRequest:                  registry.NewCounter("rejected_requests", "number of rejected requests"),
 		BadGateway:                  registry.NewCounter("bad_gateways", "number of bad gateway errors received from backends"),
@@ -85,11 +85,11 @@ func NewMetrics(registry *mr.Registry, perRequestMetricsReporting bool, meterCon
 		WebsocketFailures:           registry.NewCounter("websocket_failures", "websocket failure"),
 		Responses:                   registry.NewCounterVec("responses", "number of responses", []string{"status_group"}),
 		RouteServicesResponses:      registry.NewCounterVec("responses_route_services", "number of responses for route services", []string{"status_group"}),
-		RoutingResponseLatency:      registry.NewHistogramVec("latency", "routing response latency in ms", []string{"component"}, meterConfig.RoutingResponseLatencyHistogramBuckets),
+		RoutingResponseLatency:      registry.NewGaugeVec("latency", "routing response latency in ms", []string{"component"}),
 		FoundFileDescriptors:        registry.NewGauge("file_descriptors", "number of file descriptors found"),
 		NATSBufferedMessages:        registry.NewGauge("buffered_messages", "number of buffered messages in NATS"),
 		NATSDroppedMessages:         registry.NewGauge("total_dropped_messages", "number of total dropped messages in NATS"),
-		HTTPLatency:                 registry.NewHistogramVec("http_latency_seconds", "the latency of http requests from gorouter and back in sec", []string{"source_id"}, meterConfig.HTTPLatencyHistogramBuckets),
+		HTTPLatency:                 registry.NewGaugeVec("http_latency_seconds", "the latency of http requests from gorouter and back in sec", []string{"source_id"}),
 		perRequestMetricsReporting:  perRequestMetricsReporting,
 	}
 }
@@ -124,18 +124,18 @@ func (metrics *Metrics) CaptureTotalRoutes(totalRoutes int) {
 
 func (metrics *Metrics) CaptureLookupTime(t time.Duration) {
 	if metrics.perRequestMetricsReporting {
-		metrics.RouteLookupTime.Observe(float64(t.Nanoseconds()))
+		metrics.RouteLookupTime.Set(float64(t.Nanoseconds()))
 	}
 }
 
 func (metrics *Metrics) CaptureGorouterTime(t float64) {
 	if metrics.perRequestMetricsReporting {
-		metrics.GorouterTime.Observe(t)
+		metrics.GorouterTime.Set(t)
 	}
 }
 
 func (metrics *Metrics) CaptureRouteRegistrationLatency(t time.Duration) {
-	metrics.RouteRegistrationLatency.Observe(float64(t) / float64(time.Millisecond))
+	metrics.RouteRegistrationLatency.Set(float64(t) / float64(time.Millisecond))
 }
 
 // UnmuzzleRouteRegistrationLatency should set a flag which suppresses metric data.
@@ -184,7 +184,7 @@ func (metrics *Metrics) CaptureRoutingResponse(statusCode int) {
 // CaptureRoutingResponseLatency has extra arguments to match varz reporter
 func (metrics *Metrics) CaptureRoutingResponseLatency(b *route.Endpoint, _ int, _ time.Time, d time.Duration) {
 	if metrics.perRequestMetricsReporting {
-		metrics.RoutingResponseLatency.Observe(float64(d)/float64(time.Millisecond), []string{b.Component()})
+		metrics.RoutingResponseLatency.Set(float64(d)/float64(time.Millisecond), []string{b.Component()})
 	}
 }
 
@@ -217,7 +217,7 @@ func (metrics *Metrics) CaptureNATSDroppedMessages(messages int) {
 }
 
 func (metrics *Metrics) CaptureHTTPLatency(d time.Duration, sourceID string) {
-	metrics.HTTPLatency.Observe(float64(d)/float64(time.Second), []string{sourceID})
+	metrics.HTTPLatency.Set(float64(d)/float64(time.Second), []string{sourceID})
 }
 
 func statusGroupName(statusCode int) string {

--- a/src/code.cloudfoundry.org/gorouter/metrics_prometheus/metrics_test.go
+++ b/src/code.cloudfoundry.org/gorouter/metrics_prometheus/metrics_test.go
@@ -23,10 +23,9 @@ var _ = Describe("Metrics", func() {
 		var endpoint *route.Endpoint
 
 		BeforeEach(func() {
-			var perRequestMetricsReporting = true
-			var config = config.PrometheusConfig{Port: 0, Meters: getMetersConfig()}
+			var config = config.PrometheusConfig{Port: 0}
 			r = NewMetricsRegistry(config)
-			m = NewMetrics(r, perRequestMetricsReporting, config.Meters)
+			m = NewMetrics(r, true)
 			endpoint = new(route.Endpoint)
 		})
 		AfterEach(func() {
@@ -78,20 +77,16 @@ var _ = Describe("Metrics", func() {
 
 		It("sends the lookup time for routing table", func() {
 			m.CaptureLookupTime(time.Duration(95) * time.Microsecond)
-			Expect(getMetrics(r.Port())).To(ContainSubstring("route_lookup_time_bucket{le=\"100000\"} 1"))
-
-			m.perRequestMetricsReporting = false
-			m.CaptureLookupTime(time.Duration(95) * time.Microsecond)
-			Expect(getMetrics(r.Port())).To(ContainSubstring("route_lookup_time_bucket{le=\"100000\"} 1"))
+			Expect(getMetrics(r.Port())).To(ContainSubstring("route_lookup_time 95000"))
 		})
 
 		It("sends the gorouter time per request", func() {
 			m.CaptureGorouterTime(1)
-			Expect(getMetrics(r.Port())).To(ContainSubstring("gorouter_time_bucket{le=\"1.2\"} 1"))
+			Expect(getMetrics(r.Port())).To(ContainSubstring("gorouter_time 1"))
 
 			m.perRequestMetricsReporting = false
 			m.CaptureGorouterTime(1)
-			Expect(getMetrics(r.Port())).To(ContainSubstring("gorouter_time_bucket{le=\"1.2\"} 1"))
+			Expect(getMetrics(r.Port())).To(ContainSubstring("gorouter_time 1"))
 		})
 
 		It("increments the routes pruned metric", func() {
@@ -112,18 +107,15 @@ var _ = Describe("Metrics", func() {
 			It("properly splits the latencies apart", func() {
 				m.CaptureRouteRegistrationLatency(1234 * time.Microsecond)
 				m.CaptureRouteRegistrationLatency(134 * time.Microsecond)
-
-				Expect(getMetrics(r.Port())).To(ContainSubstring("route_registration_latency_bucket{le=\"1.4\"} 2"))
-				Expect(getMetrics(r.Port())).To(ContainSubstring("route_registration_latency_bucket{le=\"0.2\"} 1"))
+				Expect(getMetrics(r.Port())).To(ContainSubstring("route_registration_latency 0.134"))
 			})
 		})
 	})
 	Context("sends backend errors metrics", func() {
 		BeforeEach(func() {
-			var perRequestMetricsReporting = true
-			var config = config.PrometheusConfig{Port: 0, Meters: getMetersConfig()}
+			var config = config.PrometheusConfig{Port: 0}
 			r = NewMetricsRegistry(config)
-			m = NewMetrics(r, perRequestMetricsReporting, config.Meters)
+			m = NewMetrics(r, true)
 		})
 		AfterEach(func() {
 			m.perRequestMetricsReporting = true
@@ -163,10 +155,9 @@ var _ = Describe("Metrics", func() {
 	})
 	Context("sends lookup error metrics", func() {
 		BeforeEach(func() {
-			var perRequestMetricsReporting = true
-			var config = config.PrometheusConfig{Port: 0, Meters: getMetersConfig()}
+			var config = config.PrometheusConfig{Port: 0}
 			r = NewMetricsRegistry(config)
-			m = NewMetrics(r, perRequestMetricsReporting, config.Meters)
+			m = NewMetrics(r, true)
 		})
 		AfterEach(func() {
 			m.perRequestMetricsReporting = true
@@ -195,10 +186,9 @@ var _ = Describe("Metrics", func() {
 	})
 	Context("websocket metrics", func() {
 		BeforeEach(func() {
-			var perRequestMetricsReporting = true
-			var config = config.PrometheusConfig{Port: 0, Meters: getMetersConfig()}
+			var config = config.PrometheusConfig{Port: 0}
 			r = NewMetricsRegistry(config)
-			m = NewMetrics(r, perRequestMetricsReporting, config.Meters)
+			m = NewMetrics(r, true)
 		})
 		AfterEach(func() {
 			m.perRequestMetricsReporting = true
@@ -218,10 +208,9 @@ var _ = Describe("Metrics", func() {
 		var endpoint *route.Endpoint
 
 		BeforeEach(func() {
-			var perRequestMetricsReporting = true
-			var config = config.PrometheusConfig{Port: 0, Meters: getMetersConfig()}
+			var config = config.PrometheusConfig{Port: 0}
 			r = NewMetricsRegistry(config)
-			m = NewMetrics(r, perRequestMetricsReporting, config.Meters)
+			m = NewMetrics(r, true)
 			endpoint = new(route.Endpoint)
 		})
 		AfterEach(func() {
@@ -257,10 +246,9 @@ var _ = Describe("Metrics", func() {
 
 	Context("increments the response metrics", func() {
 		BeforeEach(func() {
-			var perRequestMetricsReporting = true
-			var config = config.PrometheusConfig{Port: 0, Meters: getMetersConfig()}
+			var config = config.PrometheusConfig{Port: 0}
 			r = NewMetricsRegistry(config)
-			m = NewMetrics(r, perRequestMetricsReporting, config.Meters)
+			m = NewMetrics(r, true)
 		})
 		AfterEach(func() {
 			m.perRequestMetricsReporting = true
@@ -319,10 +307,9 @@ var _ = Describe("Metrics", func() {
 		var response http.Response
 
 		BeforeEach(func() {
-			var perRequestMetricsReporting = true
-			var config = config.PrometheusConfig{Port: 0, Meters: getMetersConfig()}
+			var config = config.PrometheusConfig{Port: 0}
 			r = NewMetricsRegistry(config)
-			m = NewMetrics(r, perRequestMetricsReporting, config.Meters)
+			m = NewMetrics(r, true)
 			response = http.Response{}
 		})
 		AfterEach(func() {
@@ -389,10 +376,9 @@ var _ = Describe("Metrics", func() {
 		var endpoint *route.Endpoint
 
 		BeforeEach(func() {
-			var perRequestMetricsReporting = true
-			var config = config.PrometheusConfig{Port: 0, Meters: getMetersConfig()}
+			var config = config.PrometheusConfig{Port: 0}
 			r = NewMetricsRegistry(config)
-			m = NewMetrics(r, perRequestMetricsReporting, config.Meters)
+			m = NewMetrics(r, true)
 			endpoint = new(route.Endpoint)
 		})
 		AfterEach(func() {
@@ -400,37 +386,38 @@ var _ = Describe("Metrics", func() {
 		})
 
 		It("sends the latency", func() {
+			endpoint.Tags = map[string]string{"component": "testComponent"}
 			m.CaptureRoutingResponseLatency(endpoint, 0, time.Time{}, 2*time.Millisecond)
+			Expect(getMetrics(r.Port())).To(ContainSubstring("latency{component=\"testComponent\"} 2"))
 			m.CaptureRoutingResponseLatency(endpoint, 0, time.Time{}, 500*time.Microsecond)
-			Expect(getMetrics(r.Port())).To(ContainSubstring("latency_bucket{component=\"\",le=\"0.6\"} 1"))
-			Expect(getMetrics(r.Port())).To(ContainSubstring("latency_bucket{component=\"\",le=\"2\"} 2"))
+			Expect(getMetrics(r.Port())).To(ContainSubstring("latency{component=\"testComponent\"} 0.5"))
 		})
 
 		It("does not send the latency if switched off", func() {
 			m.perRequestMetricsReporting = false
 			m.CaptureRoutingResponseLatency(endpoint, 0, time.Time{}, 2*time.Millisecond)
-			Expect(getMetrics(r.Port())).NotTo(ContainSubstring("\nlatency_bucket"))
+			Expect(getMetrics(r.Port())).NotTo(ContainSubstring("\nlatency"))
 		})
 
 		It("sends the latency for the given component", func() {
 			endpoint.Tags = map[string]string{"component": "CloudController"}
 			m.CaptureRoutingResponseLatency(endpoint, 0, time.Time{}, 2*time.Millisecond)
-			Expect(getMetrics(r.Port())).To(ContainSubstring("latency_bucket{component=\"CloudController\",le=\"2\"} 1"))
+			Expect(getMetrics(r.Port())).To(ContainSubstring("latency{component=\"CloudController\"} 2"))
 		})
 
 		It("does not send the latency for the given component if switched off", func() {
 			m.perRequestMetricsReporting = false
 			endpoint.Tags = map[string]string{"component": "CloudController"}
 			m.CaptureRoutingResponseLatency(endpoint, 0, time.Time{}, 2*time.Millisecond)
-			Expect(getMetrics(r.Port())).NotTo(ContainSubstring("\nlatency_bucket"))
+			Expect(getMetrics(r.Port())).NotTo(ContainSubstring("\nlatency"))
 		})
 	})
 
 	Context("increments the monitor metrics", func() {
 		BeforeEach(func() {
-			var config = config.PrometheusConfig{Port: 0, Meters: getMetersConfig()}
+			var config = config.PrometheusConfig{Port: 0}
 			r = NewMetricsRegistry(config)
-			m = NewMetrics(r, false, config.Meters)
+			m = NewMetrics(r, false)
 		})
 
 		It("sends fd metric", func() {
@@ -449,32 +436,21 @@ var _ = Describe("Metrics", func() {
 
 	Context("observes http metrics", func() {
 		BeforeEach(func() {
-			var perRequestMetricsReporting = true
-			var config = config.PrometheusConfig{Port: 0, Meters: getMetersConfig()}
+			var config = config.PrometheusConfig{Port: 0}
 			r = NewMetricsRegistry(config)
-			m = NewMetrics(r, perRequestMetricsReporting, config.Meters)
+			m = NewMetrics(r, true)
 		})
 
 		It("sends the latency", func() {
 			m.CaptureHTTPLatency(2*time.Second, "")
-			Expect(getMetrics(r.Port())).To(ContainSubstring("http_latency_seconds_bucket{source_id=\"\",le=\"3.2\"} 1"))
+			Expect(getMetrics(r.Port())).To(ContainSubstring("http_latency_seconds{source_id=\"\"} 2"))
 
 			m.CaptureHTTPLatency(500*time.Millisecond, "some-source")
 			m.CaptureHTTPLatency(630*time.Millisecond, "some-source")
-			Expect(getMetrics(r.Port())).To(ContainSubstring("http_latency_seconds_bucket{source_id=\"some-source\",le=\"0.8\"} 2"))
+			Expect(getMetrics(r.Port())).To(ContainSubstring("http_latency_seconds{source_id=\"some-source\"} 0.63"))
 		})
 	})
 })
-
-func getMetersConfig() config.MetersConfig {
-	return config.MetersConfig{
-		RouteLookupTimeHistogramBuckets:          []float64{10_000, 20_000, 30_000, 40_000, 50_000, 60_000, 70_000, 80_000, 90_000, 100_000},
-		GorouterTimeHistogramBuckets:             []float64{0.2, 0.4, 0.6, 0.8, 1, 1.2, 1.4, 1.6, 1.8, 2},
-		RouteRegistrationLatencyHistogramBuckets: []float64{0.2, 0.4, 0.6, 0.8, 1, 1.2, 1.4, 1.6, 1.8, 2},
-		RoutingResponseLatencyHistogramBuckets:   []float64{0.2, 0.4, 0.6, 0.8, 1, 1.2, 1.4, 1.6, 1.8, 2},
-		HTTPLatencyHistogramBuckets:              []float64{0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6},
-	}
-}
 
 func getMetrics(port string) string {
 	addr := fmt.Sprintf("http://127.0.0.1:%s/metrics", port)


### PR DESCRIPTION
Summary
---------------

This PR introduces usage of metrics Gauge/GaugeVec types instead of Histogram/HistogramVec types.
The Gauge/GaugeVec types were introduced in the cloud foundry go-metric-registry library with this [PR](https://github.com/cloudfoundry/go-metric-registry/pull/206)

[GitHub Issue](https://github.com/cloudfoundry/routing-release/issues/506) 

Backward Compatibility
---------------
Breaking Change? **Yes**

The change was aligned with the community (see the related [discussion](https://cloudfoundry.slack.com/archives/C01ABMVNE9E/p1755515977893559))
