### PR TITLE
Restrict cipher suites on internal route services port (7070)

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/router/route_service_server.go
+++ b/src/code.cloudfoundry.org/gorouter/router/route_service_server.go
@@ -1,3 +1,8 @@
+// @AI-Generated
+// Generated in whole or in part by Cursor with a mix of different LLM models (Auto select mode)
+// Description:
+// 2026-03-17: Restrict cipher suites on internal route services server to ECDSA GCM suites (TNZ-79284)
+
 package router
 
 import (
@@ -83,6 +88,13 @@ func (rs *RouteServicesServer) Serve(handler http.Handler, errChan chan error) e
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{rs.serverCert},
 		ClientCAs:    rs.rootCA,
+		// The internal server always uses ephemeral ECDSA P-256 certs, so we
+		// hardcode the two secure ECDSA GCM cipher suites for TLS 1.2.
+		// TLS 1.3 cipher suites are not configurable in Go and are unaffected.
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		},
 	}
 
 	go func() {
@@ -104,6 +116,11 @@ func (rs *RouteServicesServer) GetRoundTripper() RouteServiceRoundTripper {
 			TLSClientConfig: &tls.Config{
 				Certificates: []tls.Certificate{rs.clientCert},
 				RootCAs:      rs.rootCA,
+				// Mirror the server's hardcoded ECDSA GCM cipher suites.
+				CipherSuites: []uint16{
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				},
 			},
 		},
 	}

--- a/src/code.cloudfoundry.org/gorouter/router/route_service_server_test.go
+++ b/src/code.cloudfoundry.org/gorouter/router/route_service_server_test.go
@@ -59,6 +59,32 @@ var _ = Describe("RouteServicesServer", func() {
 
 			Expect(resp.StatusCode).To(Equal(http.StatusTeapot))
 		})
+
+		It("rejects connections that only offer disallowed ECDSA cipher suites", func() {
+			rt := rss.GetRoundTripper()
+			clientCfg := rt.TLSClientConfig().Clone()
+			// These are the three ciphers that must not be negotiable on the internal port.
+			clientCfg.CipherSuites = []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+			}
+			// Force TLS 1.2 so cipher suite negotiation applies.
+			clientCfg.MaxVersion = tls.VersionTLS12
+
+			_, err := tls.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", cfg.RouteServicesServerPort), clientCfg)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("GetRoundTripper", func() {
+		It("hardcodes ECDSA GCM cipher suites in the client config", func() {
+			clientCfg := rss.GetRoundTripper().TLSClientConfig()
+			Expect(clientCfg.CipherSuites).To(ConsistOf(
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			))
+		})
 	})
 
 	Describe("ReadHeaderTimeout", func() {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The internal route services server generates ephemeral ECDSA P-256 certs, so hardcode TLS 1.2 cipher suites to the two secure ECDSA GCM variants:
- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384

This excludes the three ciphers:
- TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA (insecure)
- TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA (insecure)
- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256

TLS 1.3 cipher suites are not configurable in Go and are unaffected.

ai-assisted=yes
TNZ-79284


Backward Compatibility
---------------
Breaking Change? No
