### PR TITLE
Fix identity-aware routing tests for TLS 1.3

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/integration/common_integration_test.go
+++ b/src/code.cloudfoundry.org/gorouter/integration/common_integration_test.go
@@ -217,10 +217,11 @@ func (s *testState) newMtlsGetRequest(url string) (*http.Request, *http.Client) 
 
 			// Create TLS config for this connection
 			tlsConfig := &tls.Config{
-				ServerName:         originalHost, // SNI uses original hostname
-				RootCAs:            baseTransport.TLSClientConfig.RootCAs,
-				Certificates:       currentCerts, // Use current certificates from baseTransport
-				InsecureSkipVerify: true,         // Skip cert verification since we connect to 127.0.0.1
+				ServerName:           originalHost, // SNI uses original hostname
+				RootCAs:              baseTransport.TLSClientConfig.RootCAs,
+				Certificates:         currentCerts, // Use current certificates from baseTransport
+				GetClientCertificate: baseTransport.TLSClientConfig.GetClientCertificate,
+				InsecureSkipVerify:   true, // Skip cert verification since we connect to 127.0.0.1
 			}
 
 			// Create a plain dialer for the TCP connection

--- a/src/code.cloudfoundry.org/gorouter/integration/identity_aware_routing_test.go
+++ b/src/code.cloudfoundry.org/gorouter/integration/identity_aware_routing_test.go
@@ -51,6 +51,7 @@ var _ = Describe("Identity-Aware Routing", func() {
 			// Configure GoRouter with mTLS domain
 			testState.cfg.EnableSSL = true
 			testState.cfg.ClientCertificateValidationString = "request"
+			testState.cfg.MaxTLSVersionString = "TLSv1.3"
 		})
 
 		AfterEach(func() {
@@ -142,10 +143,11 @@ var _ = Describe("Identity-Aware Routing", func() {
 				testState.register(backendApp, mtlsDomain)
 
 				// Configure client with unknown cert
+				unknownTLSCert := unknownCert.TLSCert()
 				clientTLSConfig := &tls.Config{
 					RootCAs: testState.client.Transport.(*http.Transport).TLSClientConfig.RootCAs,
-					Certificates: []tls.Certificate{
-						unknownCert.TLSCert(),
+					GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+						return &unknownTLSCert, nil
 					},
 				}
 				testState.client.Transport.(*http.Transport).TLSClientConfig = clientTLSConfig


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
- Add MaxTLSVersionString=TLSv1.3 to force TLS 1.3 in integration test
- Use GetClientCertificate in unknown-CA test to bypass SupportsCertificate filter
- Propagate GetClientCertificate in newMtlsGetRequest DialTLSContext


Backward Compatibility
---------------
Breaking Change? No
