### PR TITLE
Revert "Apply TLS cipher and version settings to internal route servi…

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/router/route_service_server.go
+++ b/src/code.cloudfoundry.org/gorouter/router/route_service_server.go
@@ -1,8 +1,3 @@
-// @AI-Generated
-// Generated in whole or in part by Cursor with a mix of different LLM models (Auto select mode)
-// Description:
-// 2026-03-17: Apply TLS cipher and version settings to internal route services server (TNZ-79284)
-
 package router
 
 import (
@@ -37,9 +32,6 @@ type RouteServicesServer struct {
 	rootCA            *x509.CertPool
 	clientCert        tls.Certificate
 	serverCert        tls.Certificate
-	cipherSuites      []uint16
-	minTLSVersion     uint16
-	maxTLSVersion     uint16
 }
 
 func NewRouteServicesServer(cfg *config.Config) (*RouteServicesServer, error) {
@@ -77,9 +69,6 @@ func NewRouteServicesServer(cfg *config.Config) (*RouteServicesServer, error) {
 		rootCA:            rootCertPool,
 		clientCert:        clientCert,
 		serverCert:        serverCert,
-		cipherSuites:      cfg.CipherSuites,
-		minTLSVersion:     cfg.MinTLSVersion,
-		maxTLSVersion:     cfg.MaxTLSVersion,
 	}, nil
 }
 
@@ -94,11 +83,6 @@ func (rs *RouteServicesServer) Serve(handler http.Handler, errChan chan error) e
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{rs.serverCert},
 		ClientCAs:    rs.rootCA,
-		MinVersion:   rs.minTLSVersion,
-		MaxVersion:   rs.maxTLSVersion,
-	}
-	if len(rs.cipherSuites) > 0 {
-		tlsConfig.CipherSuites = rs.cipherSuites
 	}
 
 	go func() {
@@ -114,19 +98,13 @@ func (rs *RouteServicesServer) Stop() error {
 }
 
 func (rs *RouteServicesServer) GetRoundTripper() RouteServiceRoundTripper {
-	clientTLSConfig := &tls.Config{
-		Certificates: []tls.Certificate{rs.clientCert},
-		RootCAs:      rs.rootCA,
-		MinVersion:   rs.minTLSVersion,
-		MaxVersion:   rs.maxTLSVersion,
-	}
-	if len(rs.cipherSuites) > 0 {
-		clientTLSConfig.CipherSuites = rs.cipherSuites
-	}
 	return RouteServiceRoundTripper{
 		port: rs.port,
 		transport: &http.Transport{
-			TLSClientConfig: clientTLSConfig,
+			TLSClientConfig: &tls.Config{
+				Certificates: []tls.Certificate{rs.clientCert},
+				RootCAs:      rs.rootCA,
+			},
 		},
 	}
 }

--- a/src/code.cloudfoundry.org/gorouter/router/route_service_server_test.go
+++ b/src/code.cloudfoundry.org/gorouter/router/route_service_server_test.go
@@ -59,33 +59,6 @@ var _ = Describe("RouteServicesServer", func() {
 
 			Expect(resp.StatusCode).To(Equal(http.StatusTeapot))
 		})
-
-		It("enforces min TLS version and rejects TLS 1.1 when server requires TLS 1.2", func() {
-			// Default config already sets MinTLSVersion to TLS 1.2. Client that only offers TLS 1.1 must be rejected.
-			rt := rss.GetRoundTripper()
-			clientCfg := rt.TLSClientConfig().Clone()
-			clientCfg.MinVersion = tls.VersionTLS10
-			clientCfg.MaxVersion = tls.VersionTLS11
-
-			_, err := tls.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", cfg.RouteServicesServerPort), clientCfg)
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(ContainSubstring("remote error: tls: protocol version not supported")))
-		})
-	})
-
-	Describe("GetRoundTripper", func() {
-		BeforeEach(func() {
-			cfg.MinTLSVersion = tls.VersionTLS12
-			cfg.MaxTLSVersion = tls.VersionTLS13
-			cfg.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384}
-		})
-
-		It("applies TLS version and cipher settings to the client config", func() {
-			clientCfg := rss.GetRoundTripper().TLSClientConfig()
-			Expect(clientCfg.MinVersion).To(BeNumerically("==", tls.VersionTLS12))
-			Expect(clientCfg.MaxVersion).To(BeNumerically("==", tls.VersionTLS13))
-			Expect(clientCfg.CipherSuites).To(Equal([]uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384}))
-		})
 	})
 
 	Describe("ReadHeaderTimeout", func() {


### PR DESCRIPTION
…ces port (7070)"

This reverts commit 006b54773664405cf9e43fa2cf01e95f3c61b738.

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
reverting, because this caused issues in cf-d's pipeline