### PR TITLE
Apply TLS cipher and version settings to internal route services port…

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/router/route_service_server.go
+++ b/src/code.cloudfoundry.org/gorouter/router/route_service_server.go
@@ -1,3 +1,8 @@
+// @AI-Generated
+// Generated in whole or in part by Cursor with a mix of different LLM models (Auto select mode)
+// Description:
+// 2026-03-17: Apply TLS cipher and version settings to internal route services server (TNZ-79284)
+
 package router
 
 import (
@@ -32,6 +37,9 @@ type RouteServicesServer struct {
 	rootCA            *x509.CertPool
 	clientCert        tls.Certificate
 	serverCert        tls.Certificate
+	cipherSuites      []uint16
+	minTLSVersion     uint16
+	maxTLSVersion     uint16
 }
 
 func NewRouteServicesServer(cfg *config.Config) (*RouteServicesServer, error) {
@@ -69,6 +77,9 @@ func NewRouteServicesServer(cfg *config.Config) (*RouteServicesServer, error) {
 		rootCA:            rootCertPool,
 		clientCert:        clientCert,
 		serverCert:        serverCert,
+		cipherSuites:      cfg.CipherSuites,
+		minTLSVersion:    cfg.MinTLSVersion,
+		maxTLSVersion:    cfg.MaxTLSVersion,
 	}, nil
 }
 
@@ -83,6 +94,11 @@ func (rs *RouteServicesServer) Serve(handler http.Handler, errChan chan error) e
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{rs.serverCert},
 		ClientCAs:    rs.rootCA,
+		MinVersion:   rs.minTLSVersion,
+		MaxVersion:   rs.maxTLSVersion,
+	}
+	if len(rs.cipherSuites) > 0 {
+		tlsConfig.CipherSuites = rs.cipherSuites
 	}
 
 	go func() {
@@ -98,13 +114,19 @@ func (rs *RouteServicesServer) Stop() error {
 }
 
 func (rs *RouteServicesServer) GetRoundTripper() RouteServiceRoundTripper {
+	clientTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{rs.clientCert},
+		RootCAs:      rs.rootCA,
+		MinVersion:   rs.minTLSVersion,
+		MaxVersion:   rs.maxTLSVersion,
+	}
+	if len(rs.cipherSuites) > 0 {
+		clientTLSConfig.CipherSuites = rs.cipherSuites
+	}
 	return RouteServiceRoundTripper{
 		port: rs.port,
 		transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				Certificates: []tls.Certificate{rs.clientCert},
-				RootCAs:      rs.rootCA,
-			},
+			TLSClientConfig: clientTLSConfig,
 		},
 	}
 }

--- a/src/code.cloudfoundry.org/gorouter/router/route_service_server_test.go
+++ b/src/code.cloudfoundry.org/gorouter/router/route_service_server_test.go
@@ -59,6 +59,34 @@ var _ = Describe("RouteServicesServer", func() {
 
 			Expect(resp.StatusCode).To(Equal(http.StatusTeapot))
 		})
+
+		It("enforces min TLS version and rejects TLS 1.1 when server requires TLS 1.2", func() {
+			// Default config already sets MinTLSVersion to TLS 1.2. Client that only offers TLS 1.1 must be rejected.
+			rt := rss.GetRoundTripper()
+			clientCfg := rt.TLSClientConfig().Clone()
+			clientCfg.MinVersion = tls.VersionTLS10
+			clientCfg.MaxVersion = tls.VersionTLS11
+
+			_, err := tls.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", cfg.RouteServicesServerPort), clientCfg)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("GetRoundTripper", func() {
+		It("applies TLS version and cipher settings to the client config", func() {
+			cfg.MinTLSVersion = tls.VersionTLS12
+			cfg.MaxTLSVersion = tls.VersionTLS13
+			cfg.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384}
+
+			rssClient, err := router.NewRouteServicesServer(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			defer rssClient.Stop()
+
+			clientCfg := rssClient.GetRoundTripper().TLSClientConfig()
+			Expect(clientCfg.MinVersion).To(Equal(tls.VersionTLS12))
+			Expect(clientCfg.MaxVersion).To(Equal(tls.VersionTLS13))
+			Expect(clientCfg.CipherSuites).To(Equal([]uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384}))
+		})
 	})
 
 	Describe("ReadHeaderTimeout", func() {


### PR DESCRIPTION
… (7070)

Internal route services server and its client round tripper now use the same min/max TLS version and cipher suites as the rest of gorouter, so port 7070 respects router TLS configuration.

ai-assisted=yes
TNZ-79284

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
