### PR TITLE
Refactor endpoint selection for sticky sessions

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/route/leastconnection.go
+++ b/src/code.cloudfoundry.org/gorouter/route/leastconnection.go
@@ -30,7 +30,7 @@ func NewLeastConnection(logger *slog.Logger, p *EndpointPool, initial string, mu
 }
 
 func (r *LeastConnection) Next(attempt int) *Endpoint {
-	e := r.pool.FindStickyEndpoint(r.logger, &r.initialEndpoint, r.mustBeSticky)
+	e := r.pool.FindStickyEndpoint(r.logger, r.initialEndpoint, r.mustBeSticky)
 	if e != nil {
 		r.lastEndpoint = e
 		return e
@@ -39,6 +39,8 @@ func (r *LeastConnection) Next(attempt int) *Endpoint {
 	if r.mustBeSticky {
 		return nil
 	}
+
+	r.initialEndpoint = "" // unset initial endpoint as it was not found in the pool
 
 	endpointElem := r.next(attempt)
 	if endpointElem != nil {

--- a/src/code.cloudfoundry.org/gorouter/route/leastconnection.go
+++ b/src/code.cloudfoundry.org/gorouter/route/leastconnection.go
@@ -1,7 +1,6 @@
 package route
 
 import (
-	"context"
 	"log/slog"
 	"math/rand"
 	"time"
@@ -31,43 +30,22 @@ func NewLeastConnection(logger *slog.Logger, p *EndpointPool, initial string, mu
 }
 
 func (r *LeastConnection) Next(attempt int) *Endpoint {
-	var e *endpointElem
-	if r.initialEndpoint != "" {
-		e = r.pool.findById(r.initialEndpoint)
-		if e != nil && e.isOverloaded() {
-			if r.mustBeSticky {
-				if r.logger.Enabled(context.Background(), slog.LevelDebug) {
-					r.logger.Debug("endpoint-overloaded-but-request-must-be-sticky", e.endpoint.ToLogData()...)
-				}
-				return nil
-			}
-			e = nil
-		}
-
-		if e == nil && r.mustBeSticky {
-			r.logger.Debug("endpoint-missing-but-request-must-be-sticky", slog.String("requested-endpoint", r.initialEndpoint))
-			return nil
-		}
-
-		if !r.mustBeSticky {
-			r.logger.Debug("endpoint-missing-choosing-alternate", slog.String("requested-endpoint", r.initialEndpoint))
-			r.initialEndpoint = ""
-		}
+	e := r.pool.FindStickyEndpoint(r.logger, &r.initialEndpoint, r.mustBeSticky)
+	if e != nil {
+		r.lastEndpoint = e
+		return e
 	}
 
-	if e != nil {
-		e.RLock()
-		defer e.RUnlock()
-		r.lastEndpoint = e.endpoint
-		return e.endpoint
+	if r.mustBeSticky {
+		return nil
 	}
 
-	e = r.next(attempt)
-	if e != nil {
-		e.RLock()
-		defer e.RUnlock()
-		r.lastEndpoint = e.endpoint
-		return e.endpoint
+	endpointElem := r.next(attempt)
+	if endpointElem != nil {
+		endpointElem.RLock()
+		defer endpointElem.RUnlock()
+		r.lastEndpoint = endpointElem.endpoint
+		return endpointElem.endpoint
 	}
 
 	r.lastEndpoint = nil

--- a/src/code.cloudfoundry.org/gorouter/route/pool.go
+++ b/src/code.cloudfoundry.org/gorouter/route/pool.go
@@ -1,7 +1,6 @@
 package route
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -466,45 +465,37 @@ func (p *EndpointPool) findById(id string) *endpointElem {
 }
 
 // FindStickyEndpoint attempts to find and return a sticky session endpoint.
-// If the endpoint is found and not overloaded, it returns the endpoint.
-// If mustBeSticky is true and the endpoint is missing or overloaded, it returns nil.
-// If mustBeSticky is false and the endpoint is missing or overloaded, it clears the stickyEndpointID and returns nil.
-// The stickyEndpointID pointer is modified in place when the endpoint is not sticky.
-func (p *EndpointPool) FindStickyEndpoint(logger *slog.Logger, stickyEndpointID *string, mustBeSticky bool) *Endpoint {
-	var e *endpointElem
-	if *stickyEndpointID != "" {
-		e = p.findById(*stickyEndpointID)
-		if e != nil && e.isOverloaded() {
-			if mustBeSticky {
-				if logger.Enabled(context.Background(), slog.LevelDebug) {
-					logger.Debug("endpoint-overloaded-but-request-must-be-sticky", e.endpoint.ToLogData()...)
-				}
-				return nil
-			}
-			e = nil
-		}
+// The function returns nil if the sticky session endpoint is not found, or overloaded.
+func (p *EndpointPool) FindStickyEndpoint(logger *slog.Logger, stickyEndpointID string, mustBeSticky bool) *Endpoint {
+	if stickyEndpointID == "" {
+		return nil
+	}
 
-		if e == nil && mustBeSticky {
-			if logger.Enabled(context.Background(), slog.LevelDebug) {
-				logger.Debug("endpoint-missing-but-request-must-be-sticky", slog.String("requested-endpoint", *stickyEndpointID))
-			}
+	e := p.findById(stickyEndpointID)
+
+	// Handle overloaded endpoint
+	if e != nil && e.isOverloaded() {
+		if mustBeSticky {
+			logger.Debug("endpoint-overloaded-but-request-must-be-sticky", e.endpoint.ToLogData()...)
 			return nil
 		}
+		e = nil
+	}
 
-		if !mustBeSticky {
-			if logger.Enabled(context.Background(), slog.LevelDebug) {
-				logger.Debug("endpoint-missing-choosing-alternate", slog.String("requested-endpoint", *stickyEndpointID))
-			}
-			*stickyEndpointID = ""
+	// Handle missing endpoint
+	if e == nil {
+		if mustBeSticky {
+			logger.Debug("endpoint-missing-but-request-must-be-sticky", slog.String("requested-endpoint", stickyEndpointID))
+			return nil
 		}
+		logger.Debug("endpoint-missing-choosing-alternate", slog.String("requested-endpoint", stickyEndpointID))
+		return nil
 	}
 
-	if e != nil {
-		e.RLock()
-		defer e.RUnlock()
-		return e.endpoint
-	}
-	return nil
+	// Return found endpoint
+	e.RLock()
+	defer e.RUnlock()
+	return e.endpoint
 }
 
 func (p *EndpointPool) IsEmpty() bool {

--- a/src/code.cloudfoundry.org/gorouter/route/pool.go
+++ b/src/code.cloudfoundry.org/gorouter/route/pool.go
@@ -1,6 +1,7 @@
 package route
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -462,6 +463,48 @@ func (p *EndpointPool) findById(id string) *endpointElem {
 	p.Lock()
 	defer p.Unlock()
 	return p.index[id]
+}
+
+// FindStickyEndpoint attempts to find and return a sticky session endpoint.
+// If the endpoint is found and not overloaded, it returns the endpoint.
+// If mustBeSticky is true and the endpoint is missing or overloaded, it returns nil.
+// If mustBeSticky is false and the endpoint is missing or overloaded, it clears the stickyEndpointID and returns nil.
+// The stickyEndpointID pointer is modified in place when the endpoint is not sticky.
+func (p *EndpointPool) FindStickyEndpoint(logger *slog.Logger, stickyEndpointID *string, mustBeSticky bool) *Endpoint {
+	var e *endpointElem
+	if *stickyEndpointID != "" {
+		e = p.findById(*stickyEndpointID)
+		if e != nil && e.isOverloaded() {
+			if mustBeSticky {
+				if logger.Enabled(context.Background(), slog.LevelDebug) {
+					logger.Debug("endpoint-overloaded-but-request-must-be-sticky", e.endpoint.ToLogData()...)
+				}
+				return nil
+			}
+			e = nil
+		}
+
+		if e == nil && mustBeSticky {
+			if logger.Enabled(context.Background(), slog.LevelDebug) {
+				logger.Debug("endpoint-missing-but-request-must-be-sticky", slog.String("requested-endpoint", *stickyEndpointID))
+			}
+			return nil
+		}
+
+		if !mustBeSticky {
+			if logger.Enabled(context.Background(), slog.LevelDebug) {
+				logger.Debug("endpoint-missing-choosing-alternate", slog.String("requested-endpoint", *stickyEndpointID))
+			}
+			*stickyEndpointID = ""
+		}
+	}
+
+	if e != nil {
+		e.RLock()
+		defer e.RUnlock()
+		return e.endpoint
+	}
+	return nil
 }
 
 func (p *EndpointPool) IsEmpty() bool {

--- a/src/code.cloudfoundry.org/gorouter/route/roundrobin.go
+++ b/src/code.cloudfoundry.org/gorouter/route/roundrobin.go
@@ -1,7 +1,6 @@
 package route
 
 import (
-	"context"
 	"log/slog"
 	"sync"
 	"time"
@@ -38,43 +37,22 @@ func (r *RoundRobin) Next(attempt int) *Endpoint {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	var e *endpointElem
-	if r.initialEndpoint != "" {
-		e = r.pool.findById(r.initialEndpoint)
-		if e != nil && e.isOverloaded() {
-			if r.mustBeSticky {
-				if r.logger.Enabled(context.Background(), slog.LevelDebug) {
-					r.logger.Debug("endpoint-overloaded-but-request-must-be-sticky", e.endpoint.ToLogData()...)
-				}
-				return nil
-			}
-			e = nil
-		}
-
-		if e == nil && r.mustBeSticky {
-			r.logger.Debug("endpoint-missing-but-request-must-be-sticky", slog.String("requested-endpoint", r.initialEndpoint))
-			return nil
-		}
-
-		if !r.mustBeSticky {
-			r.logger.Debug("endpoint-missing-choosing-alternate", slog.String("requested-endpoint", r.initialEndpoint))
-			r.initialEndpoint = ""
-		}
+	e := r.pool.FindStickyEndpoint(r.logger, &r.initialEndpoint, r.mustBeSticky)
+	if e != nil {
+		r.lastEndpoint = e
+		return e
 	}
 
-	if e != nil {
-		e.RLock()
-		defer e.RUnlock()
-		r.lastEndpoint = e.endpoint
-		return e.endpoint
+	if r.mustBeSticky {
+		return nil
 	}
 
-	e = r.next(attempt)
-	if e != nil {
-		e.RLock()
-		defer e.RUnlock()
-		r.lastEndpoint = e.endpoint
-		return e.endpoint
+	endpointElem := r.next(attempt)
+	if endpointElem != nil {
+		endpointElem.RLock()
+		defer endpointElem.RUnlock()
+		r.lastEndpoint = endpointElem.endpoint
+		return endpointElem.endpoint
 	}
 
 	r.lastEndpoint = nil

--- a/src/code.cloudfoundry.org/gorouter/route/roundrobin.go
+++ b/src/code.cloudfoundry.org/gorouter/route/roundrobin.go
@@ -37,7 +37,7 @@ func (r *RoundRobin) Next(attempt int) *Endpoint {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	e := r.pool.FindStickyEndpoint(r.logger, &r.initialEndpoint, r.mustBeSticky)
+	e := r.pool.FindStickyEndpoint(r.logger, r.initialEndpoint, r.mustBeSticky)
 	if e != nil {
 		r.lastEndpoint = e
 		return e
@@ -46,6 +46,7 @@ func (r *RoundRobin) Next(attempt int) *Endpoint {
 	if r.mustBeSticky {
 		return nil
 	}
+	r.initialEndpoint = "" // unset initial endpoint as it was not found in the pool
 
 	endpointElem := r.next(attempt)
 	if endpointElem != nil {


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
During the implementation of the hash-based routing, we noticed that the code in EndpointIterators for sticky sessions is duplicated. Move the code to a single place and call it from EndpointIterators. 


Backward Compatibility
---------------
Breaking Change? **No**

