### PR TITLE
fix(gorouter): HTTP/2 endpoint timeout ignored — apply protocol-specific timeout

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/proxy/round_tripper/proxy_round_tripper.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/round_tripper/proxy_round_tripper.go
@@ -452,7 +452,7 @@ func (rt *roundTripper) timedRoundTrip(tr http.RoundTripper, request *http.Reque
 		return tr.RoundTrip(request)
 	}
 
-	reqCtx, cancel := context.WithTimeout(request.Context(), rt.config.EndpointTimeout)
+	reqCtx, cancel := context.WithTimeout(request.Context(), rt.getEndpointTimeout(request))
 	request = request.WithContext(reqCtx)
 
 	// unfortunately if the cancel function above is not called that

--- a/src/code.cloudfoundry.org/gorouter/proxy/round_tripper/proxy_round_tripper_test.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/round_tripper/proxy_round_tripper_test.go
@@ -3050,7 +3050,12 @@ var _ = Describe("ProxyRoundTripper", func() {
 				})
 				Context("when http/2 endpoint timeout is not 0", func() {
 					BeforeEach(func() {
-						cfg.Http2EndpointTimeout = 15 * time.Millisecond
+						// Use a value clearly distinct from cfg.EndpointTimeout (10ms) so the
+						// test can detect whether the wrong timeout is used.
+						cfg.Http2EndpointTimeout = 50 * time.Millisecond
+						req.Proto = "HTTP/2.0"
+						req.ProtoMajor = 2
+						req.ProtoMinor = 0
 						transport.RoundTripStub = func(req *http.Request) (*http.Response, error) {
 							reqCh <- req
 							return &http.Response{}, nil
@@ -3064,7 +3069,9 @@ var _ = Describe("ProxyRoundTripper", func() {
 
 						deadLine, deadlineSet := request.Context().Deadline()
 						Expect(deadlineSet).To(BeTrue())
-						Expect(deadLine).To(BeTemporally("~", before.Add(15*time.Millisecond), 15*time.Millisecond))
+						// Tolerance of 10ms: tight enough to distinguish Http2EndpointTimeout
+						// (50ms) from EndpointTimeout (10ms) if the wrong value is used.
+						Expect(deadLine).To(BeTemporally("~", before.Add(50*time.Millisecond), 10*time.Millisecond))
 						Eventually(func() string {
 							err := request.Context().Err()
 							if err != nil {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

Background
----------
Gorouter supports per-protocol endpoint timeouts via three config fields:
  - EndpointTimeout      (generic fallback, all protocols)
  - Http1EndpointTimeout (HTTP/1.x only)
  - Http2EndpointTimeout (HTTP/2 only)

The intent is that when a protocol-specific timeout is set, it overrides the generic EndpointTimeout for that request type. This was reported as broken by a customer (TNZ-121167): setting Http2EndpointTimeout to any non-zero value had no effect — Gorouter always used EndpointTimeout regardless.

Root cause
----------
The getEndpointTimeout helper was introduced to select the right timeout based on request.ProtoMajor. It was correctly wired into the guard condition in timedRoundTrip:

    if rt.getEndpointTimeout(request) <= 0 || handlers.IsWebSocketUpgrade(request) {
        return tr.RoundTrip(request)  // no timeout
    }

However, the context.WithTimeout call immediately after was left unchanged, still hardcoding rt.config.EndpointTimeout:

    reqCtx, cancel := context.WithTimeout(request.Context(), rt.config.EndpointTimeout)

This was an accidental omission: getEndpointTimeout was called to decide whether to apply a timeout at all, but its return value was discarded and the generic timeout was applied unconditionally. The bug was confirmed by reviewing the git diff — the condition line was updated but the WithTimeout line was not, a classic partial-refactor mistake.

Fix
---
Pass rt.getEndpointTimeout(request) to context.WithTimeout so the selected protocol-specific timeout is actually applied:

    reqCtx, cancel := context.WithTimeout(request.Context(), rt.getEndpointTimeout(request))

Test coverage
-------------
The existing test for the HTTP/2 case had two gaps that masked the bug:

1. The test request was never set to ProtoMajor=2, so getEndpointTimeout never evaluated the Http2EndpointTimeout branch — it fell through to EndpointTimeout.

2. The Gomega BeTemporally assertion used a tolerance of ±15ms around a 15ms expected value, which accepted any deadline in the range [0ms, 30ms]. Since the wrong timeout (EndpointTimeout=10ms) falls in that window, the test passed even when the bug was present.

Both gaps are corrected:
  - BeforeEach now sets req.Proto="HTTP/2.0", req.ProtoMajor=2, req.ProtoMinor=0
  - Http2EndpointTimeout is raised to 50ms (clearly distinct from EndpointTimeout=10ms)
  - Tolerance tightened to ±10ms, which rejects a 10ms deadline when 50ms is expected

Verified: go vet, go test (188/188), and staticcheck all pass clean.

ai-assisted=yes
TNZ-121167


Backward Compatibility
---------------
Breaking Change? **Yes**
