### PR TITLE
fix(gorouter): hash_balance as string (partial revert of #535)

### DIFF
--- a/src/code.cloudfoundry.org/gorouter/mbus/subscriber.go
+++ b/src/code.cloudfoundry.org/gorouter/mbus/subscriber.go
@@ -43,7 +43,7 @@ type RegistryMessage struct {
 type RegistryMessageOpts struct {
 	LoadBalancingAlgorithm string  `json:"loadbalancing"`
 	HashHeaderName         string  `json:"hash_header"`
-	HashBalance            float64 `json:"hash_balance"`
+	HashBalance            float64 `json:"hash_balance,string"`
 	// RFC route policy options (from Cloud Controller via Diego sync)
 	RoutePolicyScope   string `json:"route_policy_scope,omitempty"`
 	RoutePolicySources string `json:"route_policy_sources,omitempty"`


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This PR restores the original parsing of `hash_balance`.
The `,string` suffix was removed as part of https://github.com/cloudfoundry/routing-release/pull/535/changes#diff-a3cb8cde907ca8ef9a573547cc9464f3bfa9348ce3beedcb838e768d40a99c85L46, which broke hash-based routing.


Backward Compatibility
---------------
Breaking Change? No, fixes (unintended?) breaking change.

See https://github.com/cloudfoundry/routing-release/issues/585