### PR TITLE
Egress Block List for Gorouter Route Services

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -111,7 +111,7 @@ properties:
     description: |
       Configuration option used in conjunction with the `router.balancing_algorithm` to decide from which
       availability zone to pick a suitable backend. Defaults to "None".
-      "none" - There is no preference regarding availability zones. The router uses the 
+      "none" - There is no preference regarding availability zones. The router uses the
         `router.balancing_algorithm` across all possible backends in all existing AZs.
       "locally-optimistic" - On the initial attempt to pick a backend, the router will use
         `router.balancing_algorithm` across all backends in the same AZ as the router itself. Subsequent
@@ -247,6 +247,10 @@ properties:
     description: |
       Enable websocket connections for application routes bound to Route Services.
     default: true
+  router.route_services.egress_blocklist:
+      description: |
+        Route Service Requests to these CIDRs will be blocked with HTTP status code 502.
+      default: []
   router.route_services.cert_chain:
     description: Certificate chain used for client authentication to TLS-registered route services.  In PEM format.
   router.route_services.private_key:
@@ -503,12 +507,12 @@ properties:
     default: 900
   http_1_request_timeout_in_seconds:
     description: |
-      The amount of time HTTP/1 requests from the Gorouter to apps are allowed to live before being canceled. 
+      The amount of time HTTP/1 requests from the Gorouter to apps are allowed to live before being canceled.
       Enter value in seconds. Set to -1 to disable timeouts. If set to 0, it inherits the value from request_timeout_in_seconds.
     default: 0
   http_2_request_timeout_in_seconds:
     description: |
-      The amount of time HTTP/2 requests from the Gorouter to apps are allowed to live before being canceled. 
+      The amount of time HTTP/2 requests from the Gorouter to apps are allowed to live before being canceled.
       Enter value in seconds. Set to -1 to disable timeouts. If set to 0, it inherits the value from request_timeout_in_seconds.
     default: 0
   endpoint_dial_timeout_in_seconds:

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -340,6 +340,7 @@ end
 
 strict_signature_validation = p('router.route_services_strict_signature_validation')
 enable_websockets = p('router.route_services.enable_websockets')
+egress_blocklist = p('router.route_services.egress_blocklist')
 
 route_services = {
   'max_attempts' => route_service_attempts,
@@ -347,6 +348,7 @@ route_services = {
   'private_key' => route_services_private_key,
   'strict_signature_validation' => strict_signature_validation,
   'enable_websockets' => enable_websockets,
+  'egress_blocklist' => egress_blocklist,
 }
 
 params['route_services'] = route_services

--- a/src/code.cloudfoundry.org/gorouter/cmd/gorouter/main.go
+++ b/src/code.cloudfoundry.org/gorouter/cmd/gorouter/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net/netip"
 	"os"
 	"runtime"
 	"syscall"
@@ -170,6 +171,17 @@ func main() {
 		}
 	}
 
