### PR TITLE
TNZ-127373: Emit ALPN on backend server lines in generated haproxy.cfg

### DIFF
--- a/src/code.cloudfoundry.org/cf-tcp-router/configurer/haproxy/config_marshaller.go
+++ b/src/code.cloudfoundry.org/cf-tcp-router/configurer/haproxy/config_marshaller.go
@@ -112,6 +112,10 @@ func (cm configMarshaller) marshalHAProxyBackend(backendName string, backend mod
 				output.WriteString(fmt.Sprintf(" crt %s", backendTlsCfg.ClientCertAndKeyPath))
 			}
 
+			if server.ALPNs != "" {
+				output.WriteString(fmt.Sprintf(" alpn %s", server.ALPNs))
+			}
+
 			if server.InstanceID != "" {
 				output.WriteString(fmt.Sprintf(" verifyhost %s", server.InstanceID))
 			}

--- a/src/code.cloudfoundry.org/cf-tcp-router/configurer/haproxy/config_marshaller_test.go
+++ b/src/code.cloudfoundry.org/cf-tcp-router/configurer/haproxy/config_marshaller_test.go
@@ -644,6 +644,43 @@ backend backend_1025_rmq2.sys.tas.foobar.com
   server server_88.0.0.38_8890 88.0.0.38:8890
 `))
 			})
+
+			It("and backend_tls is enabled and ALPNs are defined", func() {
+				backendTlsCfg.Enabled = true
+				backendTlsCfg.ClientCertAndKeyPath = "/fake/path/to/client_cert_and_key.pem"
+
+				haproxyConf = models.HAProxyConfig{
+					1025: {
+						"rmq1.sys.tas.foobar.com": {
+							{Address: "88.0.0.36", TLSPort: 8888, InstanceID: "host-88-instance-id", TerminateFrontendTLS: true, EnableBackendMTLS: true, ALPNs: "alpn1,alpn2"},
+						},
+						"rmq2.sys.tas.foobar.com": {
+							{Address: "88.0.0.37", TLSPort: 8889, InstanceID: "host-89-instance-id", TerminateFrontendTLS: true, EnableBackendMTLS: true, ALPNs: "alpn1,alpn3"},
+							{Address: "88.0.0.38", TLSPort: 8890, InstanceID: "host-90-instance-id", TerminateFrontendTLS: true, EnableBackendMTLS: true, ALPNs: "alpn4,alpn1"},
+						},
+					},
+				}
+				actual := marshaller.Marshal(haproxyConf, backendTlsCfg, frontendTlsCfg)
+
+				Expect(actual).To(Equal(`
+frontend frontend_1025
+  mode tcp
+  bind :1025 ssl crt /fake/path/to/certs/ alpn alpn1,alpn2,alpn3,alpn4
+  tcp-request inspect-delay 5s
+  tcp-request content accept if { req.ssl_hello_type gt 0 }
+  use_backend backend_1025_rmq1.sys.tas.foobar.com if { ssl_fc_sni rmq1.sys.tas.foobar.com }
+  use_backend backend_1025_rmq2.sys.tas.foobar.com if { ssl_fc_sni rmq2.sys.tas.foobar.com }
+
+backend backend_1025_rmq1.sys.tas.foobar.com
+  mode tcp
+  server server_88.0.0.36_8888 88.0.0.36:8888 ssl verify required ca-file /fake/path/to/ca.pem crt /fake/path/to/client_cert_and_key.pem alpn alpn1,alpn2 verifyhost host-88-instance-id
+
+backend backend_1025_rmq2.sys.tas.foobar.com
+  mode tcp
+  server server_88.0.0.37_8889 88.0.0.37:8889 ssl verify required ca-file /fake/path/to/ca.pem crt /fake/path/to/client_cert_and_key.pem alpn alpn1,alpn3 verifyhost host-89-instance-id
+  server server_88.0.0.38_8890 88.0.0.38:8890 ssl verify required ca-file /fake/path/to/ca.pem crt /fake/path/to/client_cert_and_key.pem alpn alpn4,alpn1 verifyhost host-90-instance-id
+`))
+			})
 		})
 	})
 })


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->
Previously ALPN was only written to the frontend bind line, even when backend TLS was enabled and the route had alpns configured. Add the alpn option to the backend server line as well, so ALPN negotiation also applies to the backend TLS connection.

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
