### PR TITLE
Fix and Enhance Session Affinity Tests

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/proxy/session_affinity_test.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/session_affinity_test.go
@@ -166,7 +166,7 @@ var _ = Describe("Session Affinity with JSESSIONID", func() {
 
 		Context("when the response contains a JSESSIONID cookie", func() {
 
-			Context("and JSESSIONID is a session cookie", func() {
+			Context("and JSESSIONID cookie is a session cookie", func() {
 				var expiry time.Time
 
 				BeforeEach(func() {
@@ -225,13 +225,13 @@ var _ = Describe("Session Affinity with JSESSIONID", func() {
 				})
 			})
 
-			Context("and JSESSIONID has MaxAge < 0 to invalidate the cookie", func() {
+			Context("and JSESSIONID cookie has MaxAge < 0", func() {
 
 				BeforeEach(func() {
 					jSessionIdCookie.MaxAge = -1
 				})
 
-				It("responds with a VCAP_ID cookie scoped to the session", func() {
+				It("responds with a VCAP_ID cookie with MaxAge set to invalidate", func() {
 					ln := test_util.RegisterConnHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
 					defer ln.Close()
 
@@ -254,7 +254,7 @@ var _ = Describe("Session Affinity with JSESSIONID", func() {
 				})
 			})
 
-			Context("and JSESSIONID has positive MaxAge", func() {
+			Context("and JSESSIONID cookie has MaxAge > 0", func() {
 
 				BeforeEach(func() {
 					jSessionIdCookie.MaxAge = 1
@@ -289,7 +289,7 @@ var _ = Describe("Session Affinity with JSESSIONID", func() {
 					jSessionIdCookie.Secure = true
 				})
 
-				It("responds with a VCAP_ID cookie that is also Secure ", func() {
+				It("responds with a VCAP_ID cookie that is also Secure", func() {
 					ln := test_util.RegisterConnHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
 					defer ln.Close()
 
@@ -310,13 +310,13 @@ var _ = Describe("Session Affinity with JSESSIONID", func() {
 				})
 			})
 
-			Context("with secure cookies enabled and non-secure cookie", func() {
+			Context("and secure cookies are enabled with non-secure JSESSIONID cookie", func() {
 				BeforeEach(func() {
 					conf.SecureCookies = true
 					jSessionIdCookie.Secure = false
 				})
 
-				It("marks the cookie as secure only", func() {
+				It("responds with a VCAP_ID cookie that is marked as secure", func() {
 					ln := test_util.RegisterConnHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
 					defer ln.Close()
 

--- a/src/code.cloudfoundry.org/gorouter/proxy/session_affinity_test.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/session_affinity_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Session Affinity with JSESSIONID", func() {
 		jSessionIdCookie = &http.Cookie{
 			Name:   StickyCookieKey,
 			Value:  "xxx",
-			MaxAge: 1,
+			MaxAge: 0,
 		}
 	})
 

--- a/src/code.cloudfoundry.org/gorouter/proxy/session_affinity_test.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/session_affinity_test.go
@@ -43,9 +43,8 @@ var _ = Describe("Session Affinity with JSESSIONID", func() {
 		conf.SecureCookies = false
 
 		jSessionIdCookie = &http.Cookie{
-			Name:   StickyCookieKey,
-			Value:  "xxx",
-			MaxAge: 0,
+			Name:  StickyCookieKey,
+			Value: "xxx",
 		}
 	})
 
@@ -167,29 +166,38 @@ var _ = Describe("Session Affinity with JSESSIONID", func() {
 
 		Context("when the response contains a JSESSIONID cookie", func() {
 
-			It("responds with a VCAP_ID cookie scoped to the session", func() {
-				ln := test_util.RegisterConnHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
-				defer ln.Close()
+			Context("and JSESSIONID is a session cookie", func() {
+				var expiry time.Time
 
-				x := dialProxy(proxyServer)
-				req := test_util.NewRequest("GET", "app", "/", nil)
-				x.WriteRequest(req)
+				BeforeEach(func() {
+					jSessionIdCookie.Expires = expiry
+					jSessionIdCookie.MaxAge = 0
+				})
 
-				Eventually(done).Should(Receive())
+				It("responds with a VCAP_ID cookie scoped to the session", func() {
+					ln := test_util.RegisterConnHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
+					defer ln.Close()
 
-				resp, _ := x.ReadResponse()
-				jsessionId := getCookie(StickyCookieKey, resp.Cookies())
-				Expect(jsessionId).ToNot(BeNil())
+					x := dialProxy(proxyServer)
+					req := test_util.NewRequest("GET", "app", "/", nil)
+					x.WriteRequest(req)
 
-				cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
-				Expect(cookie).ToNot(BeNil())
-				Expect(cookie.Value).To(Equal("my-id"))
-				Expect(cookie.Secure).To(BeFalse())
-				Expect(cookie.MaxAge).To(BeZero())
-				Expect(cookie.Expires).To(BeZero())
+					Eventually(done).Should(Receive())
+
+					resp, _ := x.ReadResponse()
+					jsessionId := getCookie(StickyCookieKey, resp.Cookies())
+					Expect(jsessionId).ToNot(BeNil())
+
+					cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
+					Expect(cookie).ToNot(BeNil())
+					Expect(cookie.Value).To(Equal("my-id"))
+					Expect(cookie.Secure).To(BeFalse())
+					Expect(cookie.MaxAge).To(BeZero())
+					Expect(cookie.Expires).To(BeZero())
+				})
 			})
 
-			Context("and the JSESSIONID cookie has an expiry date", func() {
+			Context("and JSESSIONID cookie has an expiry date", func() {
 				var expiry time.Time
 
 				BeforeEach(func() {
@@ -214,6 +222,64 @@ var _ = Describe("Session Affinity with JSESSIONID", func() {
 					cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
 					Expect(cookie).ToNot(BeNil())
 					Expect(cookie.Expires).To(Equal(expiry))
+				})
+			})
+
+			Context("and JSESSIONID has MaxAge < 0 to invalidate the cookie", func() {
+
+				BeforeEach(func() {
+					jSessionIdCookie.MaxAge = -1
+				})
+
+				It("responds with a VCAP_ID cookie scoped to the session", func() {
+					ln := test_util.RegisterConnHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
+					defer ln.Close()
+
+					x := dialProxy(proxyServer)
+					req := test_util.NewRequest("GET", "app", "/", nil)
+					x.WriteRequest(req)
+
+					Eventually(done).Should(Receive())
+
+					resp, _ := x.ReadResponse()
+					jsessionId := getCookie(StickyCookieKey, resp.Cookies())
+					Expect(jsessionId).ToNot(BeNil())
+
+					cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
+					Expect(cookie).ToNot(BeNil())
+					Expect(cookie.Value).To(Equal("my-id"))
+					Expect(cookie.Secure).To(BeFalse())
+					Expect(cookie.MaxAge).To(Equal(-1))
+					Expect(cookie.Expires).To(BeZero())
+				})
+			})
+
+			Context("and JSESSIONID has positive MaxAge", func() {
+
+				BeforeEach(func() {
+					jSessionIdCookie.MaxAge = 1
+				})
+
+				It("responds with a VCAP_ID cookie with the same MaxAge", func() {
+					ln := test_util.RegisterConnHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
+					defer ln.Close()
+
+					x := dialProxy(proxyServer)
+					req := test_util.NewRequest("GET", "app", "/", nil)
+					x.WriteRequest(req)
+
+					Eventually(done).Should(Receive())
+
+					resp, _ := x.ReadResponse()
+					jsessionId := getCookie(StickyCookieKey, resp.Cookies())
+					Expect(jsessionId).ToNot(BeNil())
+
+					cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
+					Expect(cookie).ToNot(BeNil())
+					Expect(cookie.Value).To(Equal("my-id"))
+					Expect(cookie.Secure).To(BeFalse())
+					Expect(cookie.MaxAge).To(Equal(1))
+					Expect(cookie.Expires).To(BeZero())
 				})
 			})
 
@@ -391,6 +457,7 @@ var _ = Describe("Session Affinity with JSESSIONID", func() {
 			Context("when the JSESSIONID is expired", func() {
 				BeforeEach(func() {
 					jSessionIdCookie.MaxAge = -1
+
 				})
 
 				It("expires the VCAP_ID", func() {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This Pull-Request fixes a test failure introduced with #530. 
The [session affinity tests](https://github.com/cloudfoundry/routing-release/blob/e9683b43dec98ee211390c28cc8611d6869de801/src/code.cloudfoundry.org/gorouter/proxy/session_affinity_test.go#L48) use `MaxAge=1` by default. Before #530, positive `MaxAge` values were ignored and the corresponding `__VCAP_ID__` cookie had no `MaxAge` (corresponds to `Max-Age=0` in `http.Cookies`). 
After #530, Gorouter applies positive `Max-Age` values from `JSESSIONID` to `__VCAP_ID__`, but this test case has been overseen.
Removing the default value for `MaxAge` in the tests, adding a few test cases, and improving consistency over test cases.  

Backward Compatibility
---------------
Breaking Change? **No**