### PR TITLE
fix: Handle empty LoadBalancingAlgorithm in pool and update subscriber test expectations

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/mbus/subscriber_test.go
+++ b/src/code.cloudfoundry.org/gorouter/mbus/subscriber_test.go
@@ -372,10 +372,11 @@ var _ = Describe("Subscriber", func() {
 			Eventually(registry.RegisterCallCount).Should(Equal(1))
 			_, originalEndpoint := registry.RegisterArgsForCall(0)
 			expectedEndpoint := route.NewEndpoint(&route.EndpointOpts{
-				Host:             "host",
-				AppId:            "app",
-				Protocol:         "http1",
-				AvailabilityZone: "zone-meow",
+				Host:                   "host",
+				AppId:                  "app",
+				Protocol:               "http1",
+				AvailabilityZone:       "zone-meow",
+				LoadBalancingAlgorithm: cfg.LoadBalance,
 			})
 
 			Expect(originalEndpoint).To(Equal(expectedEndpoint))
@@ -405,9 +406,10 @@ var _ = Describe("Subscriber", func() {
 			Eventually(registry.RegisterCallCount).Should(Equal(1))
 			_, originalEndpoint := registry.RegisterArgsForCall(0)
 			expectedEndpoint := route.NewEndpoint(&route.EndpointOpts{
-				Host:     "host",
-				AppId:    "app",
-				Protocol: "http1",
+				Host:                   "host",
+				AppId:                  "app",
+				Protocol:               "http1",
+				LoadBalancingAlgorithm: cfg.LoadBalance,
 			})
 
 			Expect(originalEndpoint).To(Equal(expectedEndpoint))
@@ -436,9 +438,10 @@ var _ = Describe("Subscriber", func() {
 			Eventually(registry.RegisterCallCount).Should(Equal(1))
 			_, originalEndpoint := registry.RegisterArgsForCall(0)
 			expectedEndpoint := route.NewEndpoint(&route.EndpointOpts{
-				Host:     "host",
-				AppId:    "app",
-				Protocol: "http1",
+				Host:                   "host",
+				AppId:                  "app",
+				Protocol:               "http1",
+				LoadBalancingAlgorithm: cfg.LoadBalance,
 			})
 
 			Expect(originalEndpoint).To(Equal(expectedEndpoint))
@@ -468,9 +471,10 @@ var _ = Describe("Subscriber", func() {
 			Eventually(registry.RegisterCallCount).Should(Equal(1))
 			_, originalEndpoint := registry.RegisterArgsForCall(0)
 			expectedEndpoint := route.NewEndpoint(&route.EndpointOpts{
-				Host:     "host",
-				AppId:    "app",
-				Protocol: "http2",
+				Host:                   "host",
+				AppId:                  "app",
+				Protocol:               "http2",
+				LoadBalancingAlgorithm: cfg.LoadBalance,
 			})
 
 			Expect(originalEndpoint).To(Equal(expectedEndpoint))
@@ -497,9 +501,10 @@ var _ = Describe("Subscriber", func() {
 				Eventually(registry.RegisterCallCount).Should(Equal(1))
 				_, originalEndpoint := registry.RegisterArgsForCall(0)
 				expectedEndpoint := route.NewEndpoint(&route.EndpointOpts{
-					Host:     "host",
-					AppId:    "app",
-					Protocol: "http1",
+					Host:                   "host",
+					AppId:                  "app",
+					Protocol:               "http1",
+					LoadBalancingAlgorithm: cfg.LoadBalance,
 				})
 
 				Expect(originalEndpoint).To(Equal(expectedEndpoint))
@@ -545,6 +550,7 @@ var _ = Describe("Subscriber", func() {
 				PrivateInstanceIndex:    "index",
 				StaleThresholdInSeconds: 120,
 				Tags:                    map[string]string{"key": "value"},
+				LoadBalancingAlgorithm:  cfg.LoadBalance,
 			})
 
 			Expect(originalEndpoint).To(Equal(expectedEndpoint))
@@ -613,7 +619,7 @@ var _ = Describe("Subscriber", func() {
 					Host:                   "host",
 					AppId:                  "app",
 					Protocol:               "http2",
-					LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
+					LoadBalancingAlgorithm: cfg.LoadBalance,
 				})
 
 				Expect(originalEndpoint).To(Equal(expectedEndpoint))
@@ -747,10 +753,11 @@ var _ = Describe("Subscriber", func() {
 		Eventually(registry.RegisterCallCount).Should(Equal(1))
 		_, originalEndpoint := registry.RegisterArgsForCall(0)
 		expectedEndpoint := route.NewEndpoint(&route.EndpointOpts{
-			Host:      "host",
-			Port:      1111,
-			Protocol:  "http1",
-			UpdatedAt: time.Unix(0, 1234).UTC(),
+			Host:                   "host",
+			Port:                   1111,
+			Protocol:               "http1",
+			UpdatedAt:              time.Unix(0, 1234).UTC(),
+			LoadBalancingAlgorithm: cfg.LoadBalance,
 		})
 
 		Expect(originalEndpoint.UpdatedAt).To(Equal(expectedEndpoint.UpdatedAt))
@@ -795,6 +802,7 @@ var _ = Describe("Subscriber", func() {
 				PrivateInstanceIndex:    "index",
 				StaleThresholdInSeconds: 120,
 				Tags:                    map[string]string{"key": "value"},
+				LoadBalancingAlgorithm:  cfg.LoadBalance,
 			})
 
 			Expect(originalEndpoint).To(Equal(expectedEndpoint))

--- a/src/code.cloudfoundry.org/gorouter/route/pool.go
+++ b/src/code.cloudfoundry.org/gorouter/route/pool.go
@@ -668,6 +668,9 @@ func (p *EndpointPool) MarshalJSON() ([]byte, error) {
 
 // setPoolLoadBalancingAlgorithm overwrites the load balancing algorithm of a pool by that of a specified endpoint, if that is valid.
 func (p *EndpointPool) setPoolLoadBalancingAlgorithm(endpoint *Endpoint) {
+	if endpoint.LoadBalancingAlgorithm == "" {
+		return
+	}
 	if endpoint.LoadBalancingAlgorithm != p.LoadBalancingAlgorithm {
 		if config.IsLoadBalancingAlgorithmValid(endpoint.LoadBalancingAlgorithm) {
 			previousAlgorithm := p.LoadBalancingAlgorithm


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
- Re-added the empty-string guard in `setPoolLoadBalancingAlgorithm` to avoid spurious error logs caused by test endpoints that don't set a `LoadBalancingAlgorithm`
- Updated subscriber test expectations to account for `makeEndpoint` now defaulting to the global routing algorithm (`round-robin`) when none is provided in the NATS message


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