+	// Extract and convert EgressBlocklist to []netip.Prefix
+	var egressBlocklist []netip.Prefix
+	for _, cidr := range c.RouteServiceConfig.EgressBlocklist {
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			logger.Error("invalid-cidr", slog.String("cidr", cidr), grlog.ErrAttr(err))
+			continue
+		}
+		egressBlocklist = append(egressBlocklist, prefix)
+	}
+
 	routeServiceConfig := routeservice.NewRouteServiceConfig(
 		grlog.CreateLoggerWithSource(prefix, "proxy"),
 		c.RouteServiceEnabled,
@@ -181,6 +193,7 @@ func main() {
 		c.RouteServiceRecommendHttps,
 		c.RouteServiceConfig.StrictSignatureValidation,
 		c.RouteServiceConfig.EnableWebsockets,
+		egressBlocklist,
 	)
 
 	// These TLS configs are just templates. If you add other keys you will

--- a/src/code.cloudfoundry.org/gorouter/config/config.go
+++ b/src/code.cloudfoundry.org/gorouter/config/config.go
@@ -176,6 +176,7 @@ type RouteServiceConfig struct {
 	StrictSignatureValidation bool             `yaml:"strict_signature_validation"`
 	TLSPem                    `yaml:",inline"` // embed to get cert_chain and private_key for client authentication
 	EnableWebsockets          bool             `yaml:"enable_websockets"`
+	EgressBlocklist           []string         `yaml:"egress_blocklist,omitempty"`
 }
 
 type LoggingConfig struct {

--- a/src/code.cloudfoundry.org/gorouter/handlers/routeservice_test.go
+++ b/src/code.cloudfoundry.org/gorouter/handlers/routeservice_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -99,7 +100,7 @@ var _ = Describe("Route Service Handler", func() {
 		crypto, err = secure.NewAesGCM([]byte("ABCDEFGHIJKLMNOP"))
 		Expect(err).NotTo(HaveOccurred())
 		config = routeservice.NewRouteServiceConfig(
-			logger.Logger, true, true, nil, 60*time.Second, crypto, nil, true, false, true)
+			logger.Logger, true, true, nil, 60*time.Second, crypto, nil, true, false, true, []netip.Prefix{})
 
 		nextCalled = false
 		prevHandler = &PrevHandler{}
@@ -120,7 +121,7 @@ var _ = Describe("Route Service Handler", func() {
 
 	Context("with route services disabled", func() {
 		BeforeEach(func() {
-			config = routeservice.NewRouteServiceConfig(logger.Logger, false, false, nil, 0, nil, nil, false, false, true)
+			config = routeservice.NewRouteServiceConfig(logger.Logger, false, false, nil, 0, nil, nil, false, false, true, nil)
 		})
 
 		Context("for normal routes", func() {
@@ -191,7 +192,7 @@ var _ = Describe("Route Service Handler", func() {
 			Context("with strictSignatureValidation enabled", func() {
 				BeforeEach(func() {
 					config = routeservice.NewRouteServiceConfig(
-						logger.Logger, true, false, nil, 60*time.Second, crypto, nil, false, true, true,
+						logger.Logger, true, false, nil, 60*time.Second, crypto, nil, false, true, true, nil,
 					)
 				})
 
@@ -273,7 +274,7 @@ var _ = Describe("Route Service Handler", func() {
 					BeforeEach(func() {
 						hairpinning := false
 						config = routeservice.NewRouteServiceConfig(
-							logger.Logger, true, hairpinning, nil, 60*time.Second, crypto, nil, true, false, true,
+							logger.Logger, true, hairpinning, nil, 60*time.Second, crypto, nil, true, false, true, nil,
 						)
 					})
 
@@ -304,7 +305,7 @@ var _ = Describe("Route Service Handler", func() {
 					BeforeEach(func() {
 						hairpinning := true
 						config = routeservice.NewRouteServiceConfig(
-							logger.Logger, true, hairpinning, nil, 60*time.Second, crypto, nil, true, false, true,
+							logger.Logger, true, hairpinning, nil, 60*time.Second, crypto, nil, true, false, true, nil,
 						)
 					})
 
@@ -335,7 +336,7 @@ var _ = Describe("Route Service Handler", func() {
 					BeforeEach(func() {
 						hairpinning := true
 						config = routeservice.NewRouteServiceConfig(
-							logger.Logger, true, hairpinning, []string{"route-service.com"}, 60*time.Second, crypto, nil, true, false, true,
+							logger.Logger, true, hairpinning, []string{"route-service.com"}, 60*time.Second, crypto, nil, true, false, true, nil,
 						)
 					})
 
@@ -367,7 +368,7 @@ var _ = Describe("Route Service Handler", func() {
 					BeforeEach(func() {
 						hairpinning := true
 						config = routeservice.NewRouteServiceConfig(
-							logger.Logger, true, hairpinning, []string{"example.com"}, 60*time.Second, crypto, nil, true, false, true,
+							logger.Logger, true, hairpinning, []string{"example.com"}, 60*time.Second, crypto, nil, true, false, true, nil,
 						)
 					})
 
@@ -399,7 +400,7 @@ var _ = Describe("Route Service Handler", func() {
 					BeforeEach(func() {
 						hairpinning := true
 						config = routeservice.NewRouteServiceConfig(
-							logger.Logger, true, hairpinning, generateHugeAllowlist(1000000), 60*time.Second, crypto, nil, true, false, true,
+							logger.Logger, true, hairpinning, generateHugeAllowlist(1000000), 60*time.Second, crypto, nil, true, false, true, nil,
 						)
 					})
 
@@ -437,7 +438,7 @@ var _ = Describe("Route Service Handler", func() {
 			Context("when recommendHttps is set to false", func() {
 				BeforeEach(func() {
 					config = routeservice.NewRouteServiceConfig(
-						logger.Logger, true, false, nil, 60*time.Second, crypto, nil, false, false, true,
+						logger.Logger, true, false, nil, 60*time.Second, crypto, nil, false, false, true, nil,
 					)
 				})
 				It("sends the request to the route service with X-CF-Forwarded-Url using http scheme", func() {
@@ -608,7 +609,7 @@ var _ = Describe("Route Service Handler", func() {
 					cryptoPrev, err = secure.NewAesGCM([]byte("QRSTUVWXYZ123456"))
 					Expect(err).ToNot(HaveOccurred())
 					config = routeservice.NewRouteServiceConfig(
-						logger.Logger, true, false, nil, 60*time.Second, crypto, cryptoPrev, true, false, true,
+						logger.Logger, true, false, nil, 60*time.Second, crypto, cryptoPrev, true, false, true, nil,
 					)
 				})
 
@@ -891,7 +892,7 @@ var _ = Describe("Route Service Handler", func() {
 				By(testCase.name)
 
 				config = routeservice.NewRouteServiceConfig(
-					logger.Logger, true, true, testCase.allowlist, 60*time.Second, crypto, nil, true, false, true,
+					logger.Logger, true, true, testCase.allowlist, 60*time.Second, crypto, nil, true, false, true, nil,
 				)
 
 				if testCase.err {

--- a/src/code.cloudfoundry.org/gorouter/proxy/proxy.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/proxy.go
@@ -3,13 +3,16 @@ package proxy
 import (
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"net/netip"
 	"net/url"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/cloudfoundry/dropsonde"
@@ -79,6 +82,12 @@ func NewProxy(
 		KeepAlive: cfg.EndpointKeepAliveProbeInterval,
 	}
 
+	rsDialer := &net.Dialer{
+		Timeout:   cfg.EndpointDialTimeout,
+		KeepAlive: cfg.EndpointKeepAliveProbeInterval,
+		Control:   RouteServiceDialControl(routeServiceConfig),
+	}
+
 	roundTripperFactory := &round_tripper.FactoryImpl{
 		BackendTemplate: &http.Transport{
 			DialContext:            dialer.DialContext,
@@ -93,7 +102,7 @@ func NewProxy(
 			MaxResponseHeaderBytes: int64(cfg.MaxResponseHeaderBytes),
 		},
 		RouteServiceTemplate: &http.Transport{
-			DialContext:            dialer.DialContext,
+			DialContext:            rsDialer.DialContext,
 			DisableKeepAlives:      cfg.DisableKeepAlives,
 			MaxIdleConns:           cfg.MaxIdleConns,
 			IdleConnTimeout:        90 * time.Second, // setting the value to golang default transport
@@ -276,4 +285,24 @@ func escapePathAndPreserveSlashes(unescaped string) string {
 	escapedPath = strings.TrimSuffix(escapedPath, "/")
 
 	return escapedPath
+}
+
+// RouteServiceDialControl checks if the address is allowed based on the block list.
+func RouteServiceDialControl(routeServiceConfig *routeservice.RouteServiceConfig) func(network, address string, c syscall.RawConn) error {
+	return func(network, address string, c syscall.RawConn) error {
+		if routeServiceConfig == nil || len(routeServiceConfig.EgressBlockList()) == 0 {
+			return nil
+		}
+		addrPort, err := netip.ParseAddrPort(address)
+		if err != nil {
+			return fmt.Errorf("wrong address format '%s': an IP and a port number are expected", address)
+		}
+
+		for _, blockedIP := range routeServiceConfig.EgressBlockList() {
+			if blockedIP.Contains(addrPort.Addr()) {
+				return fmt.Errorf("connection to %s not allowed", addrPort.Addr().String())
+			}
+		}
+		return nil
+	}
 }

--- a/src/code.cloudfoundry.org/gorouter/proxy/proxy_suite_test.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/proxy_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"net"
 	"net/http"
+	"net/netip"
 	"os"
 	"strconv"
 	"testing"
@@ -122,6 +123,7 @@ var _ = JustBeforeEach(func() {
 		recommendHTTPS,
 		strictSignatureValidation,
 		conf.RouteServiceConfig.EnableWebsockets,
+		[]netip.Prefix{},
 	)
 
 	proxyServer, err = net.Listen("tcp", "127.0.0.1:0")

--- a/src/code.cloudfoundry.org/gorouter/proxy/proxy_test.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/proxy_test.go
@@ -3,6 +3,8 @@ package proxy_test
 import (
 	"bufio"
 	"bytes"
+	"code.cloudfoundry.org/gorouter/proxy"
+	"code.cloudfoundry.org/gorouter/routeservice"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -10,6 +12,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"regexp"
@@ -1739,7 +1742,7 @@ var _ = Describe("Proxy", func() {
 					Expect(logStr).To(ContainSubstring("failed_attempts:3"))
 					Expect(logStr).To(ContainSubstring("failed_attempts_time:0.3"))
 					Expect(logStr).To(ContainSubstring("response_time:0.3"))
-					Expect(logStr).To(ContainSubstring("gorouter_time:0"))
+					Expect(logStr).To(ContainSubstring("gorouter_time:0.0"))
 					Expect(logStr).To(ContainSubstring(`backend_time:"-"`))
 					Expect(logStr).To(ContainSubstring(`dns_time:"-"`))
 					Expect(logStr).To(ContainSubstring(`dial_time:"-"`))
@@ -2914,6 +2917,7 @@ var _ = Describe("Proxy", func() {
 			var vcapHeader string
 			ln := test_util.RegisterConnHandler(r, "app", func(conn *test_util.HttpConn) {
 				req, _ := conn.ReadRequest()
+
 				vcapHeader = req.Header.Get(handlers.VcapRequestIdHeader)
 				resp := test_util.NewResponse(http.StatusOK)
 				conn.WriteResponse(resp)
@@ -3022,6 +3026,81 @@ var _ = Describe("Proxy", func() {
 			})
 		})
 	})
+	Describe("RouteServiceDialControl", func() {
+		var (
+			blockList []netip.Prefix
+			config    *routeservice.RouteServiceConfig
+		)
+
+		BeforeEach(func() {
+			blockList = []netip.Prefix{}
+			config = nil // will be set in each test
+		})
+
+		It("does not match IPv4 address to IPv6 prefix", func() {
+			blockList = []netip.Prefix{netip.MustParsePrefix("::1/128")}
+			config = routeservice.NewRouteServiceConfig(
+				logger.Logger, true, false, nil, 1*time.Second, nil, nil, false, false, false, blockList,
+			)
+			control := proxy.RouteServiceDialControl(config)
+			err := control("tcp", "127.0.0.1:80", nil)
+			Expect(err).To(BeNil())
+		})
+
+		It("does not match IPv4-mapped IPv6 address to IPv4 prefix", func() {
+			blockList = []netip.Prefix{netip.MustParsePrefix("192.168.1.0/24")}
+			config = routeservice.NewRouteServiceConfig(
+				logger.Logger, true, false, nil, 1*time.Second, nil, nil, false, false, false, blockList,
+			)
+			control := proxy.RouteServiceDialControl(config)
+			err := control("tcp", "[::ffff:192.168.1.1]:80", nil)
+			Expect(err).To(BeNil())
+		})
+
+		It("does not match IP with IPv6 zone to any prefix", func() {
+			blockList = []netip.Prefix{netip.MustParsePrefix("fe80::/10")}
+			config = routeservice.NewRouteServiceConfig(
+				logger.Logger, true, false, nil, 1*time.Second, nil, nil, false, false, false, blockList,
+			)
+			control := proxy.RouteServiceDialControl(config)
+			err := control("tcp", "[fe80::1%lo0]:80", nil)
+			Expect(err).To(BeNil())
+		})
+
+		It("allows connection when IP is not in blocklist", func() {
+			blockList = []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")}
+			config = routeservice.NewRouteServiceConfig(
+				logger.Logger, true, false, nil, 1*time.Second, nil, nil, false, false, false, blockList,
+			)
+			control := proxy.RouteServiceDialControl(config)
+			err := control("tcp", "192.168.1.1:80", nil)
+			Expect(err).To(BeNil())
+		})
+
+		It("blocks connection and returns error when IP is in blocklist", func() {
+			blockList = []netip.Prefix{netip.MustParsePrefix("192.168.1.0/24")}
+			config = routeservice.NewRouteServiceConfig(
+				logger.Logger, true, false, nil, 1*time.Second, nil, nil, false, false, false, blockList,
+			)
+			control := proxy.RouteServiceDialControl(config)
+			err := control("tcp", "192.168.1.1:80", nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("connection to 192.168.1.1 not allowed"))
+		})
+
+		It("returns an error when ParseAddrPort fails for an invalid address", func() {
+			blockList = []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")}
+			config = routeservice.NewRouteServiceConfig(
+				logger.Logger, true, false, nil, 1*time.Second, nil, nil, false, false, false, blockList,
+			)
+			control := proxy.RouteServiceDialControl(config)
+			// Use an invalid address that is not a zero-value/empty IP
+			err := control("tcp", "invalid-address", nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("wrong address format 'invalid-address'"))
+		})
+	})
+
 })
 
 // HACK: this is used to silence any http warnings in logs

--- a/src/code.cloudfoundry.org/gorouter/proxy/proxy_unit_test.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/proxy_unit_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -65,6 +66,7 @@ var _ = Describe("Proxy Unit tests", func() {
 				false,
 				false,
 				conf.RouteServiceConfig.EnableWebsockets,
+				[]netip.Prefix{},
 			)
 			varz := test_helpers.NullVarz{}
 			sender := new(fakes.MetricSender)

--- a/src/code.cloudfoundry.org/gorouter/proxy/route_service_test.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/route_service_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -84,6 +85,7 @@ var _ = Describe("Route Services", func() {
 			recommendHTTPS,
 			strictSignatureValidation,
 			conf.RouteServiceConfig.EnableWebsockets,
+			[]netip.Prefix{}, // Pass empty blocklist for tests
 		)
 		reqArgs, err := config.CreateRequest("", forwardedUrl)
 		Expect(err).ToNot(HaveOccurred())

--- a/src/code.cloudfoundry.org/gorouter/router/router_test.go
+++ b/src/code.cloudfoundry.org/gorouter/router/router_test.go
@@ -2474,7 +2474,7 @@ func initializeRouter(config *cfg.Config, backendIdleTimeout, requestTimeout tim
 	batcher := new(fakeMetrics.MetricBatcher)
 	metricReporter := &metrics.Metrics{Sender: sender, Batcher: batcher}
 	combinedReporter := &metrics.CompositeReporter{VarzReporter: varz, MetricReporter: metricReporter}
-	routeServiceConfig := routeservice.NewRouteServiceConfig(logger, true, config.RouteServicesHairpinning, config.RouteServicesHairpinningAllowlist, config.EndpointTimeout, nil, nil, false, false, true)
+	routeServiceConfig := routeservice.NewRouteServiceConfig(logger, true, config.RouteServicesHairpinning, config.RouteServicesHairpinningAllowlist, config.EndpointTimeout, nil, nil, false, false, true, nil)
 
 	ew := errorwriter.NewPlaintextErrorWriter()
 

--- a/src/code.cloudfoundry.org/gorouter/routeservice/routeservice_config.go
+++ b/src/code.cloudfoundry.org/gorouter/routeservice/routeservice_config.go
@@ -3,6 +3,7 @@ package routeservice
 import (
 	"errors"
 	"log/slog"
+	"net/netip"
 	"net/url"
 	"time"
 
@@ -29,6 +30,7 @@ type RouteServiceConfig struct {
 	recommendHttps                   bool
 	strictSignatureValidation        bool
 	enableWebsockets                 bool
+	egressBlocklist                  []netip.Prefix
 }
 
 type RequestToSendToRouteService struct {
@@ -57,6 +59,7 @@ func NewRouteServiceConfig(
 	recommendHttps bool,
 	strictSignatureValidation bool,
 	enableWebsockets bool,
+	egressBlocklist []netip.Prefix,
 ) *RouteServiceConfig {
 	return &RouteServiceConfig{
 		routeServiceEnabled:              enabled,
@@ -69,6 +72,7 @@ func NewRouteServiceConfig(
 		recommendHttps:                   recommendHttps,
 		strictSignatureValidation:        strictSignatureValidation,
 		enableWebsockets:                 enableWebsockets,
+		egressBlocklist:                  egressBlocklist,
 	}
 }
 
@@ -78,6 +82,10 @@ func (rs *RouteServiceConfig) RouteServiceEnabled() bool {
 
 func (rs *RouteServiceConfig) EnableWebsockets() bool {
 	return rs.enableWebsockets
+}
+
+func (rs *RouteServiceConfig) EgressBlockList() []netip.Prefix {
+	return rs.egressBlocklist
 }
 
 func (rs *RouteServiceConfig) RouteServiceRecommendHttps() bool {

--- a/src/code.cloudfoundry.org/gorouter/routeservice/routeservice_config_test.go
+++ b/src/code.cloudfoundry.org/gorouter/routeservice/routeservice_config_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Route Service Config", func() {
 		crypto, err = secure.NewAesGCM([]byte(cryptoKey))
 		Expect(err).ToNot(HaveOccurred())
 		logger = test_util.NewTestLogger("test")
-		config = routeservice.NewRouteServiceConfig(logger.Logger, true, true, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true)
+		config = routeservice.NewRouteServiceConfig(logger.Logger, true, true, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true, nil)
 	})
 
 	AfterEach(func() {
@@ -73,7 +73,7 @@ var _ = Describe("Route Service Config", func() {
 				fakeCrypto := &fakes.FakeCrypto{}
 				fakeCrypto.EncryptReturns([]byte{}, []byte{}, errors.New("test failed"))
 
-				config = routeservice.NewRouteServiceConfig(logger.Logger, true, false, nil, 1*time.Hour, fakeCrypto, cryptoPrev, recommendHttps, strictValidation, true)
+				config = routeservice.NewRouteServiceConfig(logger.Logger, true, false, nil, 1*time.Hour, fakeCrypto, cryptoPrev, recommendHttps, strictValidation, true, nil)
 			})
 
 			It("returns an error", func() {
@@ -179,7 +179,7 @@ var _ = Describe("Route Service Config", func() {
 				var err error
 				crypto, err = secure.NewAesGCM([]byte("QRSTUVWXYZ123456"))
 				Expect(err).NotTo(HaveOccurred())
-				config = routeservice.NewRouteServiceConfig(logger.Logger, true, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true)
+				config = routeservice.NewRouteServiceConfig(logger.Logger, true, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true, nil)
 			})
 
 			Context("when there is no previous key in the configuration", func() {
@@ -195,7 +195,7 @@ var _ = Describe("Route Service Config", func() {
 					var err error
 					cryptoPrev, err = secure.NewAesGCM([]byte(cryptoKey))
 					Expect(err).ToNot(HaveOccurred())
-					config = routeservice.NewRouteServiceConfig(logger.Logger, true, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true)
+					config = routeservice.NewRouteServiceConfig(logger.Logger, true, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true, nil)
 				})
 
 				It("validates the signature", func() {
@@ -232,7 +232,7 @@ var _ = Describe("Route Service Config", func() {
 					var err error
 					cryptoPrev, err = secure.NewAesGCM([]byte("QRSTUVWXYZ123456"))
 					Expect(err).ToNot(HaveOccurred())
-					config = routeservice.NewRouteServiceConfig(logger.Logger, true, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true)
+					config = routeservice.NewRouteServiceConfig(logger.Logger, true, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true, nil)
 				})
 
 				It("rejects the signature", func() {
@@ -248,7 +248,7 @@ var _ = Describe("Route Service Config", func() {
 		Context("when rs recommendHttps is set to true", func() {
 			BeforeEach(func() {
 				recommendHttps = true
-				config = routeservice.NewRouteServiceConfig(logger.Logger, true, true, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true)
+				config = routeservice.NewRouteServiceConfig(logger.Logger, true, true, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true, nil)
 			})
 
 			It("returns the routeServiceEnabled to be true", func() {
@@ -259,7 +259,7 @@ var _ = Describe("Route Service Config", func() {
 		Context("when rs recommendHttps is set to false", func() {
 			BeforeEach(func() {
 				recommendHttps = false
-				config = routeservice.NewRouteServiceConfig(logger.Logger, true, true, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true)
+				config = routeservice.NewRouteServiceConfig(logger.Logger, true, true, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true, nil)
 			})
 
 			It("returns the routeServiceEnabled to be false", func() {
@@ -272,7 +272,7 @@ var _ = Describe("Route Service Config", func() {
 		Context("when routeServiceHairpinning is set to true", func() {
 			BeforeEach(func() {
 				recommendHttps = true
-				config = routeservice.NewRouteServiceConfig(logger.Logger, true, true, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true)
+				config = routeservice.NewRouteServiceConfig(logger.Logger, true, true, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true, nil)
 			})
 
 			It("returns the routeServiceEnabled to be true", func() {
@@ -283,7 +283,7 @@ var _ = Describe("Route Service Config", func() {
 		Context("when routeServiceHairpinning is set to false", func() {
 			BeforeEach(func() {
 				recommendHttps = false
-				config = routeservice.NewRouteServiceConfig(logger.Logger, true, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true)
+				config = routeservice.NewRouteServiceConfig(logger.Logger, true, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true, nil)
 			})
 
 			It("returns the routeServiceHairpinning to be false", func() {
@@ -296,7 +296,7 @@ var _ = Describe("Route Service Config", func() {
 		Context("when  RouteService is Enabled", func() {
 			BeforeEach(func() {
 				routeServiceEnabled := true
-				config = routeservice.NewRouteServiceConfig(logger.Logger, routeServiceEnabled, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true)
+				config = routeservice.NewRouteServiceConfig(logger.Logger, routeServiceEnabled, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true, nil)
 			})
 
 			It("returns the routeServiceEnabled to be true", func() {
@@ -307,7 +307,7 @@ var _ = Describe("Route Service Config", func() {
 		Context("when  RouteService is not Enabled", func() {
 			BeforeEach(func() {
 				routeServiceEnabled := false
-				config = routeservice.NewRouteServiceConfig(logger.Logger, routeServiceEnabled, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true)
+				config = routeservice.NewRouteServiceConfig(logger.Logger, routeServiceEnabled, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true, nil)
 			})
 
 			It("returns the routeServiceEnabled to be false", func() {
@@ -319,7 +319,7 @@ var _ = Describe("Route Service Config", func() {
 	Describe("EnableWebsockets", func() {
 		Context("when EnableWebsockets is enabled", func() {
 			BeforeEach(func() {
-				config = routeservice.NewRouteServiceConfig(logger.Logger, true, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true)
+				config = routeservice.NewRouteServiceConfig(logger.Logger, true, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, true, nil)
 			})
 
 			It("returns the EnableWebsockets to be true", func() {
@@ -329,7 +329,7 @@ var _ = Describe("Route Service Config", func() {
 
 		Context("when EnableWebsockets is not enabled", func() {
 			BeforeEach(func() {
-				config = routeservice.NewRouteServiceConfig(logger.Logger, true, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, false)
+				config = routeservice.NewRouteServiceConfig(logger.Logger, true, false, nil, 1*time.Hour, crypto, cryptoPrev, recommendHttps, strictValidation, false, nil)
 			})
 
 			It("returns the EnableWebsockets to be false", func() {


### PR DESCRIPTION
Summary
---------------
**Egress Blocklist for Route Services**

Operators will be enabled to provide a list of IP addresses, which can't be accessed via route services.
The list of blocked CIDRs for route services is configured in the Gorouter configuration property **router.route_services.block_CIDRs**. Route Service Requests to these CIDRs will be blocked with HTTP status code 502.

Custom Route Service Dialer enables callback to make decisions after DNS resolution and before the connection is established by providing a Control function. This function is used to abort the Dialer's connection to a particular target before it is opened based on the defined block list. 

Backward Compatibility
---------------
Breaking Change? **No**
