### PR TITLE
Preserve all X-Forwarded-For header lines

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/proxy/proxy.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/proxy.go
@@ -154,7 +154,12 @@ func NewProxy(
 				r.Out.Header.Set("X-Forwarded-Host", host)
 			}
 			if clientIP, _, err := net.SplitHostPort(r.In.RemoteAddr); err == nil {
-				if prior := r.In.Header.Get("X-Forwarded-For"); prior != "" {
+				// Join ALL inbound X-Forwarded-For header lines, not just the
+				// first. A request can legitimately arrive with multiple
+				// X-Forwarded-For header lines (e.g. a proxy in front of gorouter
+				// appends its own line in addition to any the client/upstream
+				// already set).
+				if prior := strings.Join(r.In.Header.Values("X-Forwarded-For"), ", "); prior != "" {
 					r.Out.Header.Set("X-Forwarded-For", prior+", "+clientIP)
 				} else {
 					r.Out.Header.Set("X-Forwarded-For", clientIP)

--- a/src/code.cloudfoundry.org/gorouter/proxy/proxy_test.go
+++ b/src/code.cloudfoundry.org/gorouter/proxy/proxy_test.go
@@ -496,6 +496,19 @@ var _ = Describe("Proxy", func() {
 					Expect(getProxiedHeaders(req).Get("X-Forwarded-For")).To(Equal("1.2.3.4, 127.0.0.1"))
 				})
 			})
+			Context("when the header is already set as multiple separate lines", func() {
+				It("appends the client IP and preserves all prior values", func() {
+					// A request can arrive with X-Forwarded-For split across
+					// multiple header lines, e.g. when a proxy in front of
+					// gorouter appends its own line in addition to one the
+					// client or an upstream hop already set. All lines must be
+					// preserved.
+					req.Header.Add("X-Forwarded-For", "18.157.121.255")
+					req.Header.Add("X-Forwarded-For", "18.159.86.86")
+					Expect(getProxiedHeaders(req).Get("X-Forwarded-For")).
+						To(Equal("18.157.121.255, 18.159.86.86, 127.0.0.1"))
+				})
+			})
 		})
 
 		Describe("X-Forwarded-Host", func() {


### PR DESCRIPTION
Fixes #580

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Restores handling of `X-Forwarded-For` when it arrives as multiple header lines by joining `Header.Values("X-Forwarded-For")` instead of reading only the first line via `Header.Get`, a regression introduced with the `Director`→`Rewrite` migration in #573. Fixes #580.

Backward Compatibility
---------------
Breaking Change? **No**

Note on AI Usage
---------------
Parts of this code and tests were developed with assistance from Claude Code (claude-opus-4.8).