### PR TITLE
fix: pin locket to v0.0.0-20260602143356-23bea5865010 via replace dir…

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -2,7 +2,10 @@ module code.cloudfoundry.org
 
 go 1.26.4
 
-replace github.com/cactus/go-statsd-client => github.com/cactus/go-statsd-client v2.0.2-0.20150911070441-6fa055a7b594+incompatible
+replace (
+	code.cloudfoundry.org/locket => code.cloudfoundry.org/locket v0.0.0-20260602143356-23bea5865010
+	github.com/cactus/go-statsd-client => github.com/cactus/go-statsd-client v2.0.2-0.20150911070441-6fa055a7b594+incompatible
+)
 
 require (
 	code.cloudfoundry.org/cfhttp/v2 v2.80.0


### PR DESCRIPTION
…ective

Prevents go get -u from pulling the stale go.mod published by Cursor during the detangle-submodule-deps work.

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Fixes go bumping due to Clod clodding up version tags that are now cached in code.cloudfoundry.org and interfering with everything.


Backward Compatibility
---------------
Breaking Change? no