### PR TITLE
fix: Per-route load balancing algorithm not reverting to platform default on removal

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/config/config.go
+++ b/src/code.cloudfoundry.org/gorouter/config/config.go
@@ -25,7 +25,6 @@ const (
 	LOAD_BALANCE_RR           string = "round-robin"
 	LOAD_BALANCE_LC           string = "least-connection"
 	LOAD_BALANCE_HB           string = "hash"
-	LOAD_BALANCE_DEFAULT      string = "_default"
 	AZ_PREF_NONE              string = "none"
 	AZ_PREF_LOCAL             string = "locally-optimistic"
 	SHARD_ALL                 string = "all"

--- a/src/code.cloudfoundry.org/gorouter/config/config.go
+++ b/src/code.cloudfoundry.org/gorouter/config/config.go
@@ -25,6 +25,7 @@ const (
 	LOAD_BALANCE_RR           string = "round-robin"
 	LOAD_BALANCE_LC           string = "least-connection"
 	LOAD_BALANCE_HB           string = "hash"
+	LOAD_BALANCE_DEFAULT      string = "_default"
 	AZ_PREF_NONE              string = "none"
 	AZ_PREF_LOCAL             string = "locally-optimistic"
 	SHARD_ALL                 string = "all"

--- a/src/code.cloudfoundry.org/gorouter/mbus/subscriber.go
+++ b/src/code.cloudfoundry.org/gorouter/mbus/subscriber.go
@@ -46,7 +46,7 @@ type RegistryMessageOpts struct {
 	HashBalance            float64 `json:"hash_balance,string"`
 }
 
-func (rm *RegistryMessage) makeEndpoint(http2Enabled bool) (*route.Endpoint, error) {
+func (rm *RegistryMessage) makeEndpoint(http2Enabled bool, globalRoutingAlgo string) (*route.Endpoint, error) {
 	port, useTLS, err := rm.port()
 	if err != nil {
 		return nil, err
@@ -61,12 +61,9 @@ func (rm *RegistryMessage) makeEndpoint(http2Enabled bool) (*route.Endpoint, err
 		protocol = "http1"
 	}
 
-	lbAlgo := ""
-	if rm.Options.LoadBalancingAlgorithm != nil {
+	lbAlgo := globalRoutingAlgo
+	if rm.Options.LoadBalancingAlgorithm != nil && *rm.Options.LoadBalancingAlgorithm != "" {
 		lbAlgo = *rm.Options.LoadBalancingAlgorithm
-		if lbAlgo == "" {
-			lbAlgo = config.LOAD_BALANCE_DEFAULT
-		}
 	}
 
 	return route.NewEndpoint(&route.EndpointOpts{
@@ -115,7 +112,8 @@ type Subscriber struct {
 
 	params startMessageParams
 
-	logger *slog.Logger
+	logger            *slog.Logger
+	globalRoutingAlgo string
 }
 
 type startMessageParams struct {
@@ -145,10 +143,11 @@ func NewSubscriber(
 			minimumRegisterIntervalInSeconds: int(c.StartResponseDelayInterval.Seconds()),
 			pruneThresholdInSeconds:          int(c.DropletStaleThreshold.Seconds()),
 		},
-		reconnected:      reconnected,
-		natsPendingLimit: c.NatsClientMessageBufferSize,
-		logger:           l,
-		http2Enabled:     c.EnableHTTP2,
+		reconnected:       reconnected,
+		natsPendingLimit:  c.NatsClientMessageBufferSize,
+		logger:            l,
+		http2Enabled:      c.EnableHTTP2,
+		globalRoutingAlgo: c.LoadBalance,
 	}
 }
 
@@ -251,7 +250,7 @@ func (s *Subscriber) subscribeRoutes() (*nats.Subscription, error) {
 }
 
 func (s *Subscriber) registerEndpoint(msg *RegistryMessage) {
-	endpoint, err := msg.makeEndpoint(s.http2Enabled)
+	endpoint, err := msg.makeEndpoint(s.http2Enabled, s.globalRoutingAlgo)
 	if err != nil {
 		s.logger.Error("Unable to register route",
 			log.ErrAttr(err),
@@ -266,7 +265,7 @@ func (s *Subscriber) registerEndpoint(msg *RegistryMessage) {
 }
 
 func (s *Subscriber) unregisterEndpoint(msg *RegistryMessage) {
-	endpoint, err := msg.makeEndpoint(s.http2Enabled)
+	endpoint, err := msg.makeEndpoint(s.http2Enabled, s.globalRoutingAlgo)
 	if err != nil {
 		s.logger.Error("Unable to unregister route",
 			log.ErrAttr(err),

--- a/src/code.cloudfoundry.org/gorouter/mbus/subscriber.go
+++ b/src/code.cloudfoundry.org/gorouter/mbus/subscriber.go
@@ -41,7 +41,7 @@ type RegistryMessage struct {
 }
 
 type RegistryMessageOpts struct {
-	LoadBalancingAlgorithm *string `json:"loadbalancing"`
+	LoadBalancingAlgorithm string `json:"loadbalancing"`
 	HashHeaderName         string  `json:"hash_header"`
 	HashBalance            float64 `json:"hash_balance,string"`
 }
@@ -62,8 +62,8 @@ func (rm *RegistryMessage) makeEndpoint(http2Enabled bool, globalRoutingAlgo str
 	}
 
 	lbAlgo := globalRoutingAlgo
-	if rm.Options.LoadBalancingAlgorithm != nil && *rm.Options.LoadBalancingAlgorithm != "" {
-		lbAlgo = *rm.Options.LoadBalancingAlgorithm
+	if rm.Options.LoadBalancingAlgorithm != "" {
+		lbAlgo = rm.Options.LoadBalancingAlgorithm
 	}
 
 	return route.NewEndpoint(&route.EndpointOpts{

--- a/src/code.cloudfoundry.org/gorouter/mbus/subscriber.go
+++ b/src/code.cloudfoundry.org/gorouter/mbus/subscriber.go
@@ -41,7 +41,7 @@ type RegistryMessage struct {
 }
 
 type RegistryMessageOpts struct {
-	LoadBalancingAlgorithm string `json:"loadbalancing"`
+	LoadBalancingAlgorithm string  `json:"loadbalancing"`
 	HashHeaderName         string  `json:"hash_header"`
 	HashBalance            float64 `json:"hash_balance,string"`
 }

--- a/src/code.cloudfoundry.org/gorouter/mbus/subscriber.go
+++ b/src/code.cloudfoundry.org/gorouter/mbus/subscriber.go
@@ -41,7 +41,7 @@ type RegistryMessage struct {
 }
 
 type RegistryMessageOpts struct {
-	LoadBalancingAlgorithm string  `json:"loadbalancing"`
+	LoadBalancingAlgorithm *string `json:"loadbalancing"`
 	HashHeaderName         string  `json:"hash_header"`
 	HashBalance            float64 `json:"hash_balance,string"`
 }
@@ -61,6 +61,14 @@ func (rm *RegistryMessage) makeEndpoint(http2Enabled bool) (*route.Endpoint, err
 		protocol = "http1"
 	}
 
+	lbAlgo := ""
+	if rm.Options.LoadBalancingAlgorithm != nil {
+		lbAlgo = *rm.Options.LoadBalancingAlgorithm
+		if lbAlgo == "" {
+			lbAlgo = config.LOAD_BALANCE_DEFAULT
+		}
+	}
+
 	return route.NewEndpoint(&route.EndpointOpts{
 		AppId:                   rm.App,
 		AvailabilityZone:        rm.AvailabilityZone,
@@ -77,7 +85,7 @@ func (rm *RegistryMessage) makeEndpoint(http2Enabled bool) (*route.Endpoint, err
 		IsolationSegment:        rm.IsolationSegment,
 		UseTLS:                  useTLS,
 		UpdatedAt:               updatedAt,
-		LoadBalancingAlgorithm:  rm.Options.LoadBalancingAlgorithm,
+		LoadBalancingAlgorithm:  lbAlgo,
 		HashHeaderName:          rm.Options.HashHeaderName,
 		HashBalanceFactor:       rm.Options.HashBalance,
 	}), nil

--- a/src/code.cloudfoundry.org/gorouter/mbus/subscriber_test.go
+++ b/src/code.cloudfoundry.org/gorouter/mbus/subscriber_test.go
@@ -566,7 +566,7 @@ var _ = Describe("Subscriber", func() {
 					App:      "app",
 					Protocol: "http2",
 					Uris:     []route.Uri{"test.example.com"},
-					Options:  mbus.RegistryMessageOpts{LoadBalancingAlgorithm: &expectedLBAlgo},
+					Options:  mbus.RegistryMessageOpts{LoadBalancingAlgorithm: expectedLBAlgo},
 				}
 				data, err := json.Marshal(msg)
 				Expect(err).NotTo(HaveOccurred())
@@ -587,7 +587,7 @@ var _ = Describe("Subscriber", func() {
 			})
 		})
 
-		Context("when the message contains an empty load balancing algorithm option", func() {
+		Context("when the message contains an empty or absent load balancing algorithm option", func() {
 			JustBeforeEach(func() {
 				sub = mbus.NewSubscriber(natsClient, registry, cfg, reconnected, logger.Logger)
 				process = ifrit.Invoke(sub)
@@ -618,34 +618,6 @@ var _ = Describe("Subscriber", func() {
 
 				Expect(originalEndpoint).To(Equal(expectedEndpoint))
 			})
-
-			It("endpoint gets the global default algorithm when the algorithm is explicitly set to empty string", func() {
-				emptyStr := ""
-				var msg = mbus.RegistryMessage{
-					Host:     "host",
-					App:      "app",
-					Protocol: "http2",
-					Uris:     []route.Uri{"test.example.com"},
-					Options:  mbus.RegistryMessageOpts{LoadBalancingAlgorithm: &emptyStr},
-				}
-				data, err := json.Marshal(msg)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = natsClient.Publish("router.register", data)
-				Expect(err).ToNot(HaveOccurred())
-
-				Eventually(registry.RegisterCallCount).Should(Equal(1))
-				_, originalEndpoint := registry.RegisterArgsForCall(0)
-				expectedEndpoint := route.NewEndpoint(&route.EndpointOpts{
-					Host:                   "host",
-					AppId:                  "app",
-					Protocol:               "http2",
-					LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
-				})
-
-				Expect(originalEndpoint).To(Equal(expectedEndpoint))
-			})
-
 		})
 
 		Context("when the message contains hash-based load balancing options", func() {
@@ -663,7 +635,7 @@ var _ = Describe("Subscriber", func() {
 					Protocol: "http2",
 					Uris:     []route.Uri{"test.example.com"},
 					Options: mbus.RegistryMessageOpts{
-						LoadBalancingAlgorithm: &expectedLBAlgo,
+						LoadBalancingAlgorithm: expectedLBAlgo,
 						HashHeaderName:         "X-Header",
 						HashBalance:            1.5,
 					},
@@ -697,7 +669,7 @@ var _ = Describe("Subscriber", func() {
 					Protocol: "http2",
 					Uris:     []route.Uri{"test.example.com"},
 					Options: mbus.RegistryMessageOpts{
-						LoadBalancingAlgorithm: &expectedLBAlgo,
+						LoadBalancingAlgorithm: expectedLBAlgo,
 						HashHeaderName:         "X-Header",
 					},
 				}
@@ -731,7 +703,7 @@ var _ = Describe("Subscriber", func() {
 					Protocol: "http2",
 					Uris:     []route.Uri{"test.example.com"},
 					Options: mbus.RegistryMessageOpts{
-						LoadBalancingAlgorithm: &expectedLBAlgo,
+						LoadBalancingAlgorithm: expectedLBAlgo,
 						HashHeaderName:         "X-Header",
 					},
 				}

--- a/src/code.cloudfoundry.org/gorouter/mbus/subscriber_test.go
+++ b/src/code.cloudfoundry.org/gorouter/mbus/subscriber_test.go
@@ -594,7 +594,7 @@ var _ = Describe("Subscriber", func() {
 				Eventually(process.Ready()).Should(BeClosed())
 			})
 
-			It("endpoint is constructed with the empty string load balancing algorithm", func() {
+			It("endpoint is constructed with the global default load balancing algorithm", func() {
 				var msg = mbus.RegistryMessage{
 					Host:     "host",
 					App:      "app",
@@ -610,15 +610,16 @@ var _ = Describe("Subscriber", func() {
 				Eventually(registry.RegisterCallCount).Should(Equal(1))
 				_, originalEndpoint := registry.RegisterArgsForCall(0)
 				expectedEndpoint := route.NewEndpoint(&route.EndpointOpts{
-					Host:     "host",
-					AppId:    "app",
-					Protocol: "http2",
+					Host:                   "host",
+					AppId:                  "app",
+					Protocol:               "http2",
+					LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
 				})
 
 				Expect(originalEndpoint).To(Equal(expectedEndpoint))
 			})
 
-			It("endpoint gets the reset sentinel when the algorithm is explicitly set to empty string", func() {
+			It("endpoint gets the global default algorithm when the algorithm is explicitly set to empty string", func() {
 				emptyStr := ""
 				var msg = mbus.RegistryMessage{
 					Host:     "host",
@@ -639,7 +640,7 @@ var _ = Describe("Subscriber", func() {
 					Host:                   "host",
 					AppId:                  "app",
 					Protocol:               "http2",
-					LoadBalancingAlgorithm: config.LOAD_BALANCE_DEFAULT,
+					LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
 				})
 
 				Expect(originalEndpoint).To(Equal(expectedEndpoint))

--- a/src/code.cloudfoundry.org/gorouter/mbus/subscriber_test.go
+++ b/src/code.cloudfoundry.org/gorouter/mbus/subscriber_test.go
@@ -566,7 +566,7 @@ var _ = Describe("Subscriber", func() {
 					App:      "app",
 					Protocol: "http2",
 					Uris:     []route.Uri{"test.example.com"},
-					Options:  mbus.RegistryMessageOpts{LoadBalancingAlgorithm: expectedLBAlgo},
+					Options:  mbus.RegistryMessageOpts{LoadBalancingAlgorithm: &expectedLBAlgo},
 				}
 				data, err := json.Marshal(msg)
 				Expect(err).NotTo(HaveOccurred())
@@ -618,6 +618,33 @@ var _ = Describe("Subscriber", func() {
 				Expect(originalEndpoint).To(Equal(expectedEndpoint))
 			})
 
+			It("endpoint gets the reset sentinel when the algorithm is explicitly set to empty string", func() {
+				emptyStr := ""
+				var msg = mbus.RegistryMessage{
+					Host:     "host",
+					App:      "app",
+					Protocol: "http2",
+					Uris:     []route.Uri{"test.example.com"},
+					Options:  mbus.RegistryMessageOpts{LoadBalancingAlgorithm: &emptyStr},
+				}
+				data, err := json.Marshal(msg)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = natsClient.Publish("router.register", data)
+				Expect(err).ToNot(HaveOccurred())
+
+				Eventually(registry.RegisterCallCount).Should(Equal(1))
+				_, originalEndpoint := registry.RegisterArgsForCall(0)
+				expectedEndpoint := route.NewEndpoint(&route.EndpointOpts{
+					Host:                   "host",
+					AppId:                  "app",
+					Protocol:               "http2",
+					LoadBalancingAlgorithm: config.LOAD_BALANCE_DEFAULT,
+				})
+
+				Expect(originalEndpoint).To(Equal(expectedEndpoint))
+			})
+
 		})
 
 		Context("when the message contains hash-based load balancing options", func() {
@@ -635,7 +662,7 @@ var _ = Describe("Subscriber", func() {
 					Protocol: "http2",
 					Uris:     []route.Uri{"test.example.com"},
 					Options: mbus.RegistryMessageOpts{
-						LoadBalancingAlgorithm: expectedLBAlgo,
+						LoadBalancingAlgorithm: &expectedLBAlgo,
 						HashHeaderName:         "X-Header",
 						HashBalance:            1.5,
 					},
@@ -669,7 +696,7 @@ var _ = Describe("Subscriber", func() {
 					Protocol: "http2",
 					Uris:     []route.Uri{"test.example.com"},
 					Options: mbus.RegistryMessageOpts{
-						LoadBalancingAlgorithm: expectedLBAlgo,
+						LoadBalancingAlgorithm: &expectedLBAlgo,
 						HashHeaderName:         "X-Header",
 					},
 				}
@@ -703,7 +730,7 @@ var _ = Describe("Subscriber", func() {
 					Protocol: "http2",
 					Uris:     []route.Uri{"test.example.com"},
 					Options: mbus.RegistryMessageOpts{
-						LoadBalancingAlgorithm: expectedLBAlgo,
+						LoadBalancingAlgorithm: &expectedLBAlgo,
 						HashHeaderName:         "X-Header",
 					},
 				}

--- a/src/code.cloudfoundry.org/gorouter/route/pool.go
+++ b/src/code.cloudfoundry.org/gorouter/route/pool.go
@@ -207,10 +207,9 @@ type EndpointPool struct {
 	random                 *rand.Rand
 	logger                 *slog.Logger
 	updatedAt              time.Time
-	LoadBalancingAlgorithm        string
-	defaultLoadBalancingAlgorithm string
-	HashRoutingProperties         *HashRoutingProperties
-	HashLookupTable               MaglevLookup
+	LoadBalancingAlgorithm string
+	HashRoutingProperties  *HashRoutingProperties
+	HashLookupTable        MaglevLookup
 }
 
 type EndpointOpts struct {
@@ -279,18 +278,17 @@ type PoolOpts struct {
 
 func NewPool(opts *PoolOpts) *EndpointPool {
 	pool := &EndpointPool{
-		endpoints:                     make([]*endpointElem, 0, 1),
-		index:                         make(map[string]*endpointElem),
-		retryAfterFailure:             opts.RetryAfterFailure,
-		NextIdx:                       -1,
-		maxConnsPerBackend:            opts.MaxConnsPerBackend,
-		host:                          opts.Host,
-		contextPath:                   opts.ContextPath,
-		random:                        rand.New(rand.NewSource(time.Now().UnixNano())),
-		logger:                        opts.Logger,
-		updatedAt:                     time.Now(),
-		LoadBalancingAlgorithm:        opts.LoadBalancingAlgorithm,
-		defaultLoadBalancingAlgorithm: opts.LoadBalancingAlgorithm,
+		endpoints:              make([]*endpointElem, 0, 1),
+		index:                  make(map[string]*endpointElem),
+		retryAfterFailure:      opts.RetryAfterFailure,
+		NextIdx:                -1,
+		maxConnsPerBackend:     opts.MaxConnsPerBackend,
+		host:                   opts.Host,
+		contextPath:            opts.ContextPath,
+		random:                 rand.New(rand.NewSource(time.Now().UnixNano())),
+		logger:                 opts.Logger,
+		updatedAt:              time.Now(),
+		LoadBalancingAlgorithm: opts.LoadBalancingAlgorithm,
 	}
 	if pool.LoadBalancingAlgorithm == config.LOAD_BALANCE_HB {
 		pool.HashLookupTable = NewMaglev(opts.Logger)
@@ -670,31 +668,24 @@ func (p *EndpointPool) MarshalJSON() ([]byte, error) {
 
 // setPoolLoadBalancingAlgorithm overwrites the load balancing algorithm of a pool by that of a specified endpoint, if that is valid.
 // An empty algorithm means the field was not specified and the pool keeps its current algorithm.
-// The sentinel value LOAD_BALANCE_RESET means the per-route algorithm was explicitly cleared, reverting the pool to the platform default.
 func (p *EndpointPool) setPoolLoadBalancingAlgorithm(endpoint *Endpoint) {
 	if endpoint.LoadBalancingAlgorithm == "" {
 		return
 	}
 
-	if endpoint.LoadBalancingAlgorithm == config.LOAD_BALANCE_DEFAULT {
-		if p.LoadBalancingAlgorithm != p.defaultLoadBalancingAlgorithm {
-			p.logger.Debug("resetting-pool-load-balancing-algorithm-to-default",
-				slog.String("previousLBAlgorithm", p.LoadBalancingAlgorithm),
-				slog.String("defaultLBAlgorithm", p.defaultLoadBalancingAlgorithm))
-			p.LoadBalancingAlgorithm = p.defaultLoadBalancingAlgorithm
-			p.HashLookupTable = nil
-			p.HashRoutingProperties = nil
-		}
-		return
-	}
-
 	if endpoint.LoadBalancingAlgorithm != p.LoadBalancingAlgorithm {
 		if config.IsLoadBalancingAlgorithmValid(endpoint.LoadBalancingAlgorithm) {
+			previousAlgorithm := p.LoadBalancingAlgorithm
 			p.LoadBalancingAlgorithm = endpoint.LoadBalancingAlgorithm
 			p.logger.Debug("setting-pool-load-balancing-algorithm-to-that-of-an-endpoint",
 				slog.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm),
 				slog.String("poolLBAlgorithm", p.LoadBalancingAlgorithm))
 
+			// Clean up hash-based routing state when switching away from HB
+			if previousAlgorithm == config.LOAD_BALANCE_HB && p.LoadBalancingAlgorithm != config.LOAD_BALANCE_HB {
+				p.HashLookupTable = nil
+				p.HashRoutingProperties = nil
+			}
 		} else {
 			p.logger.Error("invalid-endpoint-load-balancing-algorithm-provided-keeping-pool-lb-algo",
 				slog.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm),

--- a/src/code.cloudfoundry.org/gorouter/route/pool.go
+++ b/src/code.cloudfoundry.org/gorouter/route/pool.go
@@ -667,12 +667,7 @@ func (p *EndpointPool) MarshalJSON() ([]byte, error) {
 }
 
 // setPoolLoadBalancingAlgorithm overwrites the load balancing algorithm of a pool by that of a specified endpoint, if that is valid.
-// An empty algorithm is treated as "no change" — the pool keeps its current algorithm.
 func (p *EndpointPool) setPoolLoadBalancingAlgorithm(endpoint *Endpoint) {
-	if endpoint.LoadBalancingAlgorithm == "" {
-		return
-	}
-
 	if endpoint.LoadBalancingAlgorithm != p.LoadBalancingAlgorithm {
 		if config.IsLoadBalancingAlgorithmValid(endpoint.LoadBalancingAlgorithm) {
 			previousAlgorithm := p.LoadBalancingAlgorithm

--- a/src/code.cloudfoundry.org/gorouter/route/pool.go
+++ b/src/code.cloudfoundry.org/gorouter/route/pool.go
@@ -207,9 +207,10 @@ type EndpointPool struct {
 	random                 *rand.Rand
 	logger                 *slog.Logger
 	updatedAt              time.Time
-	LoadBalancingAlgorithm string
-	HashRoutingProperties  *HashRoutingProperties
-	HashLookupTable        MaglevLookup
+	LoadBalancingAlgorithm        string
+	defaultLoadBalancingAlgorithm string
+	HashRoutingProperties         *HashRoutingProperties
+	HashLookupTable               MaglevLookup
 }
 
 type EndpointOpts struct {
@@ -278,17 +279,18 @@ type PoolOpts struct {
 
 func NewPool(opts *PoolOpts) *EndpointPool {
 	pool := &EndpointPool{
-		endpoints:              make([]*endpointElem, 0, 1),
-		index:                  make(map[string]*endpointElem),
-		retryAfterFailure:      opts.RetryAfterFailure,
-		NextIdx:                -1,
-		maxConnsPerBackend:     opts.MaxConnsPerBackend,
-		host:                   opts.Host,
-		contextPath:            opts.ContextPath,
-		random:                 rand.New(rand.NewSource(time.Now().UnixNano())),
-		logger:                 opts.Logger,
-		updatedAt:              time.Now(),
-		LoadBalancingAlgorithm: opts.LoadBalancingAlgorithm,
+		endpoints:                     make([]*endpointElem, 0, 1),
+		index:                         make(map[string]*endpointElem),
+		retryAfterFailure:             opts.RetryAfterFailure,
+		NextIdx:                       -1,
+		maxConnsPerBackend:            opts.MaxConnsPerBackend,
+		host:                          opts.Host,
+		contextPath:                   opts.ContextPath,
+		random:                        rand.New(rand.NewSource(time.Now().UnixNano())),
+		logger:                        opts.Logger,
+		updatedAt:                     time.Now(),
+		LoadBalancingAlgorithm:        opts.LoadBalancingAlgorithm,
+		defaultLoadBalancingAlgorithm: opts.LoadBalancingAlgorithm,
 	}
 	if pool.LoadBalancingAlgorithm == config.LOAD_BALANCE_HB {
 		pool.HashLookupTable = NewMaglev(opts.Logger)
@@ -667,8 +669,22 @@ func (p *EndpointPool) MarshalJSON() ([]byte, error) {
 }
 
 // setPoolLoadBalancingAlgorithm overwrites the load balancing algorithm of a pool by that of a specified endpoint, if that is valid.
+// An empty algorithm means the field was not specified and the pool keeps its current algorithm.
+// The sentinel value LOAD_BALANCE_RESET means the per-route algorithm was explicitly cleared, reverting the pool to the platform default.
 func (p *EndpointPool) setPoolLoadBalancingAlgorithm(endpoint *Endpoint) {
 	if endpoint.LoadBalancingAlgorithm == "" {
+		return
+	}
+
+	if endpoint.LoadBalancingAlgorithm == config.LOAD_BALANCE_DEFAULT {
+		if p.LoadBalancingAlgorithm != p.defaultLoadBalancingAlgorithm {
+			p.logger.Debug("resetting-pool-load-balancing-algorithm-to-default",
+				slog.String("previousLBAlgorithm", p.LoadBalancingAlgorithm),
+				slog.String("defaultLBAlgorithm", p.defaultLoadBalancingAlgorithm))
+			p.LoadBalancingAlgorithm = p.defaultLoadBalancingAlgorithm
+			p.HashLookupTable = nil
+			p.HashRoutingProperties = nil
+		}
 		return
 	}
 

--- a/src/code.cloudfoundry.org/gorouter/route/pool.go
+++ b/src/code.cloudfoundry.org/gorouter/route/pool.go
@@ -667,7 +667,7 @@ func (p *EndpointPool) MarshalJSON() ([]byte, error) {
 }
 
 // setPoolLoadBalancingAlgorithm overwrites the load balancing algorithm of a pool by that of a specified endpoint, if that is valid.
-// An empty algorithm means the field was not specified and the pool keeps its current algorithm.
+// An empty algorithm is treated as "no change" — the pool keeps its current algorithm.
 func (p *EndpointPool) setPoolLoadBalancingAlgorithm(endpoint *Endpoint) {
 	if endpoint.LoadBalancingAlgorithm == "" {
 		return

--- a/src/code.cloudfoundry.org/gorouter/route/pool_test.go
+++ b/src/code.cloudfoundry.org/gorouter/route/pool_test.go
@@ -486,9 +486,85 @@ var _ = Describe("EndpointPool", func() {
 
 		})
 
-	})
+		Context("When removing a per-route load balancing algorithm", func() {
+			It("reverts the pool to the platform default and cleans up HB state", func() {
+				pool := route.NewPool(&route.PoolOpts{
+					Logger:                 logger.Logger,
+					LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
+				})
 
-	Context("RouteServiceUrl", func() {
+				// Set up HB routing on the pool
+				hbEndpoint := route.NewEndpoint(&route.EndpointOpts{
+					Host:                   "host-1",
+					Port:                   1234,
+					PrivateInstanceId:      "id-1",
+					LoadBalancingAlgorithm: config.LOAD_BALANCE_HB,
+					HashBalanceFactor:      1.25,
+					HashHeaderName:         "X-Tenant",
+				})
+				pool.Put(hbEndpoint)
+				Expect(pool.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_HB))
+				Expect(pool.HashLookupTable).ToNot(BeNil())
+				Expect(pool.HashRoutingProperties).ToNot(BeNil())
+
+				// Explicitly reset per-route algorithm via the sentinel value
+				resetEndpoint := route.NewEndpoint(&route.EndpointOpts{
+					Host:                   "host-1",
+					Port:                   1234,
+					PrivateInstanceId:      "id-1",
+					LoadBalancingAlgorithm: config.LOAD_BALANCE_DEFAULT,
+				})
+				pool.Put(resetEndpoint)
+				Expect(pool.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
+				Expect(pool.HashLookupTable).To(BeNil())
+				Expect(pool.HashRoutingProperties).To(BeNil())
+				Eventually(logger).Should(gbytes.Say(`resetting-pool-load-balancing-algorithm-to-default`))
+			})
+
+			It("keeps the current algorithm when the endpoint does not specify one", func() {
+				pool := route.NewPool(&route.PoolOpts{
+					Logger:                 logger.Logger,
+					LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
+				})
+
+				// Set up HB routing
+				hbEndpoint := route.NewEndpoint(&route.EndpointOpts{
+					Host:                   "host-1",
+					Port:                   1234,
+					PrivateInstanceId:      "id-1",
+					LoadBalancingAlgorithm: config.LOAD_BALANCE_HB,
+					HashBalanceFactor:      1.25,
+					HashHeaderName:         "X-Tenant",
+				})
+				pool.Put(hbEndpoint)
+				Expect(pool.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_HB))
+
+				// Register with empty algorithm (field not specified) — should NOT reset
+				noAlgoEndpoint := route.NewEndpoint(&route.EndpointOpts{
+					Host:              "host-1",
+					Port:              1234,
+					PrivateInstanceId: "id-1",
+				})
+				pool.Put(noAlgoEndpoint)
+				Expect(pool.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_HB))
+			})
+
+			It("is a no-op when the pool already uses the platform default", func() {
+				pool := route.NewPool(&route.PoolOpts{
+					Logger:                 logger.Logger,
+					LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
+				})
+
+				endpoint := route.NewEndpoint(&route.EndpointOpts{
+					Host:                   "host-1",
+					Port:                   1234,
+					PrivateInstanceId:      "id-1",
+					LoadBalancingAlgorithm: config.LOAD_BALANCE_DEFAULT,
+				})
+				pool.Put(endpoint)
+				Expect(pool.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
+			})
+		})
 		It("returns the route_service_url associated with the pool", func() {
 			endpoint := &route.Endpoint{}
 			endpointRS := &route.Endpoint{RouteServiceUrl: "my-url"}

--- a/src/code.cloudfoundry.org/gorouter/route/pool_test.go
+++ b/src/code.cloudfoundry.org/gorouter/route/pool_test.go
@@ -507,18 +507,17 @@ var _ = Describe("EndpointPool", func() {
 				Expect(pool.HashLookupTable).ToNot(BeNil())
 				Expect(pool.HashRoutingProperties).ToNot(BeNil())
 
-				// Explicitly reset per-route algorithm via the sentinel value
+				// Revert to the platform default (as the subscriber would do when the option is removed)
 				resetEndpoint := route.NewEndpoint(&route.EndpointOpts{
 					Host:                   "host-1",
 					Port:                   1234,
 					PrivateInstanceId:      "id-1",
-					LoadBalancingAlgorithm: config.LOAD_BALANCE_DEFAULT,
+					LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
 				})
 				pool.Put(resetEndpoint)
 				Expect(pool.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
 				Expect(pool.HashLookupTable).To(BeNil())
 				Expect(pool.HashRoutingProperties).To(BeNil())
-				Eventually(logger).Should(gbytes.Say(`resetting-pool-load-balancing-algorithm-to-default`))
 			})
 
 			It("keeps the current algorithm when the endpoint does not specify one", func() {
@@ -547,22 +546,6 @@ var _ = Describe("EndpointPool", func() {
 				})
 				pool.Put(noAlgoEndpoint)
 				Expect(pool.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_HB))
-			})
-
-			It("is a no-op when the pool already uses the platform default", func() {
-				pool := route.NewPool(&route.PoolOpts{
-					Logger:                 logger.Logger,
-					LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
-				})
-
-				endpoint := route.NewEndpoint(&route.EndpointOpts{
-					Host:                   "host-1",
-					Port:                   1234,
-					PrivateInstanceId:      "id-1",
-					LoadBalancingAlgorithm: config.LOAD_BALANCE_DEFAULT,
-				})
-				pool.Put(endpoint)
-				Expect(pool.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
 			})
 		})
 		It("returns the route_service_url associated with the pool", func() {

--- a/src/code.cloudfoundry.org/gorouter/route/pool_test.go
+++ b/src/code.cloudfoundry.org/gorouter/route/pool_test.go
@@ -375,20 +375,6 @@ var _ = Describe("EndpointPool", func() {
 				Eventually(logger).Should(gbytes.Say(`setting-pool-load-balancing-algorithm-to-that-of-an-endpoint`))
 			})
 
-			It("is an empty string and the load balancing algorithm of a pool is kept", func() {
-				expectedLBAlgo := config.LOAD_BALANCE_RR
-				pool := route.NewPool(&route.PoolOpts{
-					Logger:                 logger.Logger,
-					LoadBalancingAlgorithm: expectedLBAlgo,
-				})
-				endpoint := route.NewEndpoint(&route.EndpointOpts{
-					Host: "host-1", Port: 1234,
-					RouteServiceUrl: "url",
-				})
-				pool.Put(endpoint)
-				Expect(pool.LoadBalancingAlgorithm).To(Equal(expectedLBAlgo))
-			})
-
 			It("is not specified in the endpoint options and the load balancing algorithm of a pool is kept", func() {
 				expectedLBAlgo := config.LOAD_BALANCE_RR
 				pool := route.NewPool(&route.PoolOpts{
@@ -518,34 +504,6 @@ var _ = Describe("EndpointPool", func() {
 				Expect(pool.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
 				Expect(pool.HashLookupTable).To(BeNil())
 				Expect(pool.HashRoutingProperties).To(BeNil())
-			})
-
-			It("keeps the current algorithm when the endpoint does not specify one", func() {
-				pool := route.NewPool(&route.PoolOpts{
-					Logger:                 logger.Logger,
-					LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
-				})
-
-				// Set up HB routing
-				hbEndpoint := route.NewEndpoint(&route.EndpointOpts{
-					Host:                   "host-1",
-					Port:                   1234,
-					PrivateInstanceId:      "id-1",
-					LoadBalancingAlgorithm: config.LOAD_BALANCE_HB,
-					HashBalanceFactor:      1.25,
-					HashHeaderName:         "X-Tenant",
-				})
-				pool.Put(hbEndpoint)
-				Expect(pool.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_HB))
-
-				// Register with empty algorithm (field not specified) — should NOT reset
-				noAlgoEndpoint := route.NewEndpoint(&route.EndpointOpts{
-					Host:              "host-1",
-					Port:              1234,
-					PrivateInstanceId: "id-1",
-				})
-				pool.Put(noAlgoEndpoint)
-				Expect(pool.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_HB))
 			})
 		})
 		It("returns the route_service_url associated with the pool", func() {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Fixes the bug where removing a per-route load balancing algorithm (e.g., via `cf update-route -r loadbalancing`) left the pool using the old algorithm instead of reverting to the platform default. Fixes #551                                                               
   
Changes
---------------

- Default the endpoint's load balancing algorithm to the global platform algorithm (`config.LoadBalance`) in `mbus/subscriber.go`; only override when the NATS message contains a non-empty value                                                                                                                                                        
- Clean up hash-based routing state (`HashLookupTable`, `HashRoutingProperties`) in `EndpointPool.setPoolLoadBalancingAlgorithm` when switching away from hash-based routing                                                                                        
                                                                                                                                                                                                                                                                                   

Backward Compatibility
---------------
Breaking Change? **No**

Note on AI usage
---------------
Parts of this code and tests were developed with assistance from Claude Code (claude-opus-4-20250514).