### PR TITLE
fix: pin ifrit to v0.0.0-20260418191334-846868129986 (JIRA-1234)

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -2,6 +2,9 @@ module code.cloudfoundry.org
 
 go 1.26.4
 
+// pin ifrit until https://github.com/tedsuo/ifrit/pull/48 is merged
+replace github.com/tedsuo/ifrit => github.com/tedsuo/ifrit v0.0.0-20260418191334-846868129986
+
 replace github.com/cactus/go-statsd-client => github.com/cactus/go-statsd-client v2.0.2-0.20150911070441-6fa055a7b594+incompatible
 
 require (
@@ -27,7 +30,7 @@ require (
 	github.com/onsi/gomega v1.42.1
 	github.com/openzipkin/zipkin-go v0.4.3
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9
-	github.com/tedsuo/ifrit v0.0.0-20260813155221-94822c932811
+	github.com/tedsuo/ifrit v0.0.0-20260418191334-846868129986
 	github.com/urfave/cli v1.22.17
 	github.com/urfave/negroni/v3 v3.1.1
 	github.com/vito/go-sse v1.1.3

--- a/src/code.cloudfoundry.org/routing-acceptance-tests/assets/tcp-sample-receiver/go.mod
+++ b/src/code.cloudfoundry.org/routing-acceptance-tests/assets/tcp-sample-receiver/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 toolchain go1.24.3
 
-require github.com/tedsuo/ifrit v0.0.0-20230516164442-7862c310ad26
+require github.com/tedsuo/ifrit v0.0.0-20260418191334-846868129986
 
 require (
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -19,4 +19,9 @@ require (
 	golang.org/x/text v0.25.0 // indirect
 	golang.org/x/tools v0.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+replace (
+	// pin ifrit until https://github.com/tedsuo/ifrit/pull/48 is merged
+	github.com/tedsuo/ifrit => github.com/tedsuo/ifrit v0.0.0-20260418191334-846868129986
 )


### PR DESCRIPTION
## Summary

- Pins `github.com/tedsuo/ifrit` to `v0.0.0-20260418191334-846868129986` via a `replace` directive
- Prevents transitive upgrade to the newer pseudoversion while https://github.com/tedsuo/ifrit/pull/48 remains unmerged
- Matches the pattern already in place in `garden-runc-release`

Ticket: JIRA-1234

🤖 Generated with Claude Code