### PR TITLE
feat: add CF private IPs as route-service blocklist defaults

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -250,7 +250,11 @@ properties:
   router.route_services.egress_blocklist:
       description: |
         Route Service Requests to these CIDRs will be blocked with HTTP status code 502.
-      default: []
+      default:
+      - 10.0.0.0/8
+      - 169.254.0.0/16
+      - 172.16.0.0/12
+      - 192.168.0.0/16
   router.route_services.cert_chain:
     description: Certificate chain used for client authentication to TLS-registered route services.  In PEM format.
   router.route_services.private_key:

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -911,8 +911,13 @@ describe 'gorouter' do
               end
         end
         context 'when egress_blocklist is not set' do
-          it 'parses to an empty list' do
-            expect(parsed_yaml['route_services']['egress_blocklist']).to eq([])
+          it 'parses to the default blocklist' do
+            expect(parsed_yaml['route_services']['egress_blocklist']).to eq([
+              '10.0.0.0/8',
+              '169.254.0.0/16',
+              '172.16.0.0/12',
+              '192.168.0.0/16'
+            ])
           end
         end
         context 'when egress_blocklist is set' do


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
* Applies the Secure-By-Default principle
* Includes private IPv4 address ranges from RFC 1918 (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
* Also includes the link-local range (169.254.0.0/16), see https://docs.cloudfoundry.org/concepts/asg.html#default-asg


Backward Compatibility
---------------
Breaking Change? **Yes**
* users can no longer access internal network ranges via route-services
* if operators want to keep allowing this, they need to patch this property via:
```
- type: replace
  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/route_services?/egress_blocklist
  value: []
```
