### PR TITLE
Opt in to backend mTLS explicitly with enable_backend_mtls

### DIFF
--- a/src/code.cloudfoundry.org/cf-tcp-router/configurer/haproxy/config_marshaller.go
+++ b/src/code.cloudfoundry.org/cf-tcp-router/configurer/haproxy/config_marshaller.go
@@ -108,7 +108,7 @@ func (cm configMarshaller) marshalHAProxyBackend(backendName string, backend mod
 		if server.TLSPort > 0 {
 			output.WriteString(fmt.Sprintf("\n  server server_%s_%d %s:%d ssl verify required ca-file %s", server.Address, server.TLSPort, server.Address, server.TLSPort, backendTlsCfg.CACertificatePath))
 
-			if backendTlsCfg.ClientCertAndKeyPath != "" {
+			if !enableFrontendTLS && backendTlsCfg.ClientCertAndKeyPath != "" {
 				output.WriteString(fmt.Sprintf(" crt %s", backendTlsCfg.ClientCertAndKeyPath))
 			}
 

--- a/src/code.cloudfoundry.org/cf-tcp-router/configurer/haproxy/config_marshaller.go
+++ b/src/code.cloudfoundry.org/cf-tcp-router/configurer/haproxy/config_marshaller.go
@@ -108,7 +108,7 @@ func (cm configMarshaller) marshalHAProxyBackend(backendName string, backend mod
 		if server.TLSPort > 0 {
 			output.WriteString(fmt.Sprintf("\n  server server_%s_%d %s:%d ssl verify required ca-file %s", server.Address, server.TLSPort, server.Address, server.TLSPort, backendTlsCfg.CACertificatePath))
 
-			if !enableFrontendTLS && backendTlsCfg.ClientCertAndKeyPath != "" {
+			if backendTlsCfg.ClientCertAndKeyPath != "" && (!enableFrontendTLS || server.EnableBackendMTLS) {
 				output.WriteString(fmt.Sprintf(" crt %s", backendTlsCfg.ClientCertAndKeyPath))
 			}
 

--- a/src/code.cloudfoundry.org/cf-tcp-router/configurer/haproxy/config_marshaller_test.go
+++ b/src/code.cloudfoundry.org/cf-tcp-router/configurer/haproxy/config_marshaller_test.go
@@ -264,6 +264,80 @@ backend backend_80
 `))
 
 					})
+
+					Context("when frontend TLS is not terminated (pre-existing behavior)", func() {
+						Context("when EnableBackendMTLS is false (default/unset)", func() {
+							It("still presents the client cert, preserving behavior that predates EnableBackendMTLS", func() {
+								haproxyConf = models.HAProxyConfig{
+									80: {
+										"": {
+											{Address: "host-88.internal", Port: 8888, TLSPort: 8443, InstanceID: "host-88-instance-id"},
+										},
+									},
+								}
+								Expect(marshaller.Marshal(haproxyConf, backendTlsCfg, frontendTlsCfg)).To(Equal(`
+frontend frontend_80
+  mode tcp
+  bind :80
+  default_backend backend_80
+
+backend backend_80
+  mode tcp
+  server server_host-88.internal_8443 host-88.internal:8443 ssl verify required ca-file /fake/path/to/ca.pem crt /fake/path/to/client_cert_and_key.pem verifyhost host-88-instance-id
+`))
+							})
+						})
+					})
+
+					Context("when frontend TLS is terminated", func() {
+						BeforeEach(func() {
+							frontendTlsCfg[0].Enabled = true
+						})
+
+						Context("when EnableBackendMTLS is false (default)", func() {
+							It("does not present the client cert", func() {
+								haproxyConf = models.HAProxyConfig{
+									80: {
+										"": {
+											{Address: "host-88.internal", Port: 8888, TLSPort: 8443, InstanceID: "host-88-instance-id", TerminateFrontendTLS: true},
+										},
+									},
+								}
+								Expect(marshaller.Marshal(haproxyConf, backendTlsCfg, frontendTlsCfg)).To(Equal(`
+frontend frontend_80
+  mode tcp
+  bind :80 ssl crt /fake/path/to/certs/
+  default_backend backend_80
+
+backend backend_80
+  mode tcp
+  server server_host-88.internal_8443 host-88.internal:8443 ssl verify required ca-file /fake/path/to/ca.pem verifyhost host-88-instance-id
+`))
+							})
+						})
+
+						Context("when EnableBackendMTLS is true", func() {
+							It("presents the client cert", func() {
+								haproxyConf = models.HAProxyConfig{
+									80: {
+										"": {
+											{Address: "host-88.internal", Port: 8888, TLSPort: 8443, InstanceID: "host-88-instance-id", TerminateFrontendTLS: true, EnableBackendMTLS: true},
+										},
+									},
+								}
+								Expect(marshaller.Marshal(haproxyConf, backendTlsCfg, frontendTlsCfg)).To(Equal(`
+frontend frontend_80
+  mode tcp
+  bind :80 ssl crt /fake/path/to/certs/
+  default_backend backend_80
+
+backend backend_80
+  mode tcp
+  server server_host-88.internal_8443 host-88.internal:8443 ssl verify required ca-file /fake/path/to/ca.pem crt /fake/path/to/client_cert_and_key.pem verifyhost host-88-instance-id
+`))
+							})
+						})
+					})
 				})
 
 				Context("when SniRewriteHostname is provided", func() {

--- a/src/code.cloudfoundry.org/cf-tcp-router/models/routing_table.go
+++ b/src/code.cloudfoundry.org/cf-tcp-router/models/routing_table.go
@@ -26,6 +26,7 @@ type BackendServerInfo struct {
 	TerminateFrontendTLS bool
 	ALPNs                string
 	SniRewriteHostname   string
+	EnableBackendMTLS    bool
 }
 
 type BackendServerKey struct {
@@ -36,6 +37,7 @@ type BackendServerKey struct {
 	TerminateFrontendTLS bool
 	ALPNs                string
 	SniRewriteHostname   string
+	EnableBackendMTLS    bool
 }
 
 type BackendServerDetails struct {
@@ -58,7 +60,7 @@ func NewRoutingTableEntry(backends []BackendServerInfo) RoutingTableEntry {
 		Backends: make(map[BackendServerKey]BackendServerDetails),
 	}
 	for _, backend := range backends {
-		backendServerKey := BackendServerKey{Address: backend.Address, Port: backend.Port, TLSPort: backend.TLSPort, InstanceID: backend.InstanceID, TerminateFrontendTLS: backend.TerminateFrontendTLS, ALPNs: backend.ALPNs, SniRewriteHostname: backend.SniRewriteHostname}
+		backendServerKey := BackendServerKey{Address: backend.Address, Port: backend.Port, TLSPort: backend.TLSPort, InstanceID: backend.InstanceID, TerminateFrontendTLS: backend.TerminateFrontendTLS, ALPNs: backend.ALPNs, SniRewriteHostname: backend.SniRewriteHostname, EnableBackendMTLS: backend.EnableBackendMTLS}
 		backendServerDetails := BackendServerDetails{ModificationTag: backend.ModificationTag, TTL: backend.TTL, UpdatedTime: time.Now()}
 
 		routingTableEntry.Backends[backendServerKey] = backendServerDetails
@@ -130,7 +132,7 @@ func (table RoutingTable) PruneEntries(defaultTTL int) {
 }
 
 func (table RoutingTable) serverKeyDetailsFromInfo(info BackendServerInfo) (BackendServerKey, BackendServerDetails) {
-	return BackendServerKey{Address: info.Address, Port: info.Port, TLSPort: info.TLSPort, InstanceID: info.InstanceID, TerminateFrontendTLS: info.TerminateFrontendTLS, ALPNs: info.ALPNs, SniRewriteHostname: info.SniRewriteHostname}, BackendServerDetails{ModificationTag: info.ModificationTag, TTL: info.TTL, UpdatedTime: time.Now()}
+	return BackendServerKey{Address: info.Address, Port: info.Port, TLSPort: info.TLSPort, InstanceID: info.InstanceID, TerminateFrontendTLS: info.TerminateFrontendTLS, ALPNs: info.ALPNs, SniRewriteHostname: info.SniRewriteHostname, EnableBackendMTLS: info.EnableBackendMTLS}, BackendServerDetails{ModificationTag: info.ModificationTag, TTL: info.TTL, UpdatedTime: time.Now()}
 }
 
 // Set returns true if routing configuration should be modified, false if it should not.

--- a/src/code.cloudfoundry.org/cf-tcp-router/models/routing_table_test.go
+++ b/src/code.cloudfoundry.org/cf-tcp-router/models/routing_table_test.go
@@ -488,6 +488,45 @@ var _ = Describe("RoutingTable", func() {
 						)
 					})
 				})
+
+				Context("because EnableBackendMTLS does not match", func() {
+					It("adds the new entry and indicates the config needs to be reloaded", func() {
+						newBackendServerInfo := models.BackendServerInfo{
+							Address:           existingBackendServerInfo.Address,
+							Port:              existingBackendServerInfo.Port,
+							EnableBackendMTLS: true,
+							ModificationTag:   routing_api_models.ModificationTag{Guid: "33333333-3333-3333-3333-333333333333", Index: 1},
+						}
+
+						reloadConfig := routingTable.UpsertBackendServerKey(existingRoutingKey, newBackendServerInfo)
+
+						Expect(reloadConfig).To(BeTrue())
+						Expect(logger).To(gbytes.Say("applying-change-to-table"))
+						Expect(routingTable.Size()).To(Equal(1))
+
+						testutil.RoutingTableEntryMatches(
+							routingTable.Entries[existingRoutingKey],
+							models.RoutingTableEntry{
+								Backends: map[models.BackendServerKey]models.BackendServerDetails{
+									{
+										Address: existingBackendServerInfo.Address,
+										Port:    existingBackendServerInfo.Port,
+									}: {
+										ModificationTag: existingBackendServerInfo.ModificationTag,
+										TTL:             existingBackendServerInfo.TTL,
+									},
+									{
+										Address:           newBackendServerInfo.Address,
+										Port:              newBackendServerInfo.Port,
+										EnableBackendMTLS: true,
+									}: {
+										ModificationTag: newBackendServerInfo.ModificationTag,
+									},
+								},
+							},
+						)
+					})
+				})
 			})
 		})
 	})

--- a/src/code.cloudfoundry.org/cf-tcp-router/routing_table/updater.go
+++ b/src/code.cloudfoundry.org/cf-tcp-router/routing_table/updater.go
@@ -259,6 +259,7 @@ func (u *updater) toRoutingTableEntry(logger lager.Logger, routeMapping apimodel
 		TerminateFrontendTLS: routeMapping.TerminateFrontendTLS,
 		ALPNs:                routeMapping.ALPNs,
 		SniRewriteHostname:   sniRewriteHostname,
+		EnableBackendMTLS:    routeMapping.EnableBackendMTLS,
 	}
 	return routingKey, backendServerInfo
 }


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
https://github.com/cloudfoundry/routing-release/commit/c3a6d6c2ff5d9c6b4e70c027fe2776ae6cb915ff introduced a regression for TCP routes for service instances that are not running behind Diego envoy. If TCP Router terminates TLS it will supply a client certificate to backend and service instances registered with route-registrar will fail to validate the request.

This PR:

1. Reverts the change that always supplies client certificate when TLS is terminated at TCP Router. 
2. Introduces a flag on TCP route "enable_backend_mtls" to explicitly opt-in to mTLS.


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
