### PR TITLE
Re-add linter ignore command to fake_varzreporter

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/metrics/fakes/fake_varzreporter.go
+++ b/src/code.cloudfoundry.org/gorouter/metrics/fakes/fake_varzreporter.go
@@ -172,4 +172,5 @@ func (fake *FakeVarzReporter) recordInvocation(key string, args []interface{}) {
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
+//lint:ignore SA1019 - auto-generated fake will go away when Varz goes away
 var _ metrics.VarzReporter = new(FakeVarzReporter)


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
With #550, we also updated the fake files generated by counterfeiter. `fake_varzreporter.go` requires a lint:ignore  annotation, which was removed with this Pull-Request. As a consequence, `staticcheck` now fails. This Pull-Request re-adds the annotation for a short-term solution. Long-term, the `VarzReporter` interface should be removed - it's already marked for deprecation.


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
