### PR TITLE
Amelia/fix staticcheck go126

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/integration/route_services_test.go
+++ b/src/code.cloudfoundry.org/gorouter/integration/route_services_test.go
@@ -94,8 +94,8 @@ var _ = Describe("Route services", func() {
 
 		wsRouteService = httptest.NewUnstartedServer(
 			&httputil.ReverseProxy{
-				Director: func(req *http.Request) {
-					forwardedURLStr := req.Header.Get("X-Cf-Forwarded-Url")
+				Rewrite: func(r *httputil.ProxyRequest) {
+					forwardedURLStr := r.Out.Header.Get("X-Cf-Forwarded-Url")
 
 					forwardedURL, err := url.Parse(forwardedURLStr)
 					if err != nil {
@@ -103,11 +103,11 @@ var _ = Describe("Route services", func() {
 						return
 					}
 
-					req.URL = &url.URL{
+					r.Out.URL = &url.URL{
 						Scheme: "http",
 						Host:   fmt.Sprintf("127.0.0.1:%d", testState.cfg.Port),
 					}
-					req.Host = forwardedURL.Host
+					r.Out.Host = forwardedURL.Host
 				},
 				Transport: &http.Transport{
 					TLSClientConfig: &tls.Config{

--- a/src/code.cloudfoundry.org/gorouter/proxy/proxy.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/proxy.go
@@ -142,6 +142,20 @@ func NewProxy(
 	rproxy := &httputil.ReverseProxy{
 		Rewrite: func(r *httputil.ProxyRequest) {
 			p.setupProxyRequest(r.Out)
+			// Rewrite mode strips X-Forwarded-* from r.Out before calling this
+			// function. Restore them to replicate the behavior Director had:
+			// - X-Forwarded-Proto: copy the value already set by the XForwardedProto middleware.
+			// - X-Forwarded-For: append the client IP from r.In.RemoteAddr.
+			if proto := r.In.Header.Get("X-Forwarded-Proto"); proto != "" {
+				r.Out.Header.Set("X-Forwarded-Proto", proto)
+			}
+			if clientIP, _, err := net.SplitHostPort(r.In.RemoteAddr); err == nil {
+				if prior := r.In.Header.Get("X-Forwarded-For"); prior != "" {
+					r.Out.Header.Set("X-Forwarded-For", prior+", "+clientIP)
+				} else {
+					r.Out.Header.Set("X-Forwarded-For", clientIP)
+				}
+			}
 		},
 		Transport:      prt,
 		FlushInterval:  50 * time.Millisecond,

--- a/src/code.cloudfoundry.org/gorouter/proxy/proxy.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/proxy.go
@@ -145,9 +145,13 @@ func NewProxy(
 			// Rewrite mode strips X-Forwarded-* from r.Out before calling this
 			// function. Restore them to replicate the behavior Director had:
 			// - X-Forwarded-Proto: copy the value already set by the XForwardedProto middleware.
+			// - X-Forwarded-Host: preserve whatever the client/middleware set.
 			// - X-Forwarded-For: append the client IP from r.In.RemoteAddr.
 			if proto := r.In.Header.Get("X-Forwarded-Proto"); proto != "" {
 				r.Out.Header.Set("X-Forwarded-Proto", proto)
+			}
+			if host := r.In.Header.Get("X-Forwarded-Host"); host != "" {
+				r.Out.Header.Set("X-Forwarded-Host", host)
 			}
 			if clientIP, _, err := net.SplitHostPort(r.In.RemoteAddr); err == nil {
 				if prior := r.In.Header.Get("X-Forwarded-For"); prior != "" {

--- a/src/code.cloudfoundry.org/gorouter/proxy/proxy.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/proxy.go
@@ -140,7 +140,9 @@ func NewProxy(
 	)
 
 	rproxy := &httputil.ReverseProxy{
-		Director:       p.setupProxyRequest,
+		Rewrite: func(r *httputil.ProxyRequest) {
+			p.setupProxyRequest(r.Out)
+		},
 		Transport:      prt,
 		FlushInterval:  50 * time.Millisecond,
 		BufferPool:     p.bufferPool,

--- a/src/code.cloudfoundry.org/gorouter/route_fetcher/route_fetcher.go
+++ b/src/code.cloudfoundry.org/gorouter/route_fetcher/route_fetcher.go
@@ -117,7 +117,7 @@ func (r *RouteFetcher) startEventCycle() {
 					return
 				}
 				err = r.subscribeToEvents(token)
-				if err != nil && err.Error() == "unauthorized" {
+				if err.Error() == "unauthorized" {
 					forceUpdate = true
 				} else {
 					forceUpdate = false


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Fix static check. Remove deprecated "Director" calls. All logic is covered by existing tests that failed during the switch from Director to Rewrite.

Backward Compatibility
---------------
Breaking Change? No