### PR TITLE
Add missing valid values to extra_access_log_fields validation

### DIFF
--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -412,7 +412,7 @@ if p('router.enable_log_attempts_details')
 end
 
 if_p('router.logging.extra_access_log_fields') do |extra_fields|
-  valid_extra_log_fields=['backend_time', 'dial_time', 'dns_time', 'failed_attempts', 'failed_attempts_time', 'local_address', 'tls_time']
+  valid_extra_log_fields=['backend_time', 'caller_cf_app', 'caller_cf_org', 'caller_cf_space', 'dial_time', 'dns_time', 'failed_attempts', 'failed_attempts_time', 'local_address', 'route_policy', 'tls_sni', 'tls_time']
   if !extra_fields.all? { |el| valid_extra_log_fields.include?(el) }
     raise "router.logging.extra_access_log_fields (#{extra_fields}) contains invalid values, valid are #{valid_extra_log_fields}"
   end

--- a/spec/gorouter_templates_spec.rb
+++ b/spec/gorouter_templates_spec.rb
@@ -1487,6 +1487,26 @@ describe 'gorouter' do
             end
           end
 
+          context 'to a field documented in the job spec' do
+            available_fields = YAML.load_file(File.join(File.dirname(__FILE__), '..', 'jobs', 'gorouter', 'spec'))
+                                   .fetch('properties')
+                                   .fetch('router.logging.extra_access_log_fields')
+                                   .fetch('description')[/Available fields are: (.*)/, 1]
+                                   .split(',').map(&:strip)
+
+            available_fields.each do |field|
+              context "[\"#{field}\"]" do
+                before do
+                  deployment_manifest_fragment['router']['logging'] = { 'extra_access_log_fields' => [field] }
+                end
+
+                it 'renders the config property' do
+                  expect(parsed_yaml['logging']['extra_access_log_fields']).to eq([field])
+                end
+              end
+            end
+          end
+
           context 'to ["foobar"]' do
             before do
               deployment_manifest_fragment['router']['logging'] = { 'extra_access_log_fields' => ['foobar'] }


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The `router.logging.extra_access_log_fields` property in the gorouter spec documents these available fields:

`backend_time, caller_cf_app, caller_cf_org, caller_cf_space, dial_time, dns_time, failed_attempts, failed_attempts_time, local_address, route_policy, tls_sni, tls_time`

However, the validation list in `jobs/gorouter/templates/gorouter.yml.erb` only allows a subset:
`backend_time, dial_time, dns_time, failed_attempts, failed_attempts_time, local_address, tls_time`

As a result, setting any of `caller_cf_app`, `caller_cf_org`, `caller_cf_space`, `route_policy` or `tls_sni` (as documented in [the spec](https://github.com/cloudfoundry/routing-release/blob/develop/jobs/gorouter/spec#L371)) makes template rendering fail with:

`router.logging.extra_access_log_fields ([...]) contains invalid values, valid are [...]`

This PR adds the five missing values to the validation list so the template accepts everything the spec documents. Only the validation list changed; the values are passed through to gorouter as before.

Backward Compatibility
---------------
Breaking Change? **No**

This only widens the set of accepted values. Deployments that render today keep rendering identically, and deployments that previously failed on documented field names will now succeed.