### PR TITLE
Egress Block-Listing for Gorouter Route Services: Add IP Normalisation

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/proxy/proxy.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/proxy.go
@@ -336,9 +336,14 @@ func RouteServiceDialControl(routeServiceConfig *routeservice.RouteServiceConfig
 			return fmt.Errorf("wrong address format '%s': an IP and a port number are expected", address)
 		}
 
+		// Normalize the address: strip any IPv6 zone identifier (e.g. fe80::1%lo0)
+		// and unmap IPv4-mapped IPv6 addresses (e.g. ::ffff:192.168.1.1 → 192.168.1.1)
+		// so that prefix matching works correctly in both cases.
+		addr := addrPort.Addr().WithZone("").Unmap()
+
 		for _, blockedIP := range routeServiceConfig.EgressBlockList() {
-			if blockedIP.Contains(addrPort.Addr()) {
-				return fmt.Errorf("connection to %s not allowed", addrPort.Addr().String())
+			if blockedIP.Contains(addr) {
+				return fmt.Errorf("connection to %s not allowed", addr.String())
 			}
 		}
 		return nil

--- a/src/code.cloudfoundry.org/gorouter/proxy/proxy.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/proxy.go
@@ -343,7 +343,11 @@ func RouteServiceDialControl(routeServiceConfig *routeservice.RouteServiceConfig
 
 		for _, blockedIP := range routeServiceConfig.EgressBlockList() {
 			if blockedIP.Contains(addr) {
-				return fmt.Errorf("connection to %s not allowed", addr.String())
+				original := addrPort.Addr().String()
+				if original == addr.String() {
+					return fmt.Errorf("connection to %s not allowed", addr.String())
+				}
+				return fmt.Errorf("connection to %s (normalized: %s) not allowed", original, addr.String())
 			}
 		}
 		return nil

--- a/src/code.cloudfoundry.org/gorouter/proxy/proxy_test.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/proxy_test.go
@@ -3065,7 +3065,10 @@ var _ = Describe("Proxy", func() {
 			control := proxy.RouteServiceDialControl(config)
 			err := control("tcp", "[::ffff:192.168.1.1]:80", nil)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("connection to 192.168.1.1 not allowed"))
+			// Error includes original (::ffff:192.168.1.1) and normalized (192.168.1.1) addresses
+			Expect(err.Error()).To(ContainSubstring("::ffff:192.168.1.1"))
+			Expect(err.Error()).To(ContainSubstring("192.168.1.1"))
+			Expect(err.Error()).To(ContainSubstring("not allowed"))
 		})
 
 		It("matches IP with IPv6 zone to prefix and blocks it", func() {
@@ -3076,7 +3079,32 @@ var _ = Describe("Proxy", func() {
 			control := proxy.RouteServiceDialControl(config)
 			err := control("tcp", "[fe80::1%lo0]:80", nil)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("connection to fe80::1 not allowed"))
+			// Error includes original (fe80::1%lo0) and normalized (fe80::1) addresses
+			Expect(err.Error()).To(ContainSubstring("fe80::1%lo0"))
+			Expect(err.Error()).To(ContainSubstring("fe80::1"))
+			Expect(err.Error()).To(ContainSubstring("not allowed"))
+		})
+
+		It("blocks plain IPv6 address matched by IPv6 prefix", func() {
+			blockList = []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")}
+			config = routeservice.NewRouteServiceConfig(
+				logger.Logger, true, false, nil, 1*time.Second, nil, nil, false, false, false, blockList,
+			)
+			control := proxy.RouteServiceDialControl(config)
+			err := control("tcp", "[2001:db8::1]:80", nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("connection to 2001:db8::1 not allowed"))
+		})
+
+		It("allows connection when IPv6 address with zone falls outside all blocklist prefixes", func() {
+			blockList = []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")}
+			config = routeservice.NewRouteServiceConfig(
+				logger.Logger, true, false, nil, 1*time.Second, nil, nil, false, false, false, blockList,
+			)
+			control := proxy.RouteServiceDialControl(config)
+			// fe80::1%lo0 is a link-local address not in 10.0.0.0/8; must be allowed
+			err := control("tcp", "[fe80::1%lo0]:80", nil)
+			Expect(err).To(BeNil())
 		})
 
 		It("allows connection when IP is not in blocklist", func() {

--- a/src/code.cloudfoundry.org/gorouter/proxy/proxy_test.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/proxy_test.go
@@ -3057,24 +3057,26 @@ var _ = Describe("Proxy", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("does not match IPv4-mapped IPv6 address to IPv4 prefix", func() {
+		It("matches IPv4-mapped IPv6 address to IPv4 prefix and blocks it", func() {
 			blockList = []netip.Prefix{netip.MustParsePrefix("192.168.1.0/24")}
 			config = routeservice.NewRouteServiceConfig(
 				logger.Logger, true, false, nil, 1*time.Second, nil, nil, false, false, false, blockList,
 			)
 			control := proxy.RouteServiceDialControl(config)
 			err := control("tcp", "[::ffff:192.168.1.1]:80", nil)
-			Expect(err).To(BeNil())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("connection to 192.168.1.1 not allowed"))
 		})
 
-		It("does not match IP with IPv6 zone to any prefix", func() {
+		It("matches IP with IPv6 zone to prefix and blocks it", func() {
 			blockList = []netip.Prefix{netip.MustParsePrefix("fe80::/10")}
 			config = routeservice.NewRouteServiceConfig(
 				logger.Logger, true, false, nil, 1*time.Second, nil, nil, false, false, false, blockList,
 			)
 			control := proxy.RouteServiceDialControl(config)
 			err := control("tcp", "[fe80::1%lo0]:80", nil)
-			Expect(err).To(BeNil())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("connection to fe80::1 not allowed"))
 		})
 
 		It("allows connection when IP is not in blocklist", func() {


### PR DESCRIPTION

Summary
---------------
Normalise an IP address for block-listing introduced in [Egress Block List for Gorouter Route Services
](https://github.com/cloudfoundry/routing-release/pull/537) to eliminate two documented blind spots of netip.Prefix.Contains():

* IPv4-mapped IPv6 addresses (::ffff:192.168.1.1) are not matched against an IPv4 prefix (192.168.1.0/24) — Go explicitly documents this behaviour.
* IPv6 addresses with a zone identifier (fe80::1%lo0) are never matched by any prefix — Contains always returns false for zoned addresses.

The fix normalises the address before the block-list check:

addr := addrPort.Addr().WithZone("").Unmap()

.WithZone("") — strips the zone identifier (%lo0), so fe80::1%lo0 → fe80::1.
.Unmap() — converts an IPv4-mapped IPv6 address to its plain IPv4 form, so ::ffff:192.168.1.1 → 192.168.1.1.

After normalisation, Prefix.Contains() behaves correctly for both cases.


Backward Compatibility
---------------
Breaking Change? **No**

Note on AI usage
---------------
Parts of this code and tests were developed with assistance of GitHub Copilot (Model: claude-sonnet-4-6).

