### PR TITLE
Spec tests for route service egress blocklist

### DIFF
--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -909,7 +909,20 @@ describe 'gorouter' do
               it 'parses to true' do
                 expect(parsed_yaml['route_services']['enable_websockets']).to eq(false)
               end
-            end
+        end
+        context 'when egress_blocklist is not set' do
+          it 'parses to an empty list' do
+            expect(parsed_yaml['route_services']['egress_blocklist']).to eq([])
+          end
+        end
+        context 'when egress_blocklist is set' do
+          before do
+            deployment_manifest_fragment['router']['route_services']['egress_blocklist'] = ['10.9.8.7/8','100.200.300.400/16']
+          end
+          it 'parses to the specified list' do
+            expect(parsed_yaml['route_services']['egress_blocklist']).to eq(['10.9.8.7/8','100.200.300.400/16'])
+          end
+        end
       end
 
       describe 'backends' do


### PR DESCRIPTION
Spec tests for [Egress Blocklist for Route Services ](https://github.com/cloudfoundry/routing-release/pull/537)
