### PR TITLE
fix: stop router before NATS in integration test cleanup

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/integration/common_integration_test.go
+++ b/src/code.cloudfoundry.org/gorouter/integration/common_integration_test.go
@@ -297,6 +297,12 @@ func (s *testState) StartGorouterOrFail() {
 }
 
 func (s *testState) StopAndCleanup() {
+	// Stop router before NATS to prevent subscriber's ClosedCB from
+	// firing log.Fatal → os.Exit(1), which kills the test proc
+	if s.gorouterSession != nil && s.gorouterSession.ExitCode() == -1 {
+		Eventually(s.gorouterSession.Terminate(), 5).Should(Exit(0))
+	}
+
 	if s.natsRunner != nil {
 		s.natsRunner.Stop()
 	}
@@ -307,10 +313,6 @@ func (s *testState) StopAndCleanup() {
 	}
 
 	os.RemoveAll(s.tmpdir)
-
-	if s.gorouterSession != nil && s.gorouterSession.ExitCode() == -1 {
-		Eventually(s.gorouterSession.Terminate(), 5).Should(Exit(0))
-	}
 
 	if s.fakeMetron != nil {
 		s.StopMetron()


### PR DESCRIPTION
## Summary

Fixes port binding conflicts in parallel integration test runs by correcting the cleanup order in `StopAndCleanup()`.

## Problem

When running integration tests in parallel (`--nodes=7`), tests were intermittently failing with port binding errors:
```
listen tcp :40303: bind: address already in use
listen tcp 127.0.0.1:42529: bind: address already in use
```

The root cause was the cleanup order in `common_integration_test.go`:
1. NATS server stopped first
2. GoRouter session terminated second

When NATS stops before the router, the subscriber's `ClosedCB` callback fires `log.Fatal` → `os.Exit(1)`, killing the test process prematurely before ports are fully released. In parallel runs, this causes subsequent tests to fail when attempting to bind to the same ports.

## Solution

Reversed the cleanup order:
1. Terminate GoRouter session **first**
2. Stop NATS server **second**

This allows the router and its subscriber to disconnect gracefully before NATS shuts down.

## Related

This follows the same pattern as the fix in commit b2bf830e9 (from PR #555) which resolved identical cleanup ordering issues in `router/router_test.go`, but that fix was not applied to the integration test suite.

## Testing

This change affects all integration tests using `testState.StopAndCleanup()`. The fix should reduce or eliminate flaky port conflict failures in CI when tests run in parallel.