### PR TITLE
sni tcp frontend tls - crt directive

### DIFF
--- a/src/code.cloudfoundry.org/cf-tcp-router/configurer/haproxy/config_marshaller.go
+++ b/src/code.cloudfoundry.org/cf-tcp-router/configurer/haproxy/config_marshaller.go
@@ -108,7 +108,7 @@ func (cm configMarshaller) marshalHAProxyBackend(backendName string, backend mod
 		if server.TLSPort > 0 {
 			output.WriteString(fmt.Sprintf("\n  server server_%s_%d %s:%d ssl verify required ca-file %s", server.Address, server.TLSPort, server.Address, server.TLSPort, backendTlsCfg.CACertificatePath))
 
-			if !enableFrontendTLS && backendTlsCfg.ClientCertAndKeyPath != "" {
+			if backendTlsCfg.ClientCertAndKeyPath != "" {
 				output.WriteString(fmt.Sprintf(" crt %s", backendTlsCfg.ClientCertAndKeyPath))
 			}
 


### PR DESCRIPTION
ai-assisted=yes
TNZ-81099

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
frontend tls enabled, the crt directive is required in haproxy config.
backend crt is the client certificate HAProxy presents to the app container to authenticate itself.

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
